### PR TITLE
gitignore: Ignore debuild artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build
 .vscode
+obj-**
+debian**


### PR DESCRIPTION
Ignore two additional patterns to capture debuild intermediates and results.