### PR TITLE
Fix crash on Linux

### DIFF
--- a/src/networkaccessmanagerfactory.cpp
+++ b/src/networkaccessmanagerfactory.cpp
@@ -15,18 +15,20 @@
 /* Configure caching for files downloaded from Internet by QML (e.g. os_list.json and icons) */
 NetworkAccessManagerFactory::NetworkAccessManagerFactory()
 {
-    _c = new QNetworkDiskCache(this);
-    _c->setCacheDirectory(QStandardPaths::writableLocation(QStandardPaths::CacheLocation)+QDir::separator()+"oslistcache");
+    auto c = new QNetworkDiskCache;
+    c->setCacheDirectory(QStandardPaths::writableLocation(QStandardPaths::CacheLocation)+QDir::separator()+"oslistcache");
     /* Only cache images and not the .json */
     //_c->remove(QUrl(OSLIST_URL));
 
     /* Clear all for now as we do not know any potential subitems_url in advance */
-    _c->clear();
+    c->clear();
+    _nam = new QNetworkAccessManager;
+    _nam->setCache(c);
 }
 
 QNetworkAccessManager *NetworkAccessManagerFactory::create(QObject *parent)
 {
-    QNetworkAccessManager *nam = new QNetworkAccessManager(parent);
-    nam->setCache(_c);
-    return nam;
+    if (!_nam->parent() && parent && _nam->thread() == parent->thread())
+        _nam->setParent(parent);
+    return _nam;
 }

--- a/src/networkaccessmanagerfactory.h
+++ b/src/networkaccessmanagerfactory.h
@@ -8,16 +8,16 @@
 
 #include <QQmlNetworkAccessManagerFactory>
 
-class QNetworkDiskCache;
+class QNetworkAccessManager;
 
-class NetworkAccessManagerFactory : public QObject, public QQmlNetworkAccessManagerFactory
+class NetworkAccessManagerFactory : public QQmlNetworkAccessManagerFactory
 {
 public:
     NetworkAccessManagerFactory();
-    virtual QNetworkAccessManager *create(QObject *parent);
+    QNetworkAccessManager *create(QObject *parent) override;
 
 protected:
-    QNetworkDiskCache *_c;
+    QNetworkAccessManager *_nam;
 };
 
 #endif // NETWORKACCESSMANAGERFACTORY_H


### PR DESCRIPTION
When one click "CHOOSE OS", app crashes because Qt tries to create
another nam in a thread other than the main thread.
In NetworkAccessManagerFactory::create(), nam->setCache() crashes with
the message below
ASSERT failure in QCoreApplication::sendEvent: "Cannot send events to
objects owned by a different thread. Current thread 0x0x564c398b7550.
Receiver '' (of type 'QNetworkAccessManager') was created in thread
0x0x564c38bcc3f0", file path/to/qt5/qtbase/src/corelib/kernel/
qcoreapplication.cpp, line 553

QNAM::setCache tries to take ownership of the cache which was created in
the main thread.