### PR TITLE
code-quality: fixed all range-loop warnings which were reported from clazy

### DIFF
--- a/src/dependencies/mountutils/src/linux/functions.cpp
+++ b/src/dependencies/mountutils/src/linux/functions.cpp
@@ -97,7 +97,7 @@ MOUNTUTILS_RESULT unmount_disk(const char *device_path) {
   size_t unmounts = 0;
   MOUNTUTILS_RESULT result_code = MOUNTUTILS_SUCCESS;
 
-  for (std::string mount_dir : mount_dirs) {
+  for (const std::string& mount_dir : mount_dirs) {
     MountUtilsLog("Unmounting " + mount_dir + "...");
 
     mount_path = mount_dir.c_str();

--- a/src/downloadextractthread.cpp
+++ b/src/downloadextractthread.cpp
@@ -231,7 +231,7 @@ void DownloadExtractThread::extractMultiFileRun()
     {
         QThread::sleep(1);
         auto l = Drivelist::ListStorageDevices();
-        for (auto i : l)
+        for (const auto& i : l)
         {
             if (QByteArray::fromStdString(i.device).toLower() == devlower && i.mountpoints.size() == 1)
             {
@@ -363,7 +363,7 @@ void DownloadExtractThread::extractMultiFileRun()
             _cachefile.remove();
 
         qDebug() << "Deleting extracted files";
-        for (auto filename : filesExtracted)
+        for (const auto& filename : filesExtracted)
         {
             QFileInfo fi(filename);
             QString path = fi.path();

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -871,7 +871,7 @@ bool DownloadThread::_customizeImage()
     {
         QThread::sleep(1);
         auto l = Drivelist::ListStorageDevices();
-        for (auto i : l)
+        for (const auto& i : l)
         {
             if (QByteArray::fromStdString(i.device).toLower() == devlower && i.mountpoints.size())
             {
@@ -951,10 +951,10 @@ bool DownloadThread::_customizeImage()
         //
         qDebug() << "drive info. searching for:" << devlower;
         auto l = Drivelist::ListStorageDevices();
-        for (auto i : l)
+        for (const auto& i : l)
         {
             qDebug() << "drive" << QByteArray::fromStdString(i.device).toLower();
-            for (auto mp : i.mountpoints) {
+            for (const auto& mp : i.mountpoints) {
                 qDebug() << "mountpoint:" << QByteArray::fromStdString(mp);
             }
         }
@@ -973,7 +973,7 @@ bool DownloadThread::_customizeImage()
     {
         /* Search all mountpoints, as on some systems FAT partition
            may not be first volume */
-        for (auto mp : mountpoints)
+        for (const auto& mp : mountpoints)
         {
             folder = QString::fromStdString(mp);
             if (folder.right(1) == '\\')
@@ -1012,7 +1012,7 @@ bool DownloadThread::_customizeImage()
             f.close();
         }
 
-        for (QByteArray item : configItems)
+        for (const QByteArray& item : configItems)
         {
             if (config.contains("#"+item)) {
                 /* Uncomment existing line */

--- a/src/linux/linuxdrivelist.cpp
+++ b/src/linux/linuxdrivelist.cpp
@@ -132,7 +132,7 @@ namespace Drivelist
             if (d.isSystem && subsystems.contains("nvme"))
             {
                 bool isMounted = false;
-                for (std::string mp : d.mountpoints)
+                for (const std::string& mp : d.mountpoints)
                 {
                     if (!QByteArray::fromStdString(mp).startsWith("/media/")) {
                         isMounted = true;

--- a/src/linux/udisks2api.cpp
+++ b/src/linux/udisks2api.cpp
@@ -71,7 +71,7 @@ void UDisks2Api::_unmountDrive(const QString &driveDbusPath)
     if (!manager.isValid() || !list.isValid())
         return;
 
-    for (auto devpath : list.value())
+    for (const auto& devpath : list.value())
     {
         QString devpathStr = devpath.path();
 
@@ -263,7 +263,7 @@ QByteArrayList UDisks2Api::mountPoints(const QDBusInterface &filesystem)
     QVariantList args = {"org.freedesktop.UDisks2.Filesystem", "MountPoints"};
     msg.setArguments(args);
     QDBusMessage reply = QDBusConnection::systemBus().call(msg);
-    for (auto arg : reply.arguments())
+    for (const auto& arg : reply.arguments())
     {
         arg.value<QDBusVariant>().variant().value<QDBusArgument>() >> mps;
     }


### PR DESCRIPTION
See: `rpi-imager/src/downloadthread.cpp:1015:14: warning: Missing reference in range-for with non trivial type (QByteArray) [clazy-range-loop]`