### PR TITLE
i18n: ru: Shorten storage selection label

### DIFF
--- a/src/i18n/rpi-imager_ru.ts
+++ b/src/i18n/rpi-imager_ru.ts
@@ -536,7 +536,7 @@
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation>ВЫБРАТЬ ЗАПОМИНАЮЩЕЕ УСТРОЙСТВО</translation>
+        <translation>ВЫБРАТЬ ЗАПОМ. УСТРОЙСТВО</translation>
     </message>
     <message>
         <location filename="../main.qml" line="171"/>


### PR DESCRIPTION
Rather than "Choose Memory Device", use "Choose Mem. Device", an acceptable shortening of the phrase which fits inside our controls