### PR TITLE
gitignore: Ignore CMake, vscode artefacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+.vscode


### PR DESCRIPTION
While building with CMake and VSCode, I noticed we were not ignoring temporaries and ide-specific configuration.

Add both the default CMake build directory and the vscode private directory to a .gitignore.

This should really be considered a starting point rather than a destination - I fully expect this list to grow as I sound out
the other builds.