### PR TITLE
Add option to disable user field per-image. Fixes https://github.com/guysoft/pi-imager/issues/8

### DIFF
--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -226,6 +226,7 @@ Popup {
                             TextField {
                                 id: fieldUserName
                                 text: "pi"
+                                enabled: imageWriter.userDisabled()
                                 Layout.minimumWidth: 200
                                 property bool indicateError: false
 
@@ -675,6 +676,16 @@ Popup {
 
             if (chkSetUser.checked) {
                 /* Rename first ("pi") user if a different desired username was specified */
+                if (imageWriter.userDisabled()){
+                    // For now disabled user defaults to pi, could be changed later
+
+                   fieldUserName.text = "pi";
+                   fieldUserName.enabled = false;
+                }
+                else{
+                    fieldUserName.enabled = true;
+                }
+
                 addFirstRun("if [ -f /usr/lib/userconf-pi/userconf ]; then")
                 addFirstRun("   /usr/lib/userconf-pi/userconf "+escapeshellarg(fieldUserName.text)+" "+escapeshellarg(cryptedPassword))
                 addFirstRun("else")

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -191,7 +191,7 @@ void ImageWriter::setEngine(QQmlApplicationEngine *engine)
 }
 
 /* Set URL to download from */
-void ImageWriter::setSrc(const QUrl &url, quint64 downloadLen, quint64 extrLen, QByteArray expectedHash, bool multifilesinzip, QString parentcategory, QString osname, QByteArray initFormat)
+void ImageWriter::setSrc(const QUrl &url, quint64 downloadLen, quint64 extrLen, QByteArray expectedHash, bool multifilesinzip, QString parentcategory, QString osname, bool disable_user, QByteArray initFormat)
 {
     _src = url;
     _downloadLen = downloadLen;
@@ -200,6 +200,7 @@ void ImageWriter::setSrc(const QUrl &url, quint64 downloadLen, quint64 extrLen, 
     _multipleFilesInZip = multifilesinzip;
     _parentCategory = parentcategory;
     _osName = osname;
+    _disable_user = disable_user;
     _initFormat = (initFormat == "none") ? "" : initFormat;
 
     if (!_downloadLen && url.isLocalFile())
@@ -1028,6 +1029,10 @@ void ImageWriter::setImageCustomization(const QByteArray &config, const QByteArr
     qDebug() << "Custom cmdline.txt entries:" << cmdline;
     qDebug() << "Custom firstuse.sh:" << firstrun;
     qDebug() << "Cloudinit:" << cloudinit;
+}
+
+bool ImageWriter::userDisabled(){
+    return _disable_user;
 }
 
 QString ImageWriter::crypt(const QByteArray &password)

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -30,7 +30,7 @@ public:
     void setEngine(QQmlApplicationEngine *engine);
 
     /* Set URL to download from, and if known download length and uncompressed length */
-    Q_INVOKABLE void setSrc(const QUrl &url, quint64 downloadLen = 0, quint64 extrLen = 0, QByteArray expectedHash = "", bool multifilesinzip = false, QString parentcategory = "", QString osname = "", QByteArray initFormat = "");
+    Q_INVOKABLE void setSrc(const QUrl &url, quint64 downloadLen = 0, quint64 extrLen = 0, QByteArray expectedHash = "", bool multifilesinzip = false, QString parentcategory = "", QString osname = "", bool disable_user = false, QByteArray initFormat = "");
 
     /* Set device to write to */
     Q_INVOKABLE void setDst(const QString &device, quint64 deviceSize = 0);
@@ -105,6 +105,7 @@ public:
     Q_INVOKABLE bool getBoolSetting(const QString &key);
     Q_INVOKABLE void setSetting(const QString &key, const QVariant &value);
     Q_INVOKABLE void setImageCustomization(const QByteArray &config, const QByteArray &cmdline, const QByteArray &firstrun, const QByteArray &cloudinit, const QByteArray &cloudinitNetwork);
+    Q_INVOKABLE bool userDisabled();
     Q_INVOKABLE void setSavedCustomizationSettings(const QVariantMap &map);
     Q_INVOKABLE QVariantMap getSavedCustomizationSettings();
     Q_INVOKABLE void clearSavedCustomizationSettings();
@@ -164,7 +165,7 @@ protected:
     QTimer _polltimer, _networkchecktimer;
     PowerSaveBlocker _powersave;
     DownloadThread *_thread;
-    bool _verifyEnabled, _multipleFilesInZip, _cachingEnabled, _embeddedMode, _online;
+    bool _verifyEnabled, _multipleFilesInZip, _cachingEnabled, _embeddedMode, _online, _disable_user;
     QSettings _settings;
     QMap<QString,QString> _translations;
     QTranslator *_trans;

--- a/src/main.qml
+++ b/src/main.qml
@@ -13,6 +13,7 @@ import "qmlcomponents"
 ApplicationWindow {
     id: window
     visible: true
+    property alias writebutton: writebutton
 
     width: imageWriter.isEmbeddedMode() ? -1 : 680
     height: imageWriter.isEmbeddedMode() ? -1 : 420
@@ -463,6 +464,7 @@ ApplicationWindow {
                     tooltip: ""
                     website: ""
                     init_format: ""
+                    disable_user: false
                 }
             }
 
@@ -1272,13 +1274,22 @@ ApplicationWindow {
                 }
             }
         } else {
-            imageWriter.setSrc(d.url, d.image_download_size, d.extract_size, typeof(d.extract_sha256) != "undefined" ? d.extract_sha256 : "", typeof(d.contains_multiple_files) != "undefined" ? d.contains_multiple_files : false, ospopup.categorySelected, d.name, typeof(d.init_format) != "undefined" ? d.init_format : "")
+
+            imageWriter.setSrc(d.url, d.image_download_size, d.extract_size, typeof(d.extract_sha256) != "undefined" ? d.extract_sha256 : "", typeof(d.contains_multiple_files) != "undefined" ? d.contains_multiple_files : false, ospopup.categorySelected, d.name, d.disable_user, typeof(d.init_format) != "undefined" ? d.init_format : "")
             osbutton.text = d.name
             ospopup.close()
             if (imageWriter.readyToWrite()) {
                 writebutton.enabled = true
             }
             customizebutton.visible = imageWriter.imageSupportsCustomization()
+            if (imageWriter.imageSupportsCustomization()){
+
+                if (!optionspopup.initialized) {
+                    optionspopup.initialize()
+                }
+
+                optionspopup.applySettings()
+            }
         }
     }
 


### PR DESCRIPTION
Hey,
This is a proposal to force in a single-user distribution to grey out the username field and default it to pi.
The json format is:
```json
{
"disable_user":  true
}
```

I am not sure how to add it to the docs here because it looks like an automatically generated HTML, so if you need that an explanation how to do it would be helpful:
https://github.com/raspberrypi/rpi-imager/blob/qml/doc/json-schema/os-list-schema.html

I am open to suggestions how to change this. I already merged it to pi-imager for testing.

This is the current message on octoprint.org, as you can imagine people still do this.:
<img width="340" alt="advanced-password" src="https://user-images.githubusercontent.com/325670/159259313-2ca5d39a-5550-4c20-bffd-c9fabef219db.png">
