### PR TITLE
Add appimagecraft config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# editor backups
+*.*swp*
+
+# AppImage related
+*.AppImage*

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -1,0 +1,21 @@
+version: 1
+
+project:
+  name: org.raspberrypi.rpi-imager
+  version_command: git describe --tags
+
+build:
+  cmake:
+    source_dir: src/
+
+scripts:
+  post_build:
+    - |
+      sed -i 's|Name=Imager|Name=Raspberry Pi Imager|' AppDir/usr/share/applications/rpi-imager.desktop
+
+appimage:
+  linuxdeploy:
+    plugins:
+      - qt
+    raw_environment:
+      QML_SOURCES_PATHS: "\"$PROJECT_ROOT\"/src/qmlcomponents/"


### PR DESCRIPTION
This PR adds an [appimagecraft](https://github.com/TheAssassin/appimagecraft) build config. appimagecraft is an easy-to-use build script generator that allows building AppImages using short declarative configuration files. It can be used by users to build AppImages with relative ease, but you could also add it to your release cycle.

In my [fork](https://github.com/TheAssassin/rpi-imager) I added a GitHub actions configuration to automatically build AppImages for every commit, creating a so-called [continuous release](https://github.com/TheAssassin/rpi-imager/releases/tag/continuous) using [pyuploadtool](https://github.com/TheAssassin/pyuploadtool). The AppImages are built on Ubuntu 20.04 (which provides a suitable Qt release out of the box), meaning that the AppImage works on most newer distros (tested Ubuntu 22.04 and Fedora 36). In the long term, compatibility may be increased by building the AppImage on an older distro with some custom Qt build following AppImage's [best practices](https://docs.appimage.org/introduction/concepts.html#build-on-old-systems-run-on-newer-systems).
(Side note: the AppImages built in my repository already support [AppImageUpdate](https://github.com/AppImage/AppImageUpdate).)

In case you're interested, I can send a follow-up PR once this one has been merged. I highly encourage you to test the AppImages provided in the continuous release.

References: #350, #20.

![screenshot_2022-10-15_12-07-24](https://user-images.githubusercontent.com/4503202/195980724-7e4487a4-59ef-44dc-8c61-15930f65b778.png)

P.S.: the appimagecraft config rewrites the desktop file to give the resulting AppImage a sensible file name and make it easily accessible in the user's app launcher (when using some [desktop integration](https://docs.appimage.org/user-guide/run-appimages.html#integrating-appimages-into-the-desktop) tool like, e.g., [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher)). Can be removed if you don't like it, but it seemed like a good idea to me.