### PR TITLE
Show options when opening image by file association

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -241,7 +241,7 @@ ApplicationWindow {
                         onClicked: {
                             optionspopup.openPopup()
                         }
-                        visible: false
+                        visible: imageWriter.imageSupportsCustomization()
                         Accessible.description: qsTr("Select this button to access advanced settings")
                         contentItem: Image {
                             source: "icons/ic_cog_red.svg"


### PR DESCRIPTION
If you load a custom image by running `rpi-imager my_image.img.xz` then the Advanced Options button is not shown.  This is triggered if you set a file association to load rpi-imager and then double-click an image file.

The fix is simply to set the visibility on this button on start-up (custom images set on the command-line are loaded before this).

Fixes #451