### PR TITLE
Improved desktop file to solve error and warning, when building an RPM for openSUSE Leap 15.2

### DIFF
--- a/linux/rpi-imager.desktop
+++ b/linux/rpi-imager.desktop
@@ -5,5 +5,6 @@ Name=Imager
 Comment=Raspberry Pi Imager
 Icon=rpi-imager
 Exec=rpi-imager
-Categories=Utility
+Categories=System;Utility;Archiving;
+GenericName=Write Raspberry PI OS images to SD card
 StartupNotify=false


### PR DESCRIPTION
The past couple of days I spent some time packaging "rpi-imager" for different Linux distributions, including openSUSE, Fedora, Debian and Ubuntu. You can find the results at [PragmaticLinux's OBS repository](https://build.opensuse.org/package/show/home:pragmalin/rpi-imager).

While buiding and testing the RPM package on openSUSE Leap 15.2, the package could not be built due to some minor issues with the "rpi-imager.desktop" file. A few tweaks to this file solved the problem. I created a patch for this fix inside the OBS repository to be able to continue. 

It would be great if you can incorporate this pull request in the upstream "rpi-imager", so that future releases no longer need this patch.

Feel free to contact me for additional questions or comments.