### PR TITLE
Allow selection of files without extension

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -577,7 +577,7 @@ void ImageWriter::openFileDialog()
 
     QFileDialog *fd = new QFileDialog(nullptr, tr("Select image"),
                                       path,
-                                      "Image files (*.img *.zip *.iso *.gz *.xz *.zst);;All files (*.*)");
+                                      "Image files (*.img *.zip *.iso *.gz *.xz *.zst);;All files (*)");
     connect(fd, SIGNAL(fileSelected(QString)), SLOT(onFileSelected(QString)));
 
     if (_engine)


### PR DESCRIPTION
I have automatically generated images that do not match *.* as filename contains no dots. I have to rename them every time.