### PR TITLE
Allow relative URLs in the repository files

### DIFF
--- a/imagewriter.cpp
+++ b/imagewriter.cpp
@@ -301,6 +301,16 @@ QString ImageWriter::fileNameFromUrl(const QUrl &url)
     return url.fileName();
 }
 
+/* Utility function to return an absolute URL from a relative one */
+QString ImageWriter::makeUrlAbsolute(const QUrl &url, const QUrl &baseUrl)
+{
+    if(url.isRelative())
+    {
+        return baseUrl.adjusted(QUrl::RemoveFilename).resolved(url).toString();
+    }
+    return url.toString();
+}
+
 QString ImageWriter::srcFileName()
 {
     return _src.isEmpty() ? "" : _src.fileName();

--- a/imagewriter.h
+++ b/imagewriter.h
@@ -60,6 +60,9 @@ public:
     /* Utility function to return filename part from URL */
     Q_INVOKABLE QString fileNameFromUrl(const QUrl &url);
 
+    /* Utility function to return an absolute URL from a relative one */
+    static Q_INVOKABLE QString makeUrlAbsolute(const QUrl &url, const QUrl &baseUrl);
+
     /* Function to return OS list URL */
     Q_INVOKABLE QUrl constantOsListUrl() const;
 

--- a/main.qml
+++ b/main.qml
@@ -878,6 +878,26 @@ ApplicationWindow {
         progressText.text = qsTr("Finalizing...")
     }
 
+    function processRelativeUrl(obj, baseUrl, attr) {
+        var url = obj[attr]
+        if (!url)
+            return
+
+        obj[attr] = imageWriter.makeUrlAbsolute(url, baseUrl)
+    }
+
+    function processRelativeUrls(oslist, baseUrl) {
+        for (var i in oslist) {
+            var entry = oslist[i]
+            processRelativeUrl(entry, baseUrl, "icon")
+            processRelativeUrl(entry, baseUrl, "url")
+            processRelativeUrl(entry, baseUrl, "subitems_url")
+            if ("subitems" in entry) {
+                processRelativeUrls(entry.subitems, baseUrl)
+            }
+        }
+    }
+
     function fetchOSlist() {
         httpRequest(imageWriter.constantOsListUrl(), function (x) {
             var o = JSON.parse(x.responseText)
@@ -886,6 +906,7 @@ ApplicationWindow {
                 return;
             }
             var oslist = o["os_list"]
+            processRelativeUrls(oslist, imageWriter.constantOsListUrl())
             for (var i in oslist) {
                 osmodel.insert(osmodel.count-2, oslist[i])
             }
@@ -928,6 +949,7 @@ ApplicationWindow {
                         return;
                     }
                     var oslist = o["os_list"]
+                    processRelativeUrls(oslist, d.subitems_url)
                     for (var i in oslist) {
                         subosmodel.append(oslist[i])
                     }

--- a/main.qml
+++ b/main.qml
@@ -395,7 +395,11 @@ ApplicationWindow {
 
         Component.onCompleted: {
             if (imageWriter.isOnline()) {
-                fetchOSlist();
+                fetchOSlist(imageWriter.constantOsListUrl(), function(oslist) {
+                    for (var i in oslist) {
+                        osmodel.insert(osmodel.count-2, oslist[i])
+                    }
+                });
             }
         }
     }
@@ -898,18 +902,16 @@ ApplicationWindow {
         }
     }
 
-    function fetchOSlist() {
-        httpRequest(imageWriter.constantOsListUrl(), function (x) {
+    function fetchOSlist(oslistUrl, callback) {
+        httpRequest(oslistUrl, function (x) {
             var o = JSON.parse(x.responseText)
             if (!"os_list" in o) {
                 onError(qsTr("Error parsing os_list.json"))
                 return;
             }
             var oslist = o["os_list"]
-            processRelativeUrls(oslist, imageWriter.constantOsListUrl())
-            for (var i in oslist) {
-                osmodel.insert(osmodel.count-2, oslist[i])
-            }
+            processRelativeUrls(oslist, oslistUrl)
+            callback(oslist)
         })
     }
 
@@ -942,14 +944,7 @@ ApplicationWindow {
                     subosmodel.remove(1, subosmodel.count-1)
                 }
 
-                httpRequest(d.subitems_url, function (x) {
-                    var o = JSON.parse(x.responseText)
-                    if (!"os_list" in o) {
-                        onError(qsTr("Error parsing os_list.json"))
-                        return;
-                    }
-                    var oslist = o["os_list"]
-                    processRelativeUrls(oslist, d.subitems_url)
+                fetchOSlist(d.subitems_url, function(oslist) {
                     for (var i in oslist) {
                         subosmodel.append(oslist[i])
                     }


### PR DESCRIPTION
This adds support for using relative URLs in the `icon`, `url` and `subitems_url` fields of the repository files. If the URL in one of these fields is relative, it's preprocessed into an absolute one by using the URL of the containing JSON file as its base. This eases the relocation of repository files without having to change their contents (for example, I could create and test a repository in my local filesystem and then upload them without having to change anything).