### PR TITLE
Add support for compat labels

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -463,6 +463,7 @@ ApplicationWindow {
                     tooltip: ""
                     website: ""
                     init_format: ""
+                    compatibility: ""
                 }
             }
 
@@ -491,32 +492,10 @@ ApplicationWindow {
 
     ListModel {
         id: osmodel
-
-        ListElement {
-            url: "internal://format"
-            icon: "icons/erase.png"
-            extract_size: 0
-            image_download_size: 0
-            extract_sha256: ""
-            contains_multiple_files: false
-            release_date: ""
-            subitems_url: ""
-            subitems_json: ""
-            name: qsTr("Erase")
-            description: qsTr("Format card as FAT32")
-            tooltip: ""
-            website: ""
-            init_format: ""
-        }
-
-        ListElement {
-            url: ""
-            icon: "icons/use_custom.png"
-            name: qsTr("Use custom")
-            description: qsTr("Select a custom .img from your computer")
-        }
-
+        dynamicRoles: true
         Component.onCompleted: {
+            append({url: "internal://format", icon: "icons/erase.png", name: qsTr("Erase"), description: qsTr("Format card as FAT32")})
+            append({icon: "icons/use_custom.png", name: qsTr("Use custom"), description: qsTr("Select a custom .img from your computer")})
             if (imageWriter.isOnline()) {
                 fetchOSlist();
             }
@@ -640,6 +619,28 @@ ApplicationWindow {
                                   ? qsTr("Local file")
                                   : qsTr("Online - %1 GB download").arg((image_download_size/1073741824).toFixed(1))
                     }
+
+                    RowLayout {
+                        Repeater {
+                            id: compatRepeater
+                            model: compatibility && compatibility !== "" ? compatibility.split(',') : 0
+                            delegate: Rectangle {
+                                color: "#004881"
+                                Layout.preferredHeight: childrenRect.height + 4
+                                Layout.preferredWidth: childrenRect.width + 8
+                                radius: 3
+                                Label {
+                                    anchors.centerIn: parent
+                                    text: modelData
+                                    color: "white"
+                                    font.pixelSize: 10
+                                    font.family: roboto.name
+                                    font.weight: Font.Light
+                                }
+                            }
+                        }
+                    }
+
 
                     ToolTip {
                         visible: osMouseArea.containsMouse && typeof(tooltip) == "string" && tooltip != ""


### PR DESCRIPTION
Currently images list their compatibility in the description which takes away precious space in the description, as well is not unified across different OSes. Looking at the Raspberry PI website, where this became a more important topic with the arm64 images being promoted more popular now, I saw there are nice labels for the compatibility and I thought it may make sense to unify that and came up with this:

![image](https://user-images.githubusercontent.com/102573/154768471-75d0eeaf-0e63-4dd6-a7ba-960dccbac16f.png)

The attached file is a copy of the upstream os_list json with added compat tags for testing (renamed to .txt because github wouldn't allow attaching .json files).
[os_list_imagingutility_v3.json.txt](https://github.com/raspberrypi/rpi-imager/files/8100743/os_list_imagingutility_v3.json.txt)

 I am not particularly fond of the mechanism to use a comma separated string and splitting that, but QMLs ListModel does not allow injecting arrays just like that. To make it work with `"compatibility": ["A", "B", "C"]` more work and changes would be needed which I didn't want to do without asking if that's something you would even want/accept. If you think the idea in itself is good but would prefer the more proper approach I think I can give that a go when I find some time.