### PR TITLE
Add Enable UART checkbox on Advanced Options Popup

### DIFF
--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -117,6 +117,10 @@ Popup {
                         id: chkOverscan
                         text: qsTr("Disable overscan")
                     }
+                    ImCheckBox {
+                        id: chkEnableUart
+                        text: qsTr("Enable UART")
+                    }
                     RowLayout {
                         ImCheckBox {
                             id: chkHostname
@@ -461,6 +465,9 @@ Popup {
         if ('disableOverscan' in settings) {
             chkOverscan.checked = true
         }
+        if ('enableUart' in settings) {
+            chkEnableUart.checked = true
+        }
         if ('hostname' in settings) {
             fieldHostname.text = settings.hostname
             chkHostname.checked = true
@@ -602,6 +609,9 @@ Popup {
 
         if (chkOverscan.checked) {
             addConfig("disable_overscan=1")
+        }
+        if (chkEnableUart.checked) {
+            addConfig("enable_uart=1")
         }
         if (chkHostname.checked && fieldHostname.length) {
             addFirstRun("CURRENT_HOSTNAME=`cat /etc/hostname | tr -d \" \\t\\n\\r\"`")
@@ -788,6 +798,9 @@ Popup {
             var settings = { };
             if (chkOverscan.checked) {
                 settings.disableOverscan = true
+            }
+            if (chkEnableUart.checked) {
+                settings.enableUart = true
             }
             if (chkHostname.checked && fieldHostname.length) {
                 settings.hostname = fieldHostname.text

--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -118,6 +118,10 @@ Popup {
                         text: qsTr("Disable overscan")
                     }
                     ImCheckBox {
+                        id: chk2ndStageUart
+                        text: qsTr("2nd Stage Bootloader UART")
+                    }
+                    ImCheckBox {
                         id: chkEnableUart
                         text: qsTr("Enable UART")
                     }
@@ -468,6 +472,9 @@ Popup {
         if ('enableUart' in settings) {
             chkEnableUart.checked = true
         }
+        if ('secondStageUart' in settings) {
+            chk2ndStageUart.checked = true;
+        }
         if ('hostname' in settings) {
             fieldHostname.text = settings.hostname
             chkHostname.checked = true
@@ -612,6 +619,9 @@ Popup {
         }
         if (chkEnableUart.checked) {
             addConfig("enable_uart=1")
+        }
+        if (chk2ndStageUart.checked) {
+            addConfig("uart_2ndstage=1")
         }
         if (chkHostname.checked && fieldHostname.length) {
             addFirstRun("CURRENT_HOSTNAME=`cat /etc/hostname | tr -d \" \\t\\n\\r\"`")
@@ -801,6 +811,9 @@ Popup {
             }
             if (chkEnableUart.checked) {
                 settings.enableUart = true
+            }
+            if (chk2ndStageUart.checked) {
+                settings.secondStageUart = true;
             }
             if (chkHostname.checked && fieldHostname.length) {
                 settings.hostname = fieldHostname.text

--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -117,14 +117,6 @@ Popup {
                         id: chkOverscan
                         text: qsTr("Disable overscan")
                     }
-                    ImCheckBox {
-                        id: chk2ndStageUart
-                        text: qsTr("2nd Stage Bootloader UART")
-                    }
-                    ImCheckBox {
-                        id: chkEnableUart
-                        text: qsTr("Enable UART")
-                    }
                     RowLayout {
                         ImCheckBox {
                             id: chkHostname
@@ -373,6 +365,14 @@ Popup {
                             id: chkSkipFirstUse
                             text: qsTr("Skip first-run wizard")
                         }
+                    }
+                    ImCheckBox {
+                        id: chk2ndStageUart
+                        text: qsTr("2nd Stage Bootloader UART")
+                    }
+                    ImCheckBox {
+                        id: chkEnableUart
+                        text: qsTr("Enable UART")
                     }
                 }
             }


### PR DESCRIPTION
With the Enable UART checkbox selected we will have the property
`enable_uart=1` added to the config.txt.

This is useful if the user already has an usb serial converter
connected and prefers to use the board, or debug it, over serial.

With the 2nd Stage Bootloader UART checkbox select we will have
the property `uart_2ndstage=1` added to the config.txt.

Signed-off-by: Matheus Castello <matheus@castello.eng.br>