### PR TITLE
Appstream metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,7 @@ else()
     install(TARGETS rpi-imager DESTINATION bin)
     install(FILES icons/rpi-imager.png DESTINATION share/pixmaps)
     install(FILES linux/rpi-imager.desktop DESTINATION share/applications)
+    install(FILES linux/rpi-imager.metainfo.xml DESTINATION share/metainfo)
 endif()
 
 include_directories(${CURL_INCLUDE_DIR} ${LibArchive_INCLUDE_DIR})

--- a/linux/rpi-imager.metainfo.xml
+++ b/linux/rpi-imager.metainfo.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--Copyright 2020 Flathub maintainers-->
+<component type="desktop-application">
+  <id>org.raspberrypi.rpi-imager</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  <name>Raspberry Pi Imager</name>
+  <summary>Raspberry Pi imaging utility</summary>
+  <description>
+    <p>
+      Raspberry Pi Imager downloads a .JSON file from the Raspberry Pi
+      website with a list of all current download options, ensuring you are
+      always installing the most up-to-date version.
+    </p>
+    <p>
+      Once you’ve selected an operating system from the available options,
+      the utility reads the relevant file directly from the Raspberry Pi
+      website and writes it straight to the SD card. This speeds up the
+      process quite considerably compared to the standard process of reading
+      it from the website, writing it to a file on your hard drive, and then,
+      as a separate step, reading it back from the hard drive and writing it
+      to the SD card.
+    </p>
+    <p>
+      During this process, Raspberry Pi Imager also caches the downloaded
+      operating system image – that is to say, it saves a local copy on your
+      computer, so you can program additional SD cards without having to
+      download the file again.
+    </p>
+  </description>
+  <launchable type="desktop-id">rpi-imager.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-MAIN.png</image>
+      <caption>Main window</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-OS.png</image>
+      <caption>Choose OS</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-SD.png</image>
+      <caption>Choose SD</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-WRITE.png</image>
+      <caption>Write in progress</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-DONE.png</image>
+      <caption>Write done</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/raspberrypi/rpi-imager</url>
+  <provides>
+    <binary>rpi-imager</binary>
+  </provides>
+  <releases>
+    <release version="1.2" date="2020-03-10" />
+  </releases>
+  <content_rating type="oars-1.1" />
+</component>


### PR DESCRIPTION
I intend to submit a Flatpak for rpi-imager to [Flathub](https://flathub.org/) (I have it working locally) and need to provide some [AppStream](https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html) metadata for proper registration in Linux software stores like GNOME Software or KDE Discover.

I prefer contributing these metadata upstream so that all downstream distributions can benefit (not only Flatpak). I am proposing `org.raspberrypi.rpi-imager` as the application ID but it can be something else, as long as the latter fulfills the requirements explained in [section 2.1.3](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#sect-Metadata-GenericComponent).

I used the wording in the blog post introducing the imager for the description. Feel free to review it and propose improvements. This description will become what's displayed in the software store alongside the name, summary and screenshots, so it is quite important.