### PR TITLE
Fix for #13 Fuzzy text on macOS Retina Displays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(HEADERS config.h imagewriter.h networkaccessmanagerfactory.h nan.h drivelist
 # Add 3rd-party dependencies
 if (APPLE)
 set_source_files_properties("icons/rpi-imager.icns" PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
-set(DEPENDENCIES mac/macfile.cpp mac/macfile.h dependencies/mountutils/src/darwin/functions.cpp
+set(DEPENDENCIES mac/macfile.cpp mac/macfile.h mac/Info.plist dependencies/mountutils/src/darwin/functions.cpp
     dependencies/drivelist/src/darwin/list.mm dependencies/drivelist/src/darwin/REDiskList.m icons/rpi-imager.icns)
 enable_language(OBJC C)
 elseif (UNIX)
@@ -192,10 +192,7 @@ elseif(APPLE)
     #find_package(Qt5 COMPONENTS Svg)
     #set(EXTRALIBS ${CoreFoundation} ${DiskArbitration} ${Security} ${Cocoa} Qt5::Svg)
     set(EXTRALIBS ${CoreFoundation} ${DiskArbitration} ${Security} ${Cocoa})
-    set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE YES
-        MACOSX_BUNDLE_BUNDLE_NAME "Raspberry Pi Imager"
-        MACOSX_BUNDLE_GUI_IDENTIFIER "org.raspberrypi.imagingutility"
-        MACOSX_BUNDLE_ICON_FILE "rpi-imager.icns")
+    set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE YES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/mac/Info.plist)
 
     find_program(MACDEPLOYQT "macdeployqt" PATHS "${Qt5_DIR}/../../../bin")
     if (NOT MACDEPLOYQT)

--- a/mac/Info.plist
+++ b/mac/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>English</string>
+  <key>CFBundleExecutable</key>
+  <string>rpi-imager</string>
+  <key>CFBundleGetInfoString</key>
+  <string></string>
+  <key>CFBundleIconFile</key>
+  <string>rpi-imager.icns</string>
+  <key>CFBundleIdentifier</key>
+  <string>org.raspberrypi.imagingutility</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleLongVersionString</key>
+  <string></string>
+  <key>CFBundleName</key>
+  <string>Raspberry Pi Imager</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string></string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleVersion</key>
+  <string></string>
+  <key>CSResourcesFileMapped</key>
+  <true/>
+  <key>NSHumanReadableCopyright</key>
+  <string></string>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes #13 

Specify an NSPrincipalClass in Info.plist to enable Retina display support

The default Info.plist template provided by CMake doesn't have this key, and
CMake only has minimal support for settingstypically found in this file.
In order to specify NSPrincipalClass, we need to provide the whole Info.plist instead.

Info.plist is also specified as a dependancy to the application so that it will
appear in the project explorer, and changes to this file will trigger a rebuild. 

Before | After
---|---
<img width="792" alt="Screen Shot 2020-04-05 at 4 17 30 PM" src="https://user-images.githubusercontent.com/8701480/78468354-5d600000-776b-11ea-9a5c-312d94fa02a5.png"> | <img width="792" alt="Screen Shot 2020-04-05 at 4 19 16 PM" src="https://user-images.githubusercontent.com/8701480/78468358-62bd4a80-776b-11ea-9b38-a5e99d698ab9.png">
<img width="792" alt="Screen Shot 2020-04-05 at 4 17 36 PM" src="https://user-images.githubusercontent.com/8701480/78468364-7c5e9200-776b-11ea-9525-2b80d43b1dbd.png"> | <img width="792" alt="Screen Shot 2020-04-05 at 4 19 20 PM" src="https://user-images.githubusercontent.com/8701480/78468368-81234600-776b-11ea-893e-d57efefcdbb7.png">
<img width="792" alt="Screen Shot 2020-04-05 at 4 17 43 PM" src="https://user-images.githubusercontent.com/8701480/78468371-8aacae00-776b-11ea-8421-6b612c75e477.png"> | <img width="792" alt="Screen Shot 2020-04-05 at 4 19 24 PM" src="https://user-images.githubusercontent.com/8701480/78468380-95674300-776b-11ea-8eb8-d2b345e04359.png">
