### PR TITLE
Add German translation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,8 @@ if (Qt5Widgets_FOUND)
     set(EXTRALIBS ${EXTRALIBS} Qt5::Widgets)
 endif()
 
-#qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} i18n/rpi-imager_en.ts i18n/rpi-imager_nl.ts i18n/rpi-imager_zh_cn.ts i18n/rpi-imager_tr.ts i18n/rpi-imager_fr.ts)
-qt5_add_translation(QM_FILES i18n/rpi-imager_en.ts i18n/rpi-imager_nl.ts i18n/rpi-imager_zh_cn.ts i18n/rpi-imager_tr.ts i18n/rpi-imager_fr.ts)
+#qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} i18n/rpi-imager_en.ts i18n/rpi-imager_nl.ts i18n/rpi-imager_zh_cn.ts i18n/rpi-imager_tr.ts i18n/rpi-imager_fr.ts i18n/rpi-imager_de.ts)
+qt5_add_translation(QM_FILES i18n/rpi-imager_en.ts i18n/rpi-imager_nl.ts i18n/rpi-imager_zh_cn.ts i18n/rpi-imager_tr.ts i18n/rpi-imager_fr.ts i18n/rpi-imager_de.ts)
 configure_file(i18n/translations.qrc "${CMAKE_CURRENT_BINARY_DIR}" COPYONLY)
 set(SOURCES ${SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc ${QM_FILES})
 

--- a/i18n/rpi-imager_de.ts
+++ b/i18n/rpi-imager_de.ts
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en_US">
+<TS version="2.1" language="de_DE">
 <context>
     <name>DownloadExtractThread</name>
     <message>
         <location filename="../downloadextractthread.cpp" line="166"/>
         <source>Error writing to storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Schreiben auf den Speicher</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="188"/>
         <location filename="../downloadextractthread.cpp" line="348"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Entpacken des Archivs: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="234"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Einbinden der FAT32-Partition</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="244"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Das Betriebssystem band die FAT32-Partition nicht ein</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="267"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Wechseln in den Ordner &quot;%1&quot;</translation>
     </message>
 </context>
 <context>
@@ -35,89 +35,97 @@
     <message>
         <location filename="../downloadthread.cpp" line="127"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Ausführen von Diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="148"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Entfernen von existierenden Partitionen</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="174"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Authentifizierung abgebrochen</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="177"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Ausführen von authopen, um Zugriff auf Geräte zu erhalten &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="178"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
+        <translatorcomment>I don&apos;t use Mac OS, I would need help here. Unfinished translation:
+
+Bitte stellen Sie sicher, dass &apos;Raspberry Pi Imager&apos; Zugriff auf &apos;removable volumes&apos; in privacy settings hat (unter &apos;files and folders&apos;. Sie können ihm auch &apos;full disk access&apos; geben).</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="199"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Speichergerät &apos;%1&apos; kann nicht geöffnet werden.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreibfehler während dem Löschen des MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="225"/>
         <source>Write error while trying to zero out last part of card.
 Card could be advertising wrong capacity (possible counterfeit)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Löschen des letzten Teiles der Speicherkarte.
+Die Speicherkarte könnte mit einer falschen Größe beworben sein (möglicherweise Betrug)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="346"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Zugriff verweigert-Fehler beim Schreiben auf den Datenträger.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="351"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
+        <translatorcomment>I don&apos;t use Windows either. What is &quot;Controlled Folder Access&quot; in the German version?
+
+Controlled Folder Access sheint aktiviert zu sein. Bitte fügen Sie sowohl rpi-imager.exe als auch fat32format.exe zur Liste der erlaubten Apps hinzu und versuchen sie es erneut.</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="357"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../downloadthread.cpp" line="585"/>
-        <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../downloadthread.cpp" line="592"/>
-        <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Schreiben der Datei auf den Speicher</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="573"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Download beschädigt. Prüfsumme stimmt nicht überein</translation>
+    </message>
+    <message>
+        <location filename="../downloadthread.cpp" line="585"/>
+        <source>Error writing to storage (while flushing)</source>
+        <translation>Fehler beim Schreiben auf den Speicher (während flushing)</translation>
+    </message>
+    <message>
+        <location filename="../downloadthread.cpp" line="592"/>
+        <source>Error writing to storage (while fsync)</source>
+        <translation>Fehler beim Schreiben auf den Speicher (während fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="626"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Schreiben auf des ersten Blocks (Partitionstabelle)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="682"/>
         <source>Error reading from storage.
 SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Lesen vom Speicher.
+Die SD-Karte könnte kaputt sein.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="701"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifizierung fehlgeschlagen. Der Inhalt der SD-Karte weicht von dem Inhalt ab, der geschrieben werden sollte.</translation>
     </message>
 </context>
 <context>
@@ -127,52 +135,52 @@ SD card may be broken.</source>
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Partitionieren: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Starten von fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Verwenden von fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Festlegen eines neuen Laufwerksbuchstabens</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ungültiges Gerät: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Formatieren (mit udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Starten von sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="196"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Starten von mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="206"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Verwenden von mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="213"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatieren ist auf dieser Platform nicht implementiert</translation>
     </message>
 </context>
 <context>
@@ -181,23 +189,25 @@ SD card may be broken.</source>
         <location filename="../imagewriter.cpp" line="170"/>
         <source>Storage capacity is not large enough.
 Needs to be at least %1 GB</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Speicherkapazität ist nicht groß genug.
+Sie muss mindestens %1 GB betragen</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="176"/>
         <source>Input file is not a valid disk image.
 File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Eingabedatei ist kein gültiges Disk-Image.
+Die Dateigröße%1 Bytes ist kein Vielfaches von 512 Bytes.</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="200"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Image herunterladen und schreiben</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="409"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Image wählen</translation>
     </message>
 </context>
 <context>
@@ -205,7 +215,7 @@ File size %1 bytes is not a multiple of 512 bytes.</source>
     <message>
         <location filename="../localfileextractthread.cpp" line="38"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Öffnen der Imagedatei</translation>
     </message>
 </context>
 <context>
@@ -213,17 +223,17 @@ File size %1 bytes is not a multiple of 512 bytes.</source>
     <message>
         <location filename="../MsgPopup.qml" line="96"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NEIN</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>JA</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="122"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>WEITER</translation>
     </message>
 </context>
 <context>
@@ -231,7 +241,7 @@ File size %1 bytes is not a multiple of 512 bytes.</source>
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="111"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Interner SD-Kartenleser</translation>
     </message>
 </context>
 <context>
@@ -239,208 +249,208 @@ File size %1 bytes is not a multiple of 512 bytes.</source>
     <message>
         <location filename="../main.qml" line="23"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="90"/>
         <location filename="../main.qml" line="303"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem</translation>
     </message>
     <message>
         <location filename="../main.qml" line="102"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>OS WÄHLEN</translation>
     </message>
     <message>
         <location filename="../main.qml" line="120"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Klicke auf diesen Knopf, um das Betriebssystem zu ändern</translation>
     </message>
     <message>
         <location filename="../main.qml" line="133"/>
         <location filename="../main.qml" line="587"/>
         <source>SD Card</source>
-        <translation type="unfinished"></translation>
+        <translation>SD-Karte</translation>
     </message>
     <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="860"/>
         <source>CHOOSE SD CARD</source>
-        <translation type="unfinished"></translation>
+        <translation>SD-KARTE WÄHLEN</translation>
     </message>
     <message>
         <location filename="../main.qml" line="158"/>
         <source>Select this button to change the destination SD card</source>
-        <translation type="unfinished"></translation>
+        <translation>Klicke auf diesen Knopf, um die Zeil-SD-Karte zu ändern</translation>
     </message>
     <message>
         <location filename="../main.qml" line="175"/>
         <source>WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>SCHREIBEN</translation>
     </message>
     <message>
         <location filename="../main.qml" line="180"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Klicke auf diesen Knopf, um mit dem Schreiben zu beginnen</translation>
     </message>
     <message>
         <location filename="../main.qml" line="220"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>SCHREIBEN ABBRECHEN</translation>
     </message>
     <message>
         <location filename="../main.qml" line="223"/>
         <location filename="../main.qml" line="802"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="235"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>VERIFIZIERUNG ABBRECHEN</translation>
     </message>
     <message>
         <location filename="../main.qml" line="238"/>
         <location filename="../main.qml" line="825"/>
         <location filename="../main.qml" line="878"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Finalisieren...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="384"/>
         <location filename="../main.qml" line="854"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
     <message>
         <location filename="../main.qml" line="385"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Karte als FAT32 formatieren</translation>
     </message>
     <message>
         <location filename="../main.qml" line="392"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Eigenes Image</translation>
     </message>
     <message>
         <location filename="../main.qml" line="393"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Wählen Sie eine eigene .img-Datei von Ihrem Computer</translation>
     </message>
     <message>
         <location filename="../main.qml" line="416"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Zurück</translation>
     </message>
     <message>
         <location filename="../main.qml" line="417"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Zurück zum Hauptmenü</translation>
     </message>
     <message>
         <location filename="../main.qml" line="474"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Veröffentlicht: %1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="477"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Auf Ihrem Computer zwischengespeichert</translation>
     </message>
     <message>
         <location filename="../main.qml" line="479"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Lokale Datei</translation>
     </message>
     <message>
         <location filename="../main.qml" line="481"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Online - %1 GB Download</translation>
     </message>
     <message>
         <location filename="../main.qml" line="638"/>
         <location filename="../main.qml" line="690"/>
         <location filename="../main.qml" line="696"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Als %1 eingebunden</translation>
     </message>
     <message>
         <location filename="../main.qml" line="692"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[SCHREIBGESCHÜTZT]</translation>
     </message>
     <message>
         <location filename="../main.qml" line="734"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sind Sie sicher, dass Sie beenden möchten?</translation>
     </message>
     <message>
         <location filename="../main.qml" line="735"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Der Raspberry Pi Imager ist noch beschäftigt. &lt;br&gt;Möchten Sie wirklich beenden?</translation>
     </message>
     <message>
         <location filename="../main.qml" line="746"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung</translation>
     </message>
     <message>
         <location filename="../main.qml" line="752"/>
         <location filename="../main.qml" line="805"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreiben... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="765"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle vorhandenen Daten auf &apos;%1&apos; werden gelöscht.&lt;br&gt;Möchten sie wirklich fortfahren?</translation>
     </message>
     <message>
         <location filename="../main.qml" line="784"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Herunterladen der Betriebssystemsliste aus dem Internet</translation>
     </message>
     <message>
         <location filename="../main.qml" line="828"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifizierung... %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="846"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler</translation>
     </message>
     <message>
         <location filename="../main.qml" line="853"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreiben erfolgreich</translation>
     </message>
     <message>
         <location filename="../main.qml" line="855"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; wurde geleert&lt;br&gt;&lt;br&gt;Sie können die SD-Karte nun aus dem Lesegerät entfernen</translation>
     </message>
     <message>
         <location filename="../main.qml" line="857"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; wurde auf&lt;b&gt;%2&lt;/b&gt; geschrieben&lt;br&gt;&lt;br&gt;Sie können die SD-Karte nun aus dem Lesegerät entfernen</translation>
     </message>
     <message>
         <location filename="../main.qml" line="885"/>
         <location filename="../main.qml" line="927"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Parsen von os_list.json</translation>
     </message>
     <message>
         <location filename="../main.qml" line="965"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verbinden Sie zuerst einen USB-Stick mit Images.&lt;br&gt;Die Images müssen sich im Wurzelverzeichnes des USB-Sticks befinden.</translation>
     </message>
     <message>
         <location filename="../main.qml" line="980"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Speicherkarte ist schreibgeschützt.&lt;br&gt;Drücken Sie den Schutzschalter auf der linken Seite nach oben, und versuchen Sie es erneut.</translation>
     </message>
 </context>
 </TS>

--- a/i18n/rpi-imager_fr.ts
+++ b/i18n/rpi-imager_fr.ts
@@ -33,91 +33,91 @@
 <context>
     <name>DownloadThread</name>
     <message>
-        <location filename="../downloadthread.cpp" line="131"/>
+        <location filename="../downloadthread.cpp" line="127"/>
         <source>Error running diskpart: %1</source>
         <translation>Erreur lors de l&apos;exécution de diskpart : %1</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="152"/>
+        <location filename="../downloadthread.cpp" line="148"/>
         <source>Error removing existing partitions</source>
         <translation>Erreur lors de la suppression des partitions existantes</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="178"/>
+        <location filename="../downloadthread.cpp" line="174"/>
         <source>Authentication cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="181"/>
+        <location filename="../downloadthread.cpp" line="177"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
         <translation>Erreur lors de l&apos;exécution d&apos;authopen pour accéder au périphérique du stockage &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="182"/>
+        <location filename="../downloadthread.cpp" line="178"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="203"/>
+        <location filename="../downloadthread.cpp" line="199"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
         <translation>Impossible d&apos;ouvrir le périphérique de stockage &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="217"/>
+        <location filename="../downloadthread.cpp" line="213"/>
         <source>Write error while zero&apos;ing out MBR</source>
         <translation>Erreur d&apos;écriture lors du formatage du MBR</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="229"/>
+        <location filename="../downloadthread.cpp" line="225"/>
         <source>Write error while trying to zero out last part of card.
 Card could be advertising wrong capacity (possible counterfeit)</source>
         <translation>Erreur d&apos;écriture lors de la tentative de formatage de la dernière partie de la carte.
 Le stockage pourrait annoncer une mauvaise capacité (contrefaçon possible)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="350"/>
+        <location filename="../downloadthread.cpp" line="346"/>
         <source>Access denied error while writing file to disk.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="355"/>
+        <location filename="../downloadthread.cpp" line="351"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="361"/>
+        <location filename="../downloadthread.cpp" line="357"/>
         <source>Error writing file to disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="589"/>
+        <location filename="../downloadthread.cpp" line="585"/>
         <source>Error writing to storage (while flushing)</source>
         <translation>Erreur d&apos;écriture dans le stockage (lors du formatage)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="596"/>
+        <location filename="../downloadthread.cpp" line="592"/>
         <source>Error writing to storage (while fsync)</source>
         <translation>Erreur d&apos;écriture dans le stockage (pendant l&apos;exécution de fsync)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="577"/>
+        <location filename="../downloadthread.cpp" line="573"/>
         <source>Download corrupt. Hash does not match</source>
         <translation>Téléchargement corrompu. La signature ne correspond pas</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="630"/>
+        <location filename="../downloadthread.cpp" line="626"/>
         <source>Error writing first block (partition table)</source>
         <translation>Erreur lors de l&apos;écriture du premier bloc (table de partion)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="686"/>
+        <location filename="../downloadthread.cpp" line="682"/>
         <source>Error reading from storage.
 SD card may be broken.</source>
         <translation>Erreur de lecture du stockage.
 La carte SD pourrait être défectueuse.</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="705"/>
+        <location filename="../downloadthread.cpp" line="701"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
         <translation>La vérification de l&apos;écriture à échoué. Le contenu de la carte SD est différent de ce qui y a été écrit.</translation>
     </message>
@@ -241,208 +241,208 @@ La taille du fichier (d&apos;%1 octets) n&apos;est pas un multiple de 512 octets
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="24"/>
+        <location filename="../main.qml" line="23"/>
         <source>Raspberry Pi Imager v%1</source>
         <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="91"/>
-        <location filename="../main.qml" line="304"/>
+        <location filename="../main.qml" line="90"/>
+        <location filename="../main.qml" line="303"/>
         <source>Operating System</source>
         <translation>Système d&apos;exploitation</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="103"/>
+        <location filename="../main.qml" line="102"/>
         <source>CHOOSE OS</source>
         <translation>CHOISISSEZ L&apos;OS</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="121"/>
+        <location filename="../main.qml" line="120"/>
         <source>Select this button to change the operating system</source>
         <translation>Sélectionnez ce bouton pour changer le système d&apos;exploitation</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="134"/>
-        <location filename="../main.qml" line="588"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="587"/>
         <source>SD Card</source>
         <translation>Carte SD</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="146"/>
-        <location filename="../main.qml" line="868"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="860"/>
         <source>CHOOSE SD CARD</source>
         <translation>CHOISISSEZ LA CARTE SD</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="159"/>
+        <location filename="../main.qml" line="158"/>
         <source>Select this button to change the destination SD card</source>
         <translation>Sélectionnez ce bouton pour changer la carte SD de destination</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="176"/>
+        <location filename="../main.qml" line="175"/>
         <source>WRITE</source>
         <translation>ÉCRIRE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="181"/>
+        <location filename="../main.qml" line="180"/>
         <source>Select this button to start writing the image</source>
         <translation>Sélectionnez ce bouton pour commencer l&apos;écriture de l&apos;image</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="221"/>
+        <location filename="../main.qml" line="220"/>
         <source>CANCEL WRITE</source>
         <translation>ANNULER L&apos;ÉCRITURE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="224"/>
-        <location filename="../main.qml" line="810"/>
+        <location filename="../main.qml" line="223"/>
+        <location filename="../main.qml" line="802"/>
         <source>Cancelling...</source>
         <translation>Annulation...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="236"/>
+        <location filename="../main.qml" line="235"/>
         <source>CANCEL VERIFY</source>
         <translation>ANNULER LA VÉRIFICATION</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="239"/>
-        <location filename="../main.qml" line="833"/>
-        <location filename="../main.qml" line="886"/>
+        <location filename="../main.qml" line="238"/>
+        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="878"/>
         <source>Finalizing...</source>
         <translation>Finalisation...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="385"/>
-        <location filename="../main.qml" line="862"/>
+        <location filename="../main.qml" line="384"/>
+        <location filename="../main.qml" line="854"/>
         <source>Erase</source>
         <translation>Formatter</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="386"/>
+        <location filename="../main.qml" line="385"/>
         <source>Format card as FAT32</source>
         <translation>Formater la carte SD en FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="393"/>
+        <location filename="../main.qml" line="392"/>
         <source>Use custom</source>
         <translation>Utiliser image personnalisée</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="394"/>
+        <location filename="../main.qml" line="393"/>
         <source>Select a custom .img from your computer</source>
         <translation>Sélectionnez une image disque personnalisée (.img) depuis votre ordinateur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="417"/>
+        <location filename="../main.qml" line="416"/>
         <source>Back</source>
         <translation>Retour</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="418"/>
+        <location filename="../main.qml" line="417"/>
         <source>Go back to main menu</source>
         <translation>Retour au menu principal</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="474"/>
         <source>Released: %1</source>
         <translation>Sorti le : %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="478"/>
+        <location filename="../main.qml" line="477"/>
         <source>Cached on your computer</source>
         <translation>Mis en cache sur votre ordinateur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="479"/>
         <source>Local file</source>
         <translation>Fichier local</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="482"/>
+        <location filename="../main.qml" line="481"/>
         <source>Online - %1 GB download</source>
         <translation>En ligne - %1 GO téléchargé</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
-        <location filename="../main.qml" line="691"/>
-        <location filename="../main.qml" line="697"/>
+        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="696"/>
         <source>Mounted as %1</source>
         <translation>Mounté à %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="693"/>
+        <location filename="../main.qml" line="692"/>
         <source>[WRITE PROTECTED]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="735"/>
+        <location filename="../main.qml" line="734"/>
         <source>Are you sure you want to quit?</source>
         <translation>Êtes-vous sûr de vouloir quitter ?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="735"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="988"/>
+        <location filename="../main.qml" line="980"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="747"/>
+        <location filename="../main.qml" line="746"/>
         <source>Warning</source>
         <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="753"/>
-        <location filename="../main.qml" line="813"/>
+        <location filename="../main.qml" line="752"/>
+        <location filename="../main.qml" line="805"/>
         <source>Writing... %1%</source>
         <translation>Écriture... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="766"/>
+        <location filename="../main.qml" line="765"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
         <translation>Toutes les données sur le stockage &apos;%1&apos; vont être supprimées.&lt;br&gt;Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="792"/>
+        <location filename="../main.qml" line="784"/>
         <source>Error downloading OS list from Internet</source>
         <translation>Erreur lors du téléchargement de la liste des systèmes d&apos;exploitation à partir d&apos;Internet</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="828"/>
         <source>Verifying... %1%</source>
         <translation>Vérification... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="854"/>
+        <location filename="../main.qml" line="846"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="861"/>
+        <location filename="../main.qml" line="853"/>
         <source>Write Successful</source>
         <translation>Écriture réussie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="863"/>
+        <location filename="../main.qml" line="855"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation>&lt;b&gt;%1&lt;/b&gt; a bien été formaté&lt;br&gt;&lt;br&gt;Vous pouvez retirer la carte SD du lecteur.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="865"/>
+        <location filename="../main.qml" line="857"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation>&lt;b&gt;%1&lt;/b&gt; a bien été écrit sur &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;Vous pouvez retirer la carte SD du lecteur.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="893"/>
-        <location filename="../main.qml" line="935"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="927"/>
         <source>Error parsing os_list.json</source>
         <translation>Erreur de lecture du fichier os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="973"/>
+        <location filename="../main.qml" line="965"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
         <translation>Connectez en premier une clé USB contenant les images.&lt;br&gt;Les images doivent se trouver dans le dossier racine de la clé USB.</translation>
     </message>

--- a/i18n/rpi-imager_nl.ts
+++ b/i18n/rpi-imager_nl.ts
@@ -33,90 +33,90 @@
 <context>
     <name>DownloadThread</name>
     <message>
-        <location filename="../downloadthread.cpp" line="131"/>
+        <location filename="../downloadthread.cpp" line="127"/>
         <source>Error running diskpart: %1</source>
         <translation>Fout bij uitvoeren diskpart: %1</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="152"/>
+        <location filename="../downloadthread.cpp" line="148"/>
         <source>Error removing existing partitions</source>
         <translation>Fout bij verwijderen bestaande partities</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="178"/>
+        <location filename="../downloadthread.cpp" line="174"/>
         <source>Authentication cancelled</source>
         <translation>Authenticatie geannuleerd</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="181"/>
+        <location filename="../downloadthread.cpp" line="177"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
         <translation>Fout bij uitvoeren authopen: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="182"/>
+        <location filename="../downloadthread.cpp" line="178"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
         <translation>Gelieve te controlleren of &apos;Raspberry Pi Imager&apos; toegang heeft tot &apos;verwijderbare volumes&apos; in de privacy instellingen (onder &apos;bestanden en mappen&apos; of anders via &apos;volledige schijftoegang&apos;).</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="203"/>
+        <location filename="../downloadthread.cpp" line="199"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
         <translation>Fout bij openen opslagapparaat &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="217"/>
+        <location filename="../downloadthread.cpp" line="213"/>
         <source>Write error while zero&apos;ing out MBR</source>
         <translation>Fout bij wissen MBR</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="229"/>
+        <location filename="../downloadthread.cpp" line="225"/>
         <source>Write error while trying to zero out last part of card.
 Card could be advertising wrong capacity (possible counterfeit)</source>
         <translation>Fout bij wissen laatste deel van de SD kaart.
 Kaart geeft mogelijk onjuiste capaciteit aan (mogelijk counterfeit)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="350"/>
+        <location filename="../downloadthread.cpp" line="346"/>
         <source>Access denied error while writing file to disk.</source>
         <translation>Toegang geweigerd bij het schrijven naar opslag.</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="355"/>
+        <location filename="../downloadthread.cpp" line="351"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
         <translation>Controller Folder Access lijkt aan te staan. Gelieve zowel rpi-imager.exe als fat32format.exe toe te voegen aan de lijst met uitsluitingen en het nogmaals te proberen.</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="361"/>
+        <location filename="../downloadthread.cpp" line="357"/>
         <source>Error writing file to disk</source>
         <translation>Fout bij schrijven naar opslag</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="589"/>
+        <location filename="../downloadthread.cpp" line="585"/>
         <source>Error writing to storage (while flushing)</source>
         <translation>Fout bij schrijven naar opslag (tijdens flushen)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="596"/>
+        <location filename="../downloadthread.cpp" line="592"/>
         <source>Error writing to storage (while fsync)</source>
         <translation>Fout bij schrijven naar opslag (tijdens fsync)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="577"/>
+        <location filename="../downloadthread.cpp" line="573"/>
         <source>Download corrupt. Hash does not match</source>
         <translation>Download corrupt. Hash komt niet overeen</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="630"/>
+        <location filename="../downloadthread.cpp" line="626"/>
         <source>Error writing first block (partition table)</source>
         <translation>Fout bij schrijven naar eerste deel van kaart (partitie tabel)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="686"/>
+        <location filename="../downloadthread.cpp" line="682"/>
         <source>Error reading from storage.
 SD card may be broken.</source>
         <translation>Fout bij lezen van SD kaart. Kaart is mogelijk defect.</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="705"/>
+        <location filename="../downloadthread.cpp" line="701"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
         <translation>Verificatie mislukt. De gegevens die op de SD kaart staan wijken af van wat er naar geschreven is.</translation>
     </message>
@@ -240,183 +240,183 @@ Bestandsgrootte %1 bytes is geen veelvoud van 512 bytes.</translation>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="24"/>
+        <location filename="../main.qml" line="23"/>
         <source>Raspberry Pi Imager v%1</source>
         <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="735"/>
+        <location filename="../main.qml" line="734"/>
         <source>Are you sure you want to quit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="735"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
         <translation>Raspberry Pi Imager is nog niet klaar.&lt;br&gt;Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="91"/>
-        <location filename="../main.qml" line="304"/>
+        <location filename="../main.qml" line="90"/>
+        <location filename="../main.qml" line="303"/>
         <source>Operating System</source>
         <translation>Besturingssysteem</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="103"/>
+        <location filename="../main.qml" line="102"/>
         <source>CHOOSE OS</source>
         <translation>SELECTEER OS</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="134"/>
-        <location filename="../main.qml" line="588"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="587"/>
         <source>SD Card</source>
         <translation>SD kaart</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="146"/>
-        <location filename="../main.qml" line="868"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="860"/>
         <source>CHOOSE SD CARD</source>
         <translation>SELECTEER SD KAART</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="176"/>
+        <location filename="../main.qml" line="175"/>
         <source>WRITE</source>
         <translation>SCHRIJF</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="753"/>
-        <location filename="../main.qml" line="813"/>
+        <location filename="../main.qml" line="752"/>
+        <location filename="../main.qml" line="805"/>
         <source>Writing... %1%</source>
         <translation>Schrijven... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="221"/>
+        <location filename="../main.qml" line="220"/>
         <source>CANCEL WRITE</source>
         <translation>Annuleer schrijven</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="121"/>
+        <location filename="../main.qml" line="120"/>
         <source>Select this button to change the operating system</source>
         <translation>Kies deze knop om een besturingssysteem te kiezen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="159"/>
+        <location filename="../main.qml" line="158"/>
         <source>Select this button to change the destination SD card</source>
         <translation>Kies deze knop om de SD kaart te kiezen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="181"/>
+        <location filename="../main.qml" line="180"/>
         <source>Select this button to start writing the image</source>
         <translation>Kies deze knop om te beginnen met het schrijven van de image</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="224"/>
-        <location filename="../main.qml" line="810"/>
+        <location filename="../main.qml" line="223"/>
+        <location filename="../main.qml" line="802"/>
         <source>Cancelling...</source>
         <translation>Annuleren...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="236"/>
+        <location filename="../main.qml" line="235"/>
         <source>CANCEL VERIFY</source>
         <translation>ANNULEER VERIFICATIE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="239"/>
-        <location filename="../main.qml" line="833"/>
-        <location filename="../main.qml" line="886"/>
+        <location filename="../main.qml" line="238"/>
+        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="878"/>
         <source>Finalizing...</source>
         <translation>Afronden...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="385"/>
-        <location filename="../main.qml" line="862"/>
+        <location filename="../main.qml" line="384"/>
+        <location filename="../main.qml" line="854"/>
         <source>Erase</source>
         <translation>Wissen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="386"/>
+        <location filename="../main.qml" line="385"/>
         <source>Format card as FAT32</source>
         <translation>Formatteer kaart als FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="393"/>
+        <location filename="../main.qml" line="392"/>
         <source>Use custom</source>
         <translation>Gebruik eigen bestand</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="394"/>
+        <location filename="../main.qml" line="393"/>
         <source>Select a custom .img from your computer</source>
         <translation>Selecteer een eigen .img bestand</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="479"/>
         <source>Local file</source>
         <translation>Lokaal bestand</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="693"/>
+        <location filename="../main.qml" line="692"/>
         <source>[WRITE PROTECTED]</source>
         <translation>[ALLEEN LEZEN]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="747"/>
+        <location filename="../main.qml" line="746"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="766"/>
+        <location filename="../main.qml" line="765"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
         <translation>Alle bestaande gegevens op &apos;%1&apos; zullen verwijderd worden.&lt;br&gt;Weet u zeker dat u door wilt gaan?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="863"/>
+        <location filename="../main.qml" line="855"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation>&lt;b&gt;%1&lt;/b&gt; is gewist&lt;br&gt;&lt;br&gt;U kunt nu de SD kaart uit de lezer halen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="893"/>
-        <location filename="../main.qml" line="935"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="927"/>
         <source>Error parsing os_list.json</source>
         <translation>Fout bij parsen os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="973"/>
+        <location filename="../main.qml" line="965"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
         <translation>Sluit eerst een USB stick met images aan.&lt;br&gt;De images moeten in de hoofdmap van de USB stick staan.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="988"/>
+        <location filename="../main.qml" line="980"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
         <translation>SD kaart is tegen schrijven beveiligd.&lt;br&gt;Druk het schuifje aan de linkerkant van de SD kaart omhoog, en probeer nogmaals.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="417"/>
+        <location filename="../main.qml" line="416"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="418"/>
+        <location filename="../main.qml" line="417"/>
         <source>Go back to main menu</source>
         <translation>Terug naar hoofdmenu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="474"/>
         <source>Released: %1</source>
         <translation>Release datum: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="478"/>
+        <location filename="../main.qml" line="477"/>
         <source>Cached on your computer</source>
         <translation>Opgeslagen op computer</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="482"/>
+        <location filename="../main.qml" line="481"/>
         <source>Online - %1 GB download</source>
         <translation>Online %1 GB download</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
-        <location filename="../main.qml" line="691"/>
-        <location filename="../main.qml" line="697"/>
+        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="696"/>
         <source>Mounted as %1</source>
         <translation>Mounted op %1</translation>
     </message>
@@ -429,22 +429,22 @@ Bestandsgrootte %1 bytes is geen veelvoud van 512 bytes.</translation>
         <translation type="vanished">VERDER GAAN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="792"/>
+        <location filename="../main.qml" line="784"/>
         <source>Error downloading OS list from Internet</source>
         <translation>Fout bij downloaden van lijst met besturingssystemen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="828"/>
         <source>Verifying... %1%</source>
         <translation>Verifiëren... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="854"/>
+        <location filename="../main.qml" line="846"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="861"/>
+        <location filename="../main.qml" line="853"/>
         <source>Write Successful</source>
         <translation>Klaar met schrijven</translation>
     </message>
@@ -453,7 +453,7 @@ Bestandsgrootte %1 bytes is geen veelvoud van 512 bytes.</translation>
         <translation type="vanished">&lt;b&gt;%2&lt;/b&gt; is gewist&lt;br&gt;&lt;br&gt;U kunt nu de SD kaart uit de lezer halen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="865"/>
+        <location filename="../main.qml" line="857"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation>&lt;b&gt;%1&lt;/b&gt; is geschreven naar &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;U kunt nu de SD kaart uit de lezer halen</translation>
     </message>

--- a/i18n/rpi-imager_tr.ts
+++ b/i18n/rpi-imager_tr.ts
@@ -33,90 +33,90 @@
 <context>
     <name>DownloadThread</name>
     <message>
-        <location filename="../downloadthread.cpp" line="131"/>
+        <location filename="../downloadthread.cpp" line="127"/>
         <source>Error running diskpart: %1</source>
         <translation>Diskpart çalıştırılırken hata oluştu: %1</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="152"/>
+        <location filename="../downloadthread.cpp" line="148"/>
         <source>Error removing existing partitions</source>
         <translation>Mevcut bölümler kaldırılırken hata oluştu </translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="178"/>
+        <location filename="../downloadthread.cpp" line="174"/>
         <source>Authentication cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="181"/>
+        <location filename="../downloadthread.cpp" line="177"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
         <translation>&apos;%1&apos; disk aygıtına erişmek için authopen çalıştırılırken hata oluştu</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="182"/>
+        <location filename="../downloadthread.cpp" line="178"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="203"/>
+        <location filename="../downloadthread.cpp" line="199"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
         <translation>Depolama cihazı açılamıyor &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="217"/>
+        <location filename="../downloadthread.cpp" line="213"/>
         <source>Write error while zero&apos;ing out MBR</source>
         <translation>MBR sıfırlanırken yazma hatası</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="229"/>
+        <location filename="../downloadthread.cpp" line="225"/>
         <source>Write error while trying to zero out last part of card.
 Card could be advertising wrong capacity (possible counterfeit)</source>
         <translation>Kartın son kısmını sıfırlamaya çalışırken yazma hatası. Kart yanlış kapasitenin tanımını yapıyor olabilir (olası sahte bölüm boyutu tanımı)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="350"/>
+        <location filename="../downloadthread.cpp" line="346"/>
         <source>Access denied error while writing file to disk.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="355"/>
+        <location filename="../downloadthread.cpp" line="351"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="361"/>
+        <location filename="../downloadthread.cpp" line="357"/>
         <source>Error writing file to disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="589"/>
+        <location filename="../downloadthread.cpp" line="585"/>
         <source>Error writing to storage (while flushing)</source>
         <translation>Depolama alanına yazma hatası (flushing sırasında)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="596"/>
+        <location filename="../downloadthread.cpp" line="592"/>
         <source>Error writing to storage (while fsync)</source>
         <translation>Depoya yazma hatası (fsync sırasında)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="577"/>
+        <location filename="../downloadthread.cpp" line="573"/>
         <source>Download corrupt. Hash does not match</source>
         <translation>İndirme bozuk. Hash eşleşmiyor</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="630"/>
+        <location filename="../downloadthread.cpp" line="626"/>
         <source>Error writing first block (partition table)</source>
         <translation>İlk bloğu yazma hatası (bölüm tablosu)</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="686"/>
+        <location filename="../downloadthread.cpp" line="682"/>
         <source>Error reading from storage.
 SD card may be broken.</source>
         <translation>Depolamadan okuma hatası.
 SD kart arızalı olabilir.</translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="705"/>
+        <location filename="../downloadthread.cpp" line="701"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
         <translation>Yazma doğrulanamadı. SD kartın içeriği, üzerine yazılandan farklı.</translation>
     </message>
@@ -240,209 +240,209 @@ File size %1 bytes is not a multiple of 512 bytes.</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="24"/>
+        <location filename="../main.qml" line="23"/>
         <source>Raspberry Pi Imager v%1</source>
         <translation>Raspberry Pi Imaj Yöneticisi v%1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="91"/>
-        <location filename="../main.qml" line="304"/>
+        <location filename="../main.qml" line="90"/>
+        <location filename="../main.qml" line="303"/>
         <source>Operating System</source>
         <translation>İşletim sistemi</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="103"/>
+        <location filename="../main.qml" line="102"/>
         <source>CHOOSE OS</source>
         <translation>İŞLETİM SİSTEMİ SEÇİN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="121"/>
+        <location filename="../main.qml" line="120"/>
         <source>Select this button to change the operating system</source>
         <translation>İşletim sistemini değiştirmek için bu düğmeyi seçin</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="134"/>
-        <location filename="../main.qml" line="588"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="587"/>
         <source>SD Card</source>
         <translation>SD Kart</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="146"/>
-        <location filename="../main.qml" line="868"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="860"/>
         <source>CHOOSE SD CARD</source>
         <translation>SD KART SEÇİN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="159"/>
+        <location filename="../main.qml" line="158"/>
         <source>Select this button to change the destination SD card</source>
         <translation>Hedef SD kartı değiştirmek için bu düğmeyi seçin</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="176"/>
+        <location filename="../main.qml" line="175"/>
         <source>WRITE</source>
         <translation>YAZ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="181"/>
+        <location filename="../main.qml" line="180"/>
         <source>Select this button to start writing the image</source>
         <translation>Görüntüyü yazmaya başlamak için bu düğmeyi seçin</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="221"/>
+        <location filename="../main.qml" line="220"/>
         <source>CANCEL WRITE</source>
         <translation>YAZMAYI İPTAL ET</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="224"/>
-        <location filename="../main.qml" line="810"/>
+        <location filename="../main.qml" line="223"/>
+        <location filename="../main.qml" line="802"/>
         <source>Cancelling...</source>
         <translation>İptal ediliyor...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="236"/>
+        <location filename="../main.qml" line="235"/>
         <source>CANCEL VERIFY</source>
         <translation>DOĞRULAMA İPTALİ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="239"/>
-        <location filename="../main.qml" line="833"/>
-        <location filename="../main.qml" line="886"/>
+        <location filename="../main.qml" line="238"/>
+        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="878"/>
         <source>Finalizing...</source>
         <translation>Bitiriliyor...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="385"/>
-        <location filename="../main.qml" line="862"/>
+        <location filename="../main.qml" line="384"/>
+        <location filename="../main.qml" line="854"/>
         <source>Erase</source>
         <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="386"/>
+        <location filename="../main.qml" line="385"/>
         <source>Format card as FAT32</source>
         <translation>Kartı FAT32 olarak biçimlendir</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="393"/>
+        <location filename="../main.qml" line="392"/>
         <source>Use custom</source>
         <translation>Özel imaj kullan</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="394"/>
+        <location filename="../main.qml" line="393"/>
         <source>Select a custom .img from your computer</source>
         <translation>Bilgisayarınızdan özel bir .img seçin</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="417"/>
+        <location filename="../main.qml" line="416"/>
         <source>Back</source>
         <translation>Geri</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="418"/>
+        <location filename="../main.qml" line="417"/>
         <source>Go back to main menu</source>
         <translation>Ana menüye dön</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="474"/>
         <source>Released: %1</source>
         <translation>Yayın: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="478"/>
+        <location filename="../main.qml" line="477"/>
         <source>Cached on your computer</source>
         <translation>Bilgisayarınızda önbelleğe alındı
 </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="479"/>
         <source>Local file</source>
         <translation>Yerel dosya</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="482"/>
+        <location filename="../main.qml" line="481"/>
         <source>Online - %1 GB download</source>
         <translation>Çevrimiçi -%1 GB indir</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
-        <location filename="../main.qml" line="691"/>
-        <location filename="../main.qml" line="697"/>
+        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="696"/>
         <source>Mounted as %1</source>
         <translation>%1 olarak bağlandı.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="693"/>
+        <location filename="../main.qml" line="692"/>
         <source>[WRITE PROTECTED]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="735"/>
+        <location filename="../main.qml" line="734"/>
         <source>Are you sure you want to quit?</source>
         <translation>Çıkmak istediğine emin misin?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="735"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
         <translation>Raspberry Pi Imager hala meşgul.&lt;br&gt;Çıkmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="747"/>
+        <location filename="../main.qml" line="746"/>
         <source>Warning</source>
         <translation>Uyarı</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="753"/>
-        <location filename="../main.qml" line="813"/>
+        <location filename="../main.qml" line="752"/>
+        <location filename="../main.qml" line="805"/>
         <source>Writing... %1%</source>
         <translation>Yazılıyor... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="766"/>
+        <location filename="../main.qml" line="765"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
         <translation>&apos;%1&apos; üzerindeki mevcut tüm veriler silinecek.&lt;br&gt;Devam etmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="792"/>
+        <location filename="../main.qml" line="784"/>
         <source>Error downloading OS list from Internet</source>
         <translation>İnternetten işletim sistemi listesi indirilirken hata oluştu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="828"/>
         <source>Verifying... %1%</source>
         <translation>Doğrulanıyor... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="854"/>
+        <location filename="../main.qml" line="846"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="861"/>
+        <location filename="../main.qml" line="853"/>
         <source>Write Successful</source>
         <translation>Başarılı Yazıldı</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="863"/>
+        <location filename="../main.qml" line="855"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation>&lt;b&gt;%1&lt;/b&gt; silindi &lt;br&gt;&lt;br&gt; Artık SD kartı okuyucudan çıkarabilirsiniz</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="865"/>
+        <location filename="../main.qml" line="857"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation>&lt;b&gt;%1&lt;/b&gt; &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt; üzerine yazıldı. Artık SD kartı okuyucudan çıkarabilirsiniz</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="893"/>
-        <location filename="../main.qml" line="935"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="927"/>
         <source>Error parsing os_list.json</source>
         <translation>os_list.json ayrıştırma hatası</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="973"/>
+        <location filename="../main.qml" line="965"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
         <translation>Önce görüntüler içeren bir USB bellek bağlayın.&lt;br&gt; Görüntüler USB belleğin kök klasöründe bulunmalıdır.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="988"/>
+        <location filename="../main.qml" line="980"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/i18n/rpi-imager_zh_cn.ts
+++ b/i18n/rpi-imager_zh_cn.ts
@@ -33,89 +33,89 @@
 <context>
     <name>DownloadThread</name>
     <message>
-        <location filename="../downloadthread.cpp" line="131"/>
+        <location filename="../downloadthread.cpp" line="127"/>
         <source>Error running diskpart: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="152"/>
+        <location filename="../downloadthread.cpp" line="148"/>
         <source>Error removing existing partitions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="178"/>
+        <location filename="../downloadthread.cpp" line="174"/>
         <source>Authentication cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="181"/>
+        <location filename="../downloadthread.cpp" line="177"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="182"/>
+        <location filename="../downloadthread.cpp" line="178"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="203"/>
+        <location filename="../downloadthread.cpp" line="199"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="217"/>
+        <location filename="../downloadthread.cpp" line="213"/>
         <source>Write error while zero&apos;ing out MBR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="229"/>
+        <location filename="../downloadthread.cpp" line="225"/>
         <source>Write error while trying to zero out last part of card.
 Card could be advertising wrong capacity (possible counterfeit)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="350"/>
+        <location filename="../downloadthread.cpp" line="346"/>
         <source>Access denied error while writing file to disk.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="355"/>
+        <location filename="../downloadthread.cpp" line="351"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="361"/>
+        <location filename="../downloadthread.cpp" line="357"/>
         <source>Error writing file to disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="589"/>
+        <location filename="../downloadthread.cpp" line="585"/>
         <source>Error writing to storage (while flushing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="596"/>
+        <location filename="../downloadthread.cpp" line="592"/>
         <source>Error writing to storage (while fsync)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="577"/>
+        <location filename="../downloadthread.cpp" line="573"/>
         <source>Download corrupt. Hash does not match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="630"/>
+        <location filename="../downloadthread.cpp" line="626"/>
         <source>Error writing first block (partition table)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="686"/>
+        <location filename="../downloadthread.cpp" line="682"/>
         <source>Error reading from storage.
 SD card may be broken.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../downloadthread.cpp" line="705"/>
+        <location filename="../downloadthread.cpp" line="701"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -237,183 +237,183 @@ File size %1 bytes is not a multiple of 512 bytes.</source>
 <context>
     <name>main</name>
     <message>
-        <location filename="../main.qml" line="24"/>
+        <location filename="../main.qml" line="23"/>
         <source>Raspberry Pi Imager v%1</source>
         <translation>树莓派镜像烧录 v%1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="735"/>
+        <location filename="../main.qml" line="734"/>
         <source>Are you sure you want to quit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="736"/>
+        <location filename="../main.qml" line="735"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="91"/>
-        <location filename="../main.qml" line="304"/>
+        <location filename="../main.qml" line="90"/>
+        <location filename="../main.qml" line="303"/>
         <source>Operating System</source>
         <translation>操作系统</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="103"/>
+        <location filename="../main.qml" line="102"/>
         <source>CHOOSE OS</source>
         <translation>选择操作系统</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="134"/>
-        <location filename="../main.qml" line="588"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="587"/>
         <source>SD Card</source>
         <translation>SD卡</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="146"/>
-        <location filename="../main.qml" line="868"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="860"/>
         <source>CHOOSE SD CARD</source>
         <translation>选择SD卡</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="176"/>
+        <location filename="../main.qml" line="175"/>
         <source>WRITE</source>
         <translation>烧录</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="753"/>
-        <location filename="../main.qml" line="813"/>
+        <location filename="../main.qml" line="752"/>
+        <location filename="../main.qml" line="805"/>
         <source>Writing... %1%</source>
         <translation>写入中...%1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="221"/>
+        <location filename="../main.qml" line="220"/>
         <source>CANCEL WRITE</source>
         <translation>取消写入</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="121"/>
+        <location filename="../main.qml" line="120"/>
         <source>Select this button to change the operating system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="159"/>
+        <location filename="../main.qml" line="158"/>
         <source>Select this button to change the destination SD card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="181"/>
+        <location filename="../main.qml" line="180"/>
         <source>Select this button to start writing the image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="224"/>
-        <location filename="../main.qml" line="810"/>
+        <location filename="../main.qml" line="223"/>
+        <location filename="../main.qml" line="802"/>
         <source>Cancelling...</source>
         <translation>取消中...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="236"/>
+        <location filename="../main.qml" line="235"/>
         <source>CANCEL VERIFY</source>
         <translation>取消验证</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="239"/>
-        <location filename="../main.qml" line="833"/>
-        <location filename="../main.qml" line="886"/>
+        <location filename="../main.qml" line="238"/>
+        <location filename="../main.qml" line="825"/>
+        <location filename="../main.qml" line="878"/>
         <source>Finalizing...</source>
         <translation>完成中...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="385"/>
-        <location filename="../main.qml" line="862"/>
+        <location filename="../main.qml" line="384"/>
+        <location filename="../main.qml" line="854"/>
         <source>Erase</source>
         <translation>擦除</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="386"/>
+        <location filename="../main.qml" line="385"/>
         <source>Format card as FAT32</source>
         <translation>格式化SD卡为FAT32格式</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="393"/>
+        <location filename="../main.qml" line="392"/>
         <source>Use custom</source>
         <translation>使用自定义镜像</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="394"/>
+        <location filename="../main.qml" line="393"/>
         <source>Select a custom .img from your computer</source>
         <translation>使用下载的系统镜像文件烧录</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="480"/>
+        <location filename="../main.qml" line="479"/>
         <source>Local file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="693"/>
+        <location filename="../main.qml" line="692"/>
         <source>[WRITE PROTECTED]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="747"/>
+        <location filename="../main.qml" line="746"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="766"/>
+        <location filename="../main.qml" line="765"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="863"/>
+        <location filename="../main.qml" line="855"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="893"/>
-        <location filename="../main.qml" line="935"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="927"/>
         <source>Error parsing os_list.json</source>
         <translation>解析 os_list.json 错误</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="973"/>
+        <location filename="../main.qml" line="965"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="988"/>
+        <location filename="../main.qml" line="980"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="417"/>
+        <location filename="../main.qml" line="416"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="418"/>
+        <location filename="../main.qml" line="417"/>
         <source>Go back to main menu</source>
         <translation>回到主页</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="475"/>
+        <location filename="../main.qml" line="474"/>
         <source>Released: %1</source>
         <translation>解压中...%1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="478"/>
+        <location filename="../main.qml" line="477"/>
         <source>Cached on your computer</source>
         <translation>在你的电脑上缓存</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="482"/>
+        <location filename="../main.qml" line="481"/>
         <source>Online - %1 GB download</source>
         <translation>已下载：%1 GB</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
-        <location filename="../main.qml" line="691"/>
-        <location filename="../main.qml" line="697"/>
+        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="690"/>
+        <location filename="../main.qml" line="696"/>
         <source>Mounted as %1</source>
         <translation>挂载在：%1 上</translation>
     </message>
@@ -426,27 +426,27 @@ File size %1 bytes is not a multiple of 512 bytes.</source>
         <translation type="vanished">继续</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="792"/>
+        <location filename="../main.qml" line="784"/>
         <source>Error downloading OS list from Internet</source>
         <translation>下载镜像列表错误</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="836"/>
+        <location filename="../main.qml" line="828"/>
         <source>Verifying... %1%</source>
         <translation>验证文件中...%1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="854"/>
+        <location filename="../main.qml" line="846"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="861"/>
+        <location filename="../main.qml" line="853"/>
         <source>Write Successful</source>
         <translation>烧录成功</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="865"/>
+        <location filename="../main.qml" line="857"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation>&lt;b&gt;%1&lt;/b&gt; 已经成功烧录到 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;上了，你可以卸载SD卡了</translation>
     </message>

--- a/i18n/translations.qrc
+++ b/i18n/translations.qrc
@@ -5,5 +5,6 @@
         <file>rpi-imager_zh_cn.qm</file>
         <file>rpi-imager_tr.qm</file>
         <file>rpi-imager_fr.qm</file>
+        <file>rpi-imager_de.qm</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Two things are not translated because I don't own the OS to check the translation:

Windows
**Controlled Folder Access** seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.
macOS
Please verify if 'Raspberry Pi Imager' is allowed access to **'removable volumes'** in **privacy settings** (under **'files and folders'** or alternatively give it **'full disk access'**).

I could translate those, but I'm not sure if they match the real name in the OS.