### PR TITLE
UI/Popup: changes the 'NO' button color

### DIFF
--- a/MsgPopup.qml
+++ b/MsgPopup.qml
@@ -98,8 +98,8 @@ Popup {
                     msgpopup.close()
                     msgpopup.no()
                 }
-                Material.foreground: "#ffffff"
-                Material.background: "#c51a4a"
+                Material.foreground: "#c51a4a"
+                Material.background: "#ffffff"
                 font.family: roboto.name
                 visible: msgpopup.noButton
                 Accessible.onPressAction: clicked()


### PR DESCRIPTION
I switched the colors so the 'NO' button appears to be `secondary` type. I was trying to write an image to my SD card and I pushed the NO button instead of YES.