### PR TITLE
README.md: Improve wording on download link, add how to get on Raspberry Pi OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Raspberry Pi Imaging Utility
 
-Download pre-built versions from the [Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/).
+Download the latest version for Windows, macOS or Ubuntu from the [Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/).
+
+To install on Raspberry Pi OS, use `sudo apt update && sudo apt install rpi-imager`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 Raspberry Pi Imaging Utility
 
-Download the latest version for Windows, macOS and Ubuntu from the [Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/).
-
-To install on Raspberry Pi OS, use `sudo apt update && sudo apt install rpi-imager`.
+- Download the latest version for Windows, macOS and Ubuntu from the [Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/).
+- To install on Raspberry Pi OS, use `sudo apt update && sudo apt install rpi-imager`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Raspberry Pi Imaging Utility
 
-Download the latest version for Windows, macOS or Ubuntu from the [Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/).
+Download the latest version for Windows, macOS and Ubuntu from the [Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/).
 
 To install on Raspberry Pi OS, use `sudo apt update && sudo apt install rpi-imager`.
 


### PR DESCRIPTION
- The new wording has the advantage that it specifies which platforms the binaries are for - we probably don't want to get folks hopes up that their potentially unsupported platform is supported by our binaries
- Give instructions for how to get it on Raspberry Pi OS - no need to visit download page - it just needs a single shell command