### PR TITLE
Enable file associations on linux

### DIFF
--- a/src/linux/rpi-imager.desktop
+++ b/src/linux/rpi-imager.desktop
@@ -4,6 +4,6 @@ Version=1.0
 Name=Imager
 Comment=Raspberry Pi Imager
 Icon=rpi-imager
-Exec=rpi-imager
+Exec=rpi-imager %F
 Categories=Utility
 StartupNotify=false


### PR DESCRIPTION
Add " %F" to the Exec parameter in the rpi-imager.desktop file so that Linux desktop environments know that rpi-imager can be used to open files.  After this change, Imager appears within the list of "Open With" applications in GNOME, and you can set it so double-clicking image files always opens rpi-imager.