### PR TITLE
Add lzma dependencies to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For the embedded (netboot) build see also "embedded/legal-info" for more informa
 Install the build dependencies:
 
 ```
-sudo apt install --no-install-recommends build-essential devscripts debhelper cmake git libarchive-dev libcurl4-gnutls-dev \
+sudo apt install --no-install-recommends build-essential devscripts debhelper cmake git libarchive-dev libcurl4-gnutls-dev liblzma-dev \
     qtbase5-dev qtbase5-dev-tools qtdeclarative5-dev libqt5svg5-dev qttools5-dev libgnutls28-dev \
     qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-templates2 qml-module-qtquick-window2 qml-module-qtgraphicaleffects
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If udisks2 is not functional on your Linux distribution, you can alternatively s
 Install the build dependencies:
 
 ```
-sudo yum install git gcc gcc-c++ make cmake libarchive-devel libcurl-devel openssl-devel qt5-qtbase-devel qt5-qtquickcontrols2-devel qt5-qtsvg-devel qt5-linguist
+sudo yum install git gcc gcc-c++ make cmake libarchive-devel libcurl-devel lzma-sdk-devel openssl-devel qt5-qtbase-devel qt5-qtquickcontrols2-devel qt5-qtsvg-devel qt5-linguist
 ```
 
 #### Get the source


### PR DESCRIPTION
Our CMakeLists will look for lzma, and will fail by default if lzma is not found.

As a response, add lzma development packages to the Fedora and Ubuntu/Debian README sections.

Confirmed this lets CMake configure with default options on WSL2/Ubuntu.