### PR TITLE
Install icon under share/icons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ else()
     endif()
 
     install(TARGETS rpi-imager DESTINATION bin)
-    install(FILES icons/rpi-imager.png DESTINATION share/pixmaps)
+    install(FILES icons/rpi-imager.png DESTINATION share/icons/hicolor/128x128/apps)
     install(FILES linux/rpi-imager.desktop DESTINATION share/applications)
 endif()
 


### PR DESCRIPTION
Use of `share/pixmaps` is deprecated in favour of `share/icons` with right subfolder depending on the size of the icon (here 128x128). Best would be to provide the icon as an SVG and not worry about sizes depending on the desktop environment.