### PR TITLE
Fix #62 (custom user-agent)

### DIFF
--- a/imagewriter.cpp
+++ b/imagewriter.cpp
@@ -180,6 +180,7 @@ void ImageWriter::startWrite()
     connect(_thread, SIGNAL(success()), SLOT(onSuccess()));
     connect(_thread, SIGNAL(error(QString)), SLOT(onError(QString)));
     _thread->setVerifyEnabled(_verifyEnabled);
+    _thread->setUserAgent(QString("Mozilla/5.0 rpi-imager/%1").arg(constantVersion()).toUtf8());
 
     if (!_expectedHash.isEmpty() && _cachedFileHash != _expectedHash && _cachingEnabled)
     {


### PR DESCRIPTION
Append "rpi-imager/version-num" to the default User-Agent when curl is downloading the image so that image hosts can more easily distinguish rpi-imager traffic from other traffic.