### PR TITLE
Make osdelegate more flexible and robust

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -541,97 +541,8 @@ ApplicationWindow {
 
         Item {
             width: window.width-100
-            height: image_download_size ? 100 : 60
+            height: contentLayout.implicitHeight + 24
             Accessible.name: name+".\n"+description
-
-            Rectangle {
-               id: bgrect
-               anchors.fill: parent
-               color: "#f5f5f5"
-               visible: mouseOver && parent.ListView.view.currentIndex !== index
-               property bool mouseOver: false
-            }
-            Rectangle {
-               id: borderrect
-               implicitHeight: 1
-               implicitWidth: parent.width
-               color: "#dcdcdc"
-               y: parent.height
-            }
-
-            Row {
-                leftPadding: 25
-
-                Column {
-                    width: 64
-
-                    Image {
-                        source: icon == "icons/ic_build_48px.svg" ? "icons/cat_misc_utility_images.png": icon
-                        verticalAlignment: Image.AlignVCenter
-                        height: parent.parent.parent.height
-                        fillMode: Image.Pad
-                    }
-                    Text {
-                        text: " "
-//                      visible: !icon
-                    }
-                }
-                Column {
-                    width: parent.parent.width-64-50-25
-
-                    Text {
-                        verticalAlignment: Text.AlignVCenter
-                        height: parent.parent.parent.height
-                        font.family: roboto.name
-                        textFormat: Text.RichText
-                        text: {
-                            var txt = "<p style='margin-bottom: 5px; font-weight: bold;'>"+name
-                            if (typeof(website) == "string" && website) {
-                                txt += " &nbsp; <a href='"+website+"'> <img src='icons/ic_info_16px.png' align='top'></a>"
-                            }
-                            txt += "</p><font color='#1a1a1a'>"+description+"</font><font style='font-weight: 200' color='#646464'>"
-                            if (typeof(release_date) == "string" && release_date)
-                                txt += "<br>"+qsTr("Released: %1").arg(release_date)
-                            if (typeof(url) == "string" && url != "" && url != "internal://format") {
-                                if (typeof(extract_sha256) != "undefined" && imageWriter.isCached(url,extract_sha256)) {
-                                    txt += "<br>"+qsTr("Cached on your computer")
-                                } else if (url.startsWith("file://")) {
-                                    txt += "<br>"+qsTr("Local file")
-                                } else {
-                                    txt += "<br>"+qsTr("Online - %1 GB download").arg((image_download_size/1073741824).toFixed(1));
-                                }
-                            }
-                            txt += "</font>";
-
-                            return txt;
-                        }
-                        id: osText
-
-                        /*
-                        Accessible.role: Accessible.ListItem
-                        Accessible.name: name+".\n"+description
-                        Accessible.focusable: true
-                        Accessible.focused: parent.parent.parent.ListView.view.currentIndex === index
-                        */
-
-                        ToolTip {
-                            visible: osMouseArea.containsMouse && typeof(tooltip) == "string" && tooltip != ""
-                            delay: 1000
-                            text: typeof(tooltip) == "string" ? tooltip : ""
-                            clip: false
-                        }
-                    }
-
-                }
-                Column {
-                    Image {
-                        source: "icons/ic_chevron_right_40px.svg"
-                        visible: (typeof(subitems) == "object" && subitems.count) || (typeof(subitems_url) == "string" && subitems_url != "" && subitems_url != "internal://back")
-                        height: parent.parent.parent.height
-                        fillMode: Image.Pad
-                    }
-                }
-            }
 
             MouseArea {
                 id: osMouseArea
@@ -648,11 +559,114 @@ ApplicationWindow {
                 }
 
                 onClicked: {
-                    if (osText.hoveredLink) {
-                        Qt.openUrlExternally(osText.hoveredLink)
-                    } else {
-                        selectOSitem(model)
+                    selectOSitem(model)
+                }
+            }
+
+            Rectangle {
+               id: bgrect
+               anchors.fill: parent
+               color: "#f5f5f5"
+               visible: mouseOver && parent.ListView.view.currentIndex !== index
+               property bool mouseOver: false
+            }
+            Rectangle {
+               id: borderrect
+               implicitHeight: 1
+               implicitWidth: parent.width
+               color: "#dcdcdc"
+               y: parent.height
+            }
+
+            RowLayout {
+                id: contentLayout
+                anchors {
+                    left: parent.left
+                    top: parent.top
+                    right: parent.right
+                    margins: 12
+                }
+                spacing: 12
+
+                Image {
+                    source: icon == "icons/ic_build_48px.svg" ? "icons/cat_misc_utility_images.png": icon
+                    Layout.preferredHeight: 40
+                    Layout.preferredWidth: 40
+                    sourceSize.width: 40
+                    sourceSize.height: 40
+                    fillMode: Image.PreserveAspectFit
+                    verticalAlignment: Image.AlignVCenter
+                    Layout.alignment: Qt.AlignVCenter
+                }
+                ColumnLayout {
+                    Layout.fillWidth: true
+
+                    RowLayout {
+                        spacing: 12
+                        Text {
+                            text: name
+                            elide: Text.ElideRight
+                            font.family: roboto.name
+                            font.bold: true
+                        }
+                        Image {
+                            source: "icons/ic_info_16px.png"
+                            Layout.preferredHeight: 16
+                            Layout.preferredWidth: 16
+                            visible: typeof(website) == "string" && website
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: Qt.openUrlExternally(website)
+                            }
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
                     }
+
+                    Text {
+                        Layout.fillWidth: true
+                        font.family: roboto.name
+                        text: description
+                        wrapMode: Text.WordWrap
+                        color: "#1a1a1a"
+                    }
+
+                    Text {
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        color: "#646464"
+                        font.weight: Font.Light
+                        visible: typeof(release_date) == "string" && release_date
+                        text: qsTr("Released: %1").arg(release_date)
+                    }
+                    Text {
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        color: "#646464"
+                        font.weight: Font.Light
+                        visible: typeof(url) == "string" && url != "" && url != "internal://format"
+                        text: !url ? "" :
+                              typeof(extract_sha256) != "undefined" && imageWriter.isCached(url,extract_sha256)
+                                ? qsTr("Cached on your computer")
+                                : url.startsWith("file://")
+                                  ? qsTr("Local file")
+                                  : qsTr("Online - %1 GB download").arg((image_download_size/1073741824).toFixed(1))
+                    }
+
+                    ToolTip {
+                        visible: osMouseArea.containsMouse && typeof(tooltip) == "string" && tooltip != ""
+                        delay: 1000
+                        text: typeof(tooltip) == "string" ? tooltip : ""
+                        clip: false
+                    }
+                }
+                Image {
+                    source: "icons/ic_chevron_right_40px.svg"
+                    visible: (typeof(subitems) == "object" && subitems.count) || (typeof(subitems_url) == "string" && subitems_url != "" && subitems_url != "internal://back")
+                    Layout.preferredHeight: 40
+                    Layout.preferredWidth: 40
+                    fillMode: Image.PreserveAspectFit
                 }
             }
         }


### PR DESCRIPTION
While creating the repository json for the nymea image I noticed that if the json provides an icon that is too large, it can break the delegate. For example:

![image](https://user-images.githubusercontent.com/102573/148682891-7173a304-65b8-4cf0-aca9-15c20d52b4af.png)

Also I noticed that the description breaks the layout too if it's too long:

![image](https://user-images.githubusercontent.com/102573/148682919-0f804363-b560-477f-867f-27dd28a27f35.png)

This patch should keep visuals the same (I think there's a tad more spacing between the lines, keeping Qt's default spacing - if you don't like that I can easily change that). Also it fetches the remote icon now and puts it into 40x40 box like all the icons, scaling if necessariy. A repo json can now feed it it svg or png files of any size and it will always look correct.

Then it splits up the text content in individual entries. For one, this allows to wrap and/or elide as needed and secondly, IMHO this makes the code much easier to work with, without having to construct a huge string with html tags. In order to always fit the content, regardless of how long it is, it will dynamically adjust the delegate height to fit it.
Changed version:
![image](https://user-images.githubusercontent.com/102573/148683048-2da0f095-663b-4232-a909-2114f272c5b5.png)

If you think it's not good that the delegates height expands to infinity on very long description texts, it can be limited to e.g. 2 lines just by setting `maximumLineCount: 2` on the according Text item.
