### PR TITLE
gitignore: Ignore all build** trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build
+build**
 .vscode
 obj-**
 debian**


### PR DESCRIPTION
When building with QtCreator, or another CMake-driving target, you may find the IDE creates build directories of the form:

build**

Typically, the IDE appends some kind of config string relevant to the configuration it's building (eg, RelWithDebInfo).

Unfortunately, none of these directories should be commited to the repo.