### PR TITLE
fix bug with incorrect function names

### DIFF
--- a/src/renderer/components/SDButton/index.js
+++ b/src/renderer/components/SDButton/index.js
@@ -17,7 +17,7 @@ class SDButton extends React.Component {
     this.handleDialogClose = this.handleDialogClose.bind(this)
   }
 
-  sdDialogClose (val) {
+  handleDialogClose (val) {
     this.setState({
       open: false
     })

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -177,7 +177,7 @@ class App extends React.Component {
     })
   }
 
-  dialogClose () {
+  handleDialogClose () {
     this.setState(prevState => ({
       dialog: {
         ...prevState.dialog,


### PR DESCRIPTION
When renaming react handler functions as required by StandardJS naming guides, two functions were accidentally not renamed, and therefore produce errors when they are called/referenced. This patch renames them correctly, and fixes that bug.