### PR TITLE
Remove download count retention period from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ In order to understand which images and operating systems are most popular and r
 
 This web service is hosted by [Heroku](https://www.heroku.com) and only stores an incrementing counter using a [Redis Sorted Set](https://redis.io/topics/data-types#sorted-sets) for each URL, operating system name and category per day in the `eu-west-1` region and does not associate any personal data with those counts. This allows us to query the number of downloads over time and nothing else.
 
-The download counts are retained for 90 days and the last 1,500 requests to the service are logged for one week before expiring as this is the [minimum log retention period for Heroku](https://devcenter.heroku.com/articles/logging#log-history-limits).
+The last 1,500 requests to the service are logged for one week before expiring as this is the [minimum log retention period for Heroku](https://devcenter.heroku.com/articles/logging#log-history-limits).
 
 On Windows, you can opt out of telemetry by disabling it in the Registry:
 


### PR DESCRIPTION
In order to view the impact of changes such as OS releases over a longer period of time, we have removed the automatic expiry of the anonymous download counts from the rpi-imager stats service.

For reference, the download counts contain only the following data:

    > ZREVRANGE image:2021-03-12 0 1 WITHSCORES
    1) Raspberry Pi OS (32-bit)
    2) 1234
    3) Raspberry Pi OS Lite (32-bit)
    4) 567

Update the README section about telemetry in order to reflect the change.
