### PR TITLE
Update URLs after move to raspberrypi.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Raspberry Pi Imaging Utility
 
-- Download the latest version for Windows, macOS and Ubuntu from the [Raspberry Pi downloads page](https://www.raspberrypi.org/downloads/).
+- Download the latest version for Windows, macOS and Ubuntu from the [Raspberry Pi downloads page](https://www.raspberrypi.com/software/).
 - To install on Raspberry Pi OS, use `sudo apt update && sudo apt install rpi-imager`.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ So can simply create another 'start menu shortcut' to the application with that 
 
 ### Telemetry
 
-In order to understand which images and operating systems are most popular and re-organise the application accordingly, when using the default image repository, the URL, operating system name and category (if present) of a selected image are sent to https://rpi-imager-stats.raspberrypi.org by [`downloadstatstelemetry.cpp`](https://github.com/raspberrypi/rpi-imager/blob/qml/downloadstatstelemetry.cpp).
+In order to understand which images and operating systems are most popular and re-organise the application accordingly, when using the default image repository, the URL, operating system name and category (if present) of a selected image are sent to https://rpi-imager-stats.raspberrypi.com by [`downloadstatstelemetry.cpp`](https://github.com/raspberrypi/rpi-imager/blob/qml/downloadstatstelemetry.cpp).
 
 This web service is hosted by [Heroku](https://www.heroku.com) and only stores an incrementing counter using a [Redis Sorted Set](https://redis.io/topics/data-types#sorted-sets) for each URL, operating system name and category per day in the `eu-west-1` region and does not associate any personal data with those counts. This allows us to query the number of downloads over time and nothing else.
 

--- a/config.h
+++ b/config.h
@@ -14,7 +14,7 @@
 #define TIME_URL                          "http://downloads.raspberrypi.org/os_list_imagingutility_v2.json?time_synchronization"
 
 /* Phone home the name of images downloaded for image popularity ranking */
-#define TELEMETRY_URL                     "https://rpi-imager-stats.raspberrypi.org/downloads"
+#define TELEMETRY_URL                     "https://rpi-imager-stats.raspberrypi.com/downloads"
 #define TELEMETRY_ENABLED_DEFAULT         true
 
 /* Hash algorithm for verifying (uncompressed image) checksum */


### PR DESCRIPTION
Now we've moved the downloads page and telemetry endpoint from raspberrypi.org to raspberrypi.com, update the download link in the README and the URL used for telemetry. (Note that the raspberrypi.org endpoint will continue to work indefinitely in order to support existing clients.)
