### PR TITLE
Revert "i18n: Advanced Settings -> OS Customisation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ On macOS, disable it by editing the property list for the application:
 defaults write org.raspberrypi.Imager.plist telemetry -bool NO
 ```
 
-### OS Customization
+### Advanced options
 
-When using the app, press <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>X</kbd> to reveal the **OS Customization** dialog.
+When using the app, press <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>X</kbd> to reveal the **Advanced options** dialog.
 
 In here, you can specify several things you would otherwise set in the boot configuration files. For example, you can enable SSH, set the Wi-Fi login, and specify your locale settings for the system image.

--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -17,7 +17,7 @@ Window {
     maximumWidth: width
     minimumHeight: 125
     height: Math.min(750, cl.implicitHeight)
-    title: qsTr("OS Customization")
+    title: qsTr("Advanced options")
 
     property bool initialized: false
     property bool hasSavedSettings: false
@@ -49,7 +49,7 @@ Window {
 
                 RowLayout {
                     Label {
-                        text: qsTr("OS customization options")
+                        text: qsTr("Image customization options")
                     }
                     ComboBox {
                         id: comboSaveSettings
@@ -539,7 +539,7 @@ Window {
                 /* Lacking an easy cross-platform to fetch keyboard layout
                    from host system, just default to "gb" for people in
                    UK time zone for now, and "us" for everyone else */
-                if (tz === "Europe/London") {
+                if (tz == "Europe/London") {
                     fieldKeyboardLayout.currentIndex = fieldKeyboardLayout.find("gb")
                 } else {
                     fieldKeyboardLayout.currentIndex = fieldKeyboardLayout.find("us")

--- a/src/UseSavedSettingsPopup.qml
+++ b/src/UseSavedSettingsPopup.qml
@@ -70,7 +70,7 @@ Popup {
             Layout.topMargin: 10
             font.family: roboto.name
             font.bold: true
-            text: qsTr("Use OS customization?")
+            text: qsTr("Use image customisation?")
         }
 
         Text {
@@ -85,7 +85,7 @@ Popup {
             Layout.topMargin: 25
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
             Accessible.name: text.replace(/<\/?[^>]+(>|$)/g, "")
-            text: qsTr("Would you like to apply OS customization settings?")
+            text: qsTr("Would you like to apply image customization settings?")
         }
 
         RowLayout {
@@ -95,10 +95,10 @@ Popup {
             id: buttons
 
             ImButton {
-                text: qsTr("EDIT SETTINGS")
+                text: qsTr("NO")
                 onClicked: {
                     msgpopup.close()
-                    msgpopup.editSettings()
+                    msgpopup.no()
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
                 Material.background: "#c51a4a"
@@ -127,10 +127,10 @@ Popup {
             }
 
             ImButton {
-                text: qsTr("NO")
+                text: qsTr("EDIT SETTINGS")
                 onClicked: {
                     msgpopup.close()
-                    msgpopup.no()
+                    msgpopup.editSettings()
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
                 Material.background: "#c51a4a"

--- a/src/i18n/rpi-imager_ca.ts
+++ b/src/i18n/rpi-imager_ca.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en extreure l&apos;arxiu: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en muntar la partició FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>El sistema operatiu no ha muntat la partició FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en canviar al directori «%1»</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">S&apos;ha produït un error en escriure a l&apos;emmagatzematge</translation>
     </message>
 </context>
 <context>
@@ -30,124 +34,124 @@
     <message>
         <location filename="../downloadthread.cpp" line="118"/>
         <source>unmounting drive</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està desmuntant el dispositiu</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està obrint la unitat</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en executar «diskpart»: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en eliminar les particions existents.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha cancel·lat l&apos;autenticació</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en executar «authopen» per a obtenir l&apos;accés al dispositiu de disc «%1»</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifiqueu si el «Raspberry Pi Imager» té accés als «volums extraïbles» des de la configuració de privacitat (sota «fitxers i carpetes» o doneu-li «accés complet al disc»)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>No s&apos;ha pogut obrir el dispositiu d&apos;emmagatzematge «%1»</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;estan descartant les dades existents a la unitat</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està esborrant amb zeros el primer i l&apos;últim MB de la unitat</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en esborrar amb zeros l&apos;«MBR».</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error d&apos;escriptura en esborrar amb zeros l&apos;última part de la targeta.&lt;br&gt;La targeta podria estar indicant una capacitat errònia (possible falsificació)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està iniciant la baixada</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en la baixada: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error d&apos;accés denegat en escriure el fitxer al disc.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;opció «Controla l&apos;accés de la carpeta» de la Seguretat del Windows sembla que està activada. Afegiu els executables «rpi-imager.exe» i «fat32format.exe» a la llista d&apos;aplicacions permeses i torneu-ho a provar.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en escriure el fitxer al disc</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>La baixada està corrompuda. El «hash» no coincideix</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en escriure a l&apos;emmagatzematge (procés: Flushing)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en escriure a l&apos;emmagatzematge (procés: fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en escriure el primer bloc (taula de particions)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en llegir l&apos;emmagatzematge.&lt;br&gt;És possible que la targeta SD estigui malmesa.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ha fallat la verificació de l&apos;escriptura. El contingut de la targeta SD és diferent del que s&apos;hi ha escrit.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està personalitzant la imatge</translation>
     </message>
 </context>
 <context>
@@ -157,85 +161,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error durant la partició: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en iniciar «fat32format»</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en executar «fat32format»: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en determinar la lletra de la nova unitat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>El dispositiu no és vàlid: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en formatar (a través d&apos;«udisks2»)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en iniciar «sfdisk»</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>No s&apos;ha pogut crear la partició FAT %1 esperada</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en iniciar «mkfs.fat»</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en executar «mkfs.fat»: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Aquesta plataforma no té implementada la formatació</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>La capacitat de l&apos;emmagatzematge no és suficient.&lt;br&gt;Ha de ser de %1 GB com a mínim.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>El fitxer d&apos;entrada no és una imatge de disc vàlida.&lt;br&gt;La mida del fitxer és de %1 bytes, que no és múltiple de 512 bytes.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està baixant i escrivint la imatge</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecciona una imatge</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Voleu emplenar la contrasenya del wifi des del clauer del sistema?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +247,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està obrint el fitxer de la imatge</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en obrir el fitxer de la imatge</translation>
     </message>
 </context>
 <context>
@@ -256,22 +260,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NO</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>SÍ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>CONTINUA</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>SURT</translation>
     </message>
 </context>
 <context>
@@ -279,22 +283,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opcions avançades</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opcions de personalització de les imatges</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>per a aquesta sessió només</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>per utilitzar sempre</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,83 +318,83 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Defineix un nom de la màquina (hostname):</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Defineix el nom d&apos;usuari i contrasenya</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom d&apos;usuari:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Contrasenya:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Configura la wifi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostra la contrasenya</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID oculta</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>País del wifi:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Estableix la configuració regional</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Fus horari:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Disposició del teclat:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>Activa el protocol SSH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilitza l&apos;autenticació de contrasenya</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Permet només l&apos;autenticació de claus públiques</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>Establiu «authorized_keys» per a l&apos;usuari «%1»:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +404,26 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Fes un so quan acabi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Expulsa el mitjà quan acabi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Activa la telemetria</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>DESA</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Configuració persistent</translation>
     </message>
 </context>
 <context>
@@ -423,7 +431,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Lector de targetes SD intern</translation>
     </message>
 </context>
 <context>
@@ -434,29 +442,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NO</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>NO, ESBORRA LA CONFIGURACIÓ</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>SÍ</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>EDITA LA CONFIGURACIÓ</translation>
     </message>
 </context>
 <context>
@@ -464,7 +472,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +491,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistema operatiu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>ESCULL SO</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccioneu aquest botó si voleu canviar el sistema operatiu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Emmagatzematge</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>ESCULL L&apos;EMMAGATZEMATGE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>ESCRIU</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccioneu aquest botó per a canviar la destinació del dispositiu d&apos;emmagatzematge</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>CANCEL·LA L&apos;ESCRIPTURA</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està cancel·lant...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>CANCEL·LA LA VERIFICACIÓ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està finalitzant...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +557,197 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccioneu aquest botó per a començar l&apos;escriptura de la imatge</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Seleccioneu aquest botó per accedir a la configuració avançada</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està usant el repositori personalitzat: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegació per teclat: &lt;tab&gt; navega al botó següent &lt;espai&gt; prem el botó o selecciona l&apos;element &lt;fletxa amunt o avall&gt; desplaçament per les llistes</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Idioma: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>Teclat: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Enrere</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Torna al menú principal</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Llançat el: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>A la memòria cau de l&apos;ordinador</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Fitxer local</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Disponible en línia (%1 GB)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Muntat com a %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[PROTEGIT CONTRA ESCRIPTURA]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>N&apos;esteu segur que voleu sortir?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>El Raspberry Pi Imager està ocupat.&lt;br&gt;N&apos;esteu segur que voleu sortir?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Avís</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està preparant per a escriure...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Totes les dades existents a «%1» s&apos;esborraràn.&lt;br&gt;Esteu segur que voleu continuar?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Hi ha una actualització disponible</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Hi ha una nova versió de l&apos;Imager disponible.&lt;br&gt;Voleu visitar el lloc web per baixar-la?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en baixar la llista dels SO d&apos;internet</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està escrivint... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està verificant... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;està preparant per escriure... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha escrit amb èxit</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Esborra</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha esborrat &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Ja podeu retirar la targeta SD del lector</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha escrit el «&lt;b&gt;%1&lt;/b&gt;» a &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;Ja podeu retirar la targeta SD del lector</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>S&apos;ha produït un error en analitzar os_lists.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Formata la targeta com a FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilitza una personalitzada</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecciona una imatge .img personalitzada de l&apos;ordinador</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Connecteu una memòria USB que contingui primer imatges.&lt;br&gt;Les imatges s&apos;han de trobar a la carpeta arrel de la memòria.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>La targeta SD està protegida contra escriptura.&lt;br&gt;Accioneu l&apos;interruptor del costat esquerre de la targeta SD per tal que quedi posicionat a la part superior i torneu-ho a provar.</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_de.ts
+++ b/src/i18n/rpi-imager_de.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Entpacken des Archivs: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Einbinden der FAT32-Partition</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Das Betriebssystem band die FAT32-Partition nicht ein</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Wechseln in den Ordner &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Fehler beim Schreiben auf den Speicher</translation>
     </message>
 </context>
 <context>
@@ -35,119 +39,161 @@
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Gerät wird geöffnet</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Ausführen von Diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Entfernen von existierenden Partitionen</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Authentifizierung abgebrochen</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Ausführen von authopen, um Zugriff auf Geräte zu erhalten &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
+        <translatorcomment>I don&apos;t use Mac OS, I would need help here. Unfinished translation:
+
+Bitte stellen Sie sicher, dass &apos;Raspberry Pi Imager&apos; Zugriff auf &apos;removable volumes&apos; in privacy settings hat (unter &apos;files and folders&apos;. Sie können ihm auch &apos;full disk access&apos; geben).</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Speichergerät &apos;%1&apos; kann nicht geöffnet werden.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Vorhandene Daten auf dem Medium werden gelöscht</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Erstes und letztes Megabyte des Mediums werden überschrieben</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreibfehler während des Löschens des MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Löschen des letzten Teiles der Speicherkarte.&lt;br&gt;Die Speicherkarte könnte mit einer falschen Größe beworben sein (möglicherweise Betrug).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>Download wird gestartet</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Herunterladen: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Zugriff verweigert-Fehler beim Schreiben auf den Datenträger.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
+        <translatorcomment>I don&apos;t use Windows either. What is &quot;Controlled Folder Access&quot; in the German version?
+
+Controlled Folder Access scheint aktiviert zu sein. Bitte fügen Sie sowohl rpi-imager.exe als auch fat32format.exe zur Liste der erlaubten Apps hinzu und versuchen sie es erneut.</translatorcomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Schreiben der Datei auf den Speicher</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Download beschädigt. Prüfsumme stimmt nicht überein</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Schreiben auf den Speicher (während flushing)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Schreiben auf den Speicher (während fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Schreiben auf des ersten Blocks (Partitionstabelle)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Lesen vom Speicher.&lt;br&gt;Die SD-Karte könnte defekt sein.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifizierung fehlgeschlagen. Der Inhalt der SD-Karte weicht von dem Inhalt ab, der geschrieben werden sollte.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Image modifizieren</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">Warten auf das Einbinden der FAT-Partition</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">Fehler beim Einbinden der FAT32-Partition</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">Das Betriebssystem hat die FAT32-Partition nicht eingebunden.</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">Modifizieren fehlgeschlagen. Die Datei &apos;%1&apos; existiert nicht.</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">Fehler beim Erstellen von firstrun.sh auf der FAT-Partition</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">Fehler beim Schreiben in config.txt auf der FAT-Partition</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">Fehler beim Erstellen der user-data cloudinit Datei auf der FAT-Partition</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">Fehler beim Erstellen der network-config cloudinit Datei auf der FAT-Partition</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">Fehler beim Schreiben in cmdline.txt auf der FAT-Partition</translation>
     </message>
 </context>
 <context>
@@ -157,85 +203,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Partitionieren: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Starten von fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Verwenden von fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Festlegen eines neuen Laufwerksbuchstabens</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ungültiges Gerät: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Formatieren (mit udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Starten von sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Partitionierung hat nicht die erwartete FAT-partition %1 erstellt</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Starten von mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Verwenden von mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatieren wird auf dieser Platform nicht unterstützt</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Speicherkapazität ist nicht groß genug.&lt;br&gt;Sie muss mindestens %1 GB betragen.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Eingabedatei ist kein gültiges Disk-Image.&lt;br&gt;Die Dateigröße%1 Bytes ist kein Vielfaches von 512 Bytes.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Image herunterladen und schreiben</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Image wählen</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Möchten Sie das Wifi-Passwort aus dem System-Schlüsselbund vorab ausfüllen?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +289,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbilddatei wird geöffnet</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Öffnen der Imagedatei</translation>
     </message>
 </context>
 <context>
@@ -256,22 +302,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NEIN</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>JA</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>WEITER</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>BEENDEN</translation>
     </message>
 </context>
 <context>
@@ -279,22 +325,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Erweiterte Optionen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>OS-Modifizierungen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>Nur für diese Sitzung</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>Immer verwenden</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,83 +360,83 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Hostname:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Benutzername und Passwort setzen:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Benutzername:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Passwort:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Wifi einrichten</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Passwort anzeigen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>Verborgene SSID</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>Wifi-Land:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Spracheinstellungen festlegen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeitzone:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tastaturlayout:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>SSH aktivieren</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Password zur Authentifizierung verwenden</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Authentifizierung via Public-Key</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>authorized_keys für &apos;%1&apos;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +446,38 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Tonsignal nach Beenden abspielen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Medien nach Beenden auswerfen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Telemetry aktivieren</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>SPEICHERN</translation>
+    </message>
+    <message>
+        <source>Disable overscan</source>
+        <translation type="vanished">Overscan deaktivieren</translation>
+    </message>
+    <message>
+        <source>Set password for &apos;%1&apos; user:</source>
+        <translation type="vanished">Passwort für &apos;%1&apos;:</translation>
+    </message>
+    <message>
+        <source>Skip first-run wizard</source>
+        <translation type="vanished">Einrichtungsassistent überspringen</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Dauerhafte Einstellungen</translation>
     </message>
 </context>
 <context>
@@ -423,7 +485,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Interner SD-Kartenleser</translation>
     </message>
 </context>
 <context>
@@ -434,29 +496,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NEIN</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>NEIN, EINSTELLUNGEN LÖSCHEN</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>EINSTELLUNGEN BEARBEITEN</translation>
     </message>
 </context>
 <context>
@@ -464,7 +526,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +545,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>OS WÄHLEN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Klicke auf diesen Knopf, um das Betriebssystem zu ändern</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>SD-Karte</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>SD-KARTE WÄHLEN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>SCHREIBEN</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Klicken Sie auf diesen Knopf, um das Ziel-Speichermedium zu ändern</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>SCHREIBEN ABBRECHEN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>VERIFIZIERUNG ABBRECHEN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Finalisieren...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +611,205 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Klicke auf diesen Knopf, um mit dem Schreiben zu beginnen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Klicken Sie auf diesen Knopf, um zu den erweiterten Einstellungen zu gelangen.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Verwende benutzerdefiniertes Repository: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Sprache: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>Tastatur: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Zurück</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Zurück zum Hauptmenü</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Veröffentlicht: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Auf Ihrem Computer zwischengespeichert</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Lokale Datei</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Online - %1 GB Download</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Als %1 eingebunden</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[SCHREIBGESCHÜTZT]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sind Sie sicher, dass Sie beenden möchten?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Der Raspberry Pi Imager ist noch beschäftigt. &lt;br&gt;Möchten Sie wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreiben wird vorbereitet...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle vorhandenen Daten auf &apos;%1&apos; werden gelöscht.&lt;br&gt;Möchten Sie wirklich fortfahren?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Update verfügbar</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Eine neuere Version von Imager ist verfügbar. &lt;br&gt;Möchten Sie die Webseite besuchen, um das Update herunterzuladen?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Herunterladen der Betriebssystemsliste aus dem Internet</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreiben... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifizierung... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreiben wird vorbereitet... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreiben erfolgreich</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; wurde geleert&lt;br&gt;&lt;br&gt;Sie können die SD-Karte nun aus dem Lesegerät entfernen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; wurde auf &lt;b&gt;%2&lt;/b&gt; geschrieben&lt;br&gt;&lt;br&gt;Sie können die SD-Karte nun aus dem Lesegerät entfernen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Fehler beim Parsen von os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Karte als FAT32 formatieren</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Eigenes Image</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Wählen Sie eine eigene .img-Datei von Ihrem Computer</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verbinden Sie zuerst einen USB-Stick mit Images.&lt;br&gt;Die Images müssen sich im Wurzelverzeichnes des USB-Sticks befinden.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Speicherkarte ist schreibgeschützt.&lt;br&gt;Schieben Sie den Schutzschalter auf der linken Seite nach oben, und versuchen Sie es erneut.</translation>
+    </message>
+    <message>
+        <source>Select this button to change the destination SD card</source>
+        <translation type="vanished">Klicke auf diesen Knopf, um die Ziel-SD-Karte zu ändern</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; wurde auf &lt;b&gt;%2&lt;/b&gt; geschrieben</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_en.ts
+++ b/src/i18n/rpi-imager_en.ts
@@ -213,27 +213,27 @@
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -434,28 +434,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
+        <source>NO</source>
+        <translation></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
         <source>NO, CLEAR SETTINGS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
         <source>YES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
-        <source>NO</source>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -473,68 +473,73 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="126"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE DEVICE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="138"/>
+        <location filename="../main.qml" line="120"/>
         <source>Select this button to choose your target Raspberry Pi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="132"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="144"/>
         <source>CHOOSE OS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="156"/>
         <source>Select this button to change the operating system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -544,185 +549,195 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/i18n/rpi-imager_es.ts
+++ b/src/i18n/rpi-imager_es.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error extrayendo el archivo: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Error montando la partición FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>El sistema operativo no montó la partición FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Error cambiando al directorio &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Error escribiendo en la memoria</translation>
     </message>
 </context>
 <context>
@@ -30,124 +34,124 @@
     <message>
         <location filename="../downloadthread.cpp" line="118"/>
         <source>unmounting drive</source>
-        <translation type="unfinished"></translation>
+        <translation>desmontando unidad</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>abriendo unidad</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error ejecutando diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Error eliminando las particiones existentes</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Autenticación cancelada</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Error ejecutando authopen para acceder al dispositivo de disco &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Por favor, compruebe si &apos;Raspberry Pi Imager&apos; tiene permitido el acceso a &apos;volúmenes extraíbles&apos; en los ajustes de privacidad (en &apos;archivos y carpetas&apos; o alternativamente dele &apos;acceso total al disco&apos;).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>No se puede abrir el dispositivo de almacenamiento &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>descartando datos existentes en la unidad</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>poniendo a cero el primer y el último MB de la unidad</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Error de escritura al poner a cero MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Error de escritura al intentar poner a cero la última parte de la tarjeta.&lt;br&gt;La tarjeta podría estar anunciando una capacidad incorrecta (posible falsificación).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>iniciando descarga</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error descargando: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error de acceso denegado escribiendo el archivo en el disco.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>El acceso controlado a carpetas parece estar activado. Añada rpi-imager.exe y fat32format.exe a la lista de aplicaciones permitidas y vuelva a intentarlo.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Error escribiendo el archivo en el disco</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Descarga corrupta. El hash no coincide</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Error escribiendo en la memoria (durante la limpieza)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Error escribiendo en el almacenamiento (mientras fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Error escribiendo el primer bloque (tabla de particiones)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error leyendo del almacenamiento.&lt;br&gt;La tarjeta SD puede estar rota.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error verificando la escritura. El contenido de la tarjeta SD es diferente del que se escribió en ella.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Personalizando imagen</translation>
     </message>
 </context>
 <context>
@@ -157,85 +161,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error particionando: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Error iniciando fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error ejecutando fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Error determinando la nueva letra de unidad</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispositivo no válido: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Error formateando (a través de udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Error iniciando sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>El particionado no creó la partición FAT %1 esperada</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Error iniciando mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Error ejecutando mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Formateo no implementado para esta plataforma</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>La capacidad de almacenamiento no es lo suficientemente grande.&lt;br&gt;Necesita ser de al menos %1 GB.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>El archivo de entrada no es una imagen de disco válida.&lt;br&gt;El tamaño del archivo %1 bytes no es múltiplo de 512 bytes.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Descargando y escribiendo imagen</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionar imagen</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>¿Desea rellenar previamente la contraseña wifi desde el llavero del sistema?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +247,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>abriendo archivo de imagen</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Error abriendo archivo de imagen</translation>
     </message>
 </context>
 <context>
@@ -256,22 +260,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NO</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>SÍ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>CONTINUAR</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>SALIR</translation>
     </message>
 </context>
 <context>
@@ -279,143 +283,147 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opciones avanzadas</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opciones de personalización de imagen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>solo para esta sesión</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>para usar siempre</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>General</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="79"/>
         <source>Services</source>
-        <translation type="unfinished"></translation>
+        <translation>Servicios</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="82"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opciones</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer nombre de anfitrión:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer nombre de usuario y contraseña</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nombre de usuario:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Contraseña:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Configurar LAN inalámbrica</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar contraseña</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID oculta</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>País de LAN inalámbrica:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer ajustes regionales</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Zona horaria:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Distribución del teclado:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>Activar SSH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Usar autenticación por contraseña</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Permitir solo la autenticación de clave pública</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>Establecer authorized_keys para &apos;%1&apos;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
         <source>RUN SSH-KEYGEN</source>
-        <translation type="unfinished"></translation>
+        <translation>EJECUTAR SSH-KEYGEN</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Reproducir sonido al finalizar</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Expulsar soporte al finalizar</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Activar telemetría</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Ajustes persistentes</translation>
     </message>
 </context>
 <context>
@@ -423,7 +431,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Lector de tarjetas SD interno</translation>
     </message>
 </context>
 <context>
@@ -434,29 +442,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NO</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>NO, BORRAR AJUSTES</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>SÍ</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>EDITAR AJUSTES</translation>
     </message>
 </context>
 <context>
@@ -464,7 +472,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +491,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistema operativo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>ELEGIR SO</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccione este botón para cambiar el sistema operativo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Almacenamiento</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>ELEGIR ALMACENAMIENTO</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>ESCRIBIR</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccione este botón para cambiar el dispositivo de almacenamiento de destino</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>CANCELAR ESCRITURA</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancelando...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>CANCELAR VERIFICACIÓN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Finalizando...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +557,197 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccione este botón para empezar a escribir la imagen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Seleccione este botón para acceder a los ajustes avanzados</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Usando repositorio personalizado: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Navegación por teclado: &lt;tab&gt; navegar al botón siguiente &lt;space&gt; pulsar botón/seleccionar elemento &lt;arrow up/down&gt; subir/bajar en listas</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Idioma: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
-        <translation type="unfinished"></translation>
+        <translation>Teclado: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
+        <translation>Modelo Pi:</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
-        <translation type="unfinished"></translation>
+        <translation>[ Todos ]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Volver</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Volver al menú principal</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Publicado: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>En caché en su ordenador</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivo local</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>En línea - %1 GB descarga</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Montado como %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[PROTEGIDO CONTRA ESCRITURA]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>¿Está seguro de que quiere salir?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager sigue ocupado.&lt;br&gt;¿Está seguro de que quiere salir?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Advertencia</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Preparando para escribir...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Se borrarán todos los datos existentes en &apos;%1&apos;.&lt;br&gt;¿Está seguro de que desea continuar?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Actualización disponible</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Hay una versión más reciente de Imager disponible.&lt;br&gt;¿Desea visitar el sitio web para descargarla?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al descargar la lista de sistemas operativos de Internet</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Escribiendo... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Verificando... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Preparando para escribir... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Error</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Escritura exitosa</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; se ha borrado&lt;br&gt;&lt;br&gt;Ya puede retirar la tarjeta SD del lector</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; se ha escrito en &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;Ya puede retirar la tarjeta SD del lector</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al parsear os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatear tarjeta como FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Usar personalizado</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccione un .img personalizado de su ordenador</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Conecte primero una memoria USB que contenga imágenes.&lt;br&gt;Las imágenes deben estar ubicadas en la carpeta raíz de la memoria USB.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>La tarjeta SD está protegida contra escritura.&lt;br&gt;Pulse hacia arriba el interruptor de bloqueo situado en el lado izquierdo de la tarjeta y vuelva a intentarlo.</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_fr.ts
+++ b/src/i18n/rpi-imager_fr.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;extraction de l&apos;archive&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors du montage de la partition FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Le système d&apos;exploitation n&apos;a pas monté la partition FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors du changement du répertoire &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Erreur d&apos;écriture dans le stockage</translation>
     </message>
 </context>
 <context>
@@ -30,124 +34,160 @@
     <message>
         <location filename="../downloadthread.cpp" line="118"/>
         <source>unmounting drive</source>
-        <translation type="unfinished"></translation>
+        <translation>démontage du disque</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>ouverture du disque</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;exécution de diskpart&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de la suppression des partitions existantes</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Authentification annulée</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;exécution d&apos;authopen pour accéder au périphérique du stockage &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Veuillez vérifier dans les réglages de confidentialité (sous &apos;fichiers et dossiers&apos;) si &apos;Raspberry Pi Imager&apos; est autorisé à accéder aux volumes amovibles (ou bien donnez-lui accès complet au disque).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossible d&apos;ouvrir le périphérique de stockage &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>suppression des données existantes sur le disque</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>mise à zéro du premier et du dernier Mo du disque</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur d&apos;écriture lors du formatage du MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur d&apos;écriture lors de la tentative de formatage de la dernière partie de la carte.&lt;br&gt;La carte annonce peut-être une capacité erronée (contrefaçon possible).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>début du téléchargement</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur de téléchargement&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Accès refusé lors de l&apos;écriture d&apos;un fichier sur le disque.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;accès contrôlé aux dossiers semble être activé. Veuillez ajouter rpi-imager.exe et fat32format.exe à la liste des applications autorisées et réessayez.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur d&apos;écriture de fichier sur le disque</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Téléchargement corrompu. La signature ne correspond pas</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur d&apos;écriture dans le stockage (lors du formatage)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur d&apos;écriture dans le stockage (pendant l&apos;exécution de fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;écriture du premier bloc (table de partition)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur de lecture du stockage.&lt;br&gt;La carte SD est peut-être défectueuse.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>La vérification de l&apos;écriture à échoué. Le contenu de la carte SD est différent de ce qui y a été écrit.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Personnalisation de l&apos;image</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">En attente du montage de la partition FAT</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">Erreur lors du montage de la partition FAT32</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">Le système d&apos;exploitation n&apos;a pas monté la partition FAT32</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">Impossible de personnaliser. Le fichier &apos;%1&apos; n&apos;existe pas.</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">Erreur lors de la création de firstrun.sh sur la partition FAT</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">Erreur lors de la création de config.txt sur la partition FAT</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">Erreur lors de la création du fichier user-data cloudinit sur la partition FAT</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">Erreur lors de la création du fichier network-config cloudinit sur la partition FAT</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">Erreur lors de l&apos;écriture de cmdline.txt sur la partition FAT</translation>
     </message>
 </context>
 <context>
@@ -157,85 +197,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur de partitionnement&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors du démarrage de fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;exécution de fat32format&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de la détermination de la nouvelle lettre du stockage</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Périphérique non valide&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur de formatage (via udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors du démarrage de sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Le partitionnement n&apos;a pas créé la partition FAT %1 attendue</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors du démarrage de mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;exécution de mkfs.fat&#xa0;: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatage non implémenté pour cette plateforme</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>La capacité de stockage n&apos;est pas assez grande.&lt;br&gt;Elle doit être d&apos;au moins %1 Go.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le fichier source n&apos;est pas une image disque valide.&lt;br&gt;La taille du fichier (d&apos;%1 octets) n&apos;est pas un multiple de 512 octets.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Téléchargement et écriture de l&apos;image</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner l&apos;image</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Voulez-vous pré-remplir le mot de passe Wi-Fi à partir du trousseau du système&#xa0;?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +283,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>ouverture de l&apos;image disque</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors de l&apos;ouverture de l&apos;image disque</translation>
     </message>
 </context>
 <context>
@@ -256,22 +296,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NON</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>OUI</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>CONTINUER</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>QUITTER</translation>
     </message>
 </context>
 <context>
@@ -279,22 +319,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Réglages avancés</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Options de personnalisation de l&apos;image</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>pour cette session uniquement</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>pour toutes les sessions</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,83 +354,83 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom d&apos;hôte</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Définir nom d&apos;utilisateur et mot de passe</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nom d&apos;utilisateur&#xa0;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Mot de passe&#xa0;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Configurer le Wi-Fi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID&#xa0;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher le mot de passe</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID caché</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>Pays Wi-Fi&#xa0;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Définir les réglages locaux</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuseau horaire&#xa0;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Type de clavier&#xa0;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer SSH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser un mot de passe pour l&apos;authentification</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Authentification via clef publique</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>Définir authorized_keys pour &apos;%1&apos;&#xa0;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +440,26 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Jouer un son quand terminé</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Éjecter le média quand terminé</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Activer la télémétrie</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>ENREGISTRER</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Réglages permanents</translation>
     </message>
 </context>
 <context>
@@ -423,7 +467,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Lecteur de carte SD interne</translation>
     </message>
 </context>
 <context>
@@ -434,29 +478,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NON</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>NON, EFFACER LES RÉGLAGES</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>OUI</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>MODIFIER RÉGLAGES</translation>
     </message>
 </context>
 <context>
@@ -464,7 +508,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +527,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Système d&apos;exploitation</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>CHOISIR L&apos;OS</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner ce bouton pour changer le système d&apos;exploitation</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Stockage</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>CHOISIR LE STOCKAGE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>ÉCRIRE</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner ce bouton pour modifier le périphérique de stockage de destination</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>ANNULER L&apos;ÉCRITURE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Annulation...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>ANNULER LA VÉRIFICATION</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Finalisation...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +593,205 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner ce bouton pour commencer l&apos;écriture de l&apos;image</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Sélectionner ce bouton pour accéder aux réglages avancés</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Utilisation d&apos;un dépôt personnalisé&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Navigation au clavier&#xa0;: &lt;tab&gt; passer au bouton suivant &lt;espace&gt; presser un bouton/sélectionner un élément &lt;flèche haut/bas&gt; monter/descendre dans les listes</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Langue&#xa0;: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>Clavier&#xa0;: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Retour</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Retour au menu principal</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Publié le&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Mis en cache sur votre ordinateur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Fichier local</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>En ligne - %1 GO à télécharger</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Monté sur %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[PROTÉGÉ EN ÉCRITURE]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Voulez-vous vraiment quitter&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager est encore occupé.&lt;br&gt;Voulez-vous vraiment quitter&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Attention</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Préparation de l&apos;écriture...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Toutes les données sur le périphérique de stockage &apos;%1&apos; vont être supprimées.&lt;br&gt;Voulez-vous vraiment continuer&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Mise à jour disponible</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Une version plus récente d&apos;Imager est disponible.&lt;br&gt;Voulez-vous accéder au site web pour la télécharger&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur lors du téléchargement de la liste des systèmes d&apos;exploitation à partir d&apos;Internet</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Écriture... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Vérification... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Préparation de l&apos;écriture... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Écriture réussie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; a bien été effacé&lt;br&gt;&lt;br&gt;Vous pouvez retirer la carte SD du lecteur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; a bien été écrit sur &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;Vous pouvez retirer la carte SD du lecteur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Erreur de lecture du fichier os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Formater la carte SD en FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Utiliser image personnalisée</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner une image disque personnalisée (.img) sur votre ordinateur</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Connecter d&apos;abord une clé USB contenant les images.&lt;br&gt;Les images doivent se trouver dans le dossier racine de la clé USB.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>La carte SD est protégée en écriture.&lt;br&gt;Poussez vers le haut le commutateur de verrouillage sur le côté gauche de la carte et essayez à nouveau.</translation>
+    </message>
+    <message>
+        <source>Select this button to change the destination SD card</source>
+        <translation type="vanished">Sélectionnez ce bouton pour changer la carte SD de destination</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; a bien été écrit sur &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_it.ts
+++ b/src/i18n/rpi-imager_it.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore estrazione archivio: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore montaggio partizione FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Il sistema operativo non ha montato la partizione FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore passaggio a cartella &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Errore scrittura nello storage</translation>
     </message>
 </context>
 <context>
@@ -30,124 +34,161 @@
     <message>
         <location filename="../downloadthread.cpp" line="118"/>
         <source>unmounting drive</source>
-        <translation type="unfinished"></translation>
+        <translation>smontaggio unità</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>apertura unità</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore esecuzione diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore rimozione partizioni esistenti</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Autenticazione annullata</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore esecuzione auhopen per ottenere accesso al dispositivo disco %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifica se a &apos;Raspberry Pi Imager&apos; è consentito l&apos;accesso a &apos;volumi rimovibili&apos; nelle impostazioni privacy (in &apos;file e cartelle&apos; o in alternativa concedi &apos;accesso completo al disco&apos;).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Impossibile aprire dispositivo storage &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>elimina i dati esistenti nell&apos;unità</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>azzera il primo e l&apos;ultimo MB dell&apos;unità</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore scrittura durante azzeramento MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore di scrittura durante il tentativo di azzerare l&apos;ultima parte della scheda.&lt;br&gt;La scheda potrebbe riportare una capacità maggiore di quella reale (possibile contraffazione).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>avvio download</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore download: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore accesso negato durante la scrittura del file su disco.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sembra sia abilitato l&apos;accesso controllato alle cartelle. 
+Aggiungi sia &apos;rpi-imager.exe&apos; che &apos;fat32format.exe&apos; all&apos;elenco delle app consentite e riprova.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore scrittura file su disco</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Download corrotto.&lt;br&gt;L&apos;hash non corrisponde</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore scrittura nello storage (durante flushing)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore scrittura nello storage (durante fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore scrittura primo blocco (tabella partizione)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore lettura dallo storage.&lt;br&gt;La scheda SD potrebbe essere danneggiata.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifica scrittura fallita.&lt;br&gt;Il contenuto della SD è differente da quello che vi è stato scritto.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Personalizza immagine</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">Attesa montaggio partizione FAT</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">Errore montaggio partizione FAT32</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">Il sistema operativo non ha montato la partizione FAT32</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">Impossibile personalizzare. Il file &apos;%1&apos; non esiste.</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">Errore creazione firstrun.sh nella partizione FAT</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">Errore scrittura in config.txt nella partizione FAT</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">Errore nel creare il file cloudinit dei dati utente nella partizione FAT</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">Errore durante la creazione del file network-config cloudinit nella partizione FAT</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">Errore scrittura in cmdline.txt nella partizione FAT</translation>
     </message>
 </context>
 <context>
@@ -157,85 +198,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore partizionamento: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore avvio fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore esecuzione fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore determinazione nuova lettera unità</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispositivo non valido: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore formattazione (attraverso udisk2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore avvio sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Il partizionamento non ha creato la partizione FAT prevista %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore avvio mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore esecuzione mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Formattazione non implementata per questa piattaforma</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>La capacità dello storage non è sufficiente.&lt;br&gt;Sono necessari almeno %1 GB.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Il file sorgente non è un&apos;immagine disco valida.&lt;br&gt;La dimensione file %1 non è un multiplo di 512 byte.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Download e scrittura file immagine</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleziona file immagine</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Vuoi precompilare la password WiFi usando il portachiavi di sistema?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +284,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>apertura file immagine</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante l&apos;apertura del file immagine</translation>
     </message>
 </context>
 <context>
@@ -256,22 +297,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NO</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>SI</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>CONTINUA</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>ESCI</translation>
     </message>
 </context>
 <context>
@@ -279,143 +320,163 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opzioni avanzate</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opzioni personalizzazione immagine</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>solo per questa sessione</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>da usare sempre</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>Generale</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="79"/>
         <source>Services</source>
-        <translation type="unfinished"></translation>
+        <translation>Servizi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="82"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opzioni</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta nome host:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta nome utente e password</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nome utente:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Password:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Configura WiFi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Visualizza password</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID nascosto</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nazione WiFi:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta configurazioni locali</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuso orario:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Layout tastiera:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>Abilita SSH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Usa password autenticazione</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Permetti solo autenticazione con chiave pubblica</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>Imposta authorized_keys per &apos;%1&apos;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
         <source>RUN SSH-KEYGEN</source>
-        <translation type="unfinished"></translation>
+        <translation>ESEGUI SSH-KEYGEN</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Riproduci suono quando completato</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Espelli media quando completato</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Abilita telemetria</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>SALVA</translation>
+    </message>
+    <message>
+        <source>Disable overscan</source>
+        <translation type="vanished">Disabilita overscan</translation>
+    </message>
+    <message>
+        <source>Set password for &apos;pi&apos; user:</source>
+        <translation type="vanished">Imposta password utente &apos;pi&apos;:</translation>
+    </message>
+    <message>
+        <source>Set authorized_keys for &apos;pi&apos;:</source>
+        <translation type="vanished">Imposta authorized_key per &apos;pi&apos;:</translation>
+    </message>
+    <message>
+        <source>Skip first-run wizard</source>
+        <translation type="vanished">Salta procedura prima impostazione</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Impostazioni persistenti</translation>
     </message>
 </context>
 <context>
@@ -423,7 +484,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Lettore scheda SD interno</translation>
     </message>
 </context>
 <context>
@@ -434,29 +495,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NO</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>NO, AZZERA IMPOSTAZIONI</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>SI&apos;</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>MODIFICA IMPOSTAZIONI</translation>
     </message>
 </context>
 <context>
@@ -464,7 +525,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v. %1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +544,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistema operativo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>SCEGLI S.O.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleziona questo pulsante per modificare il sistema operativo scelto</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Scheda SD</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>SCEGLI SCHEDA SD</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>SCRIVI</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleziona questo pulsante per modificare il dispositivo archiviazione destinazione</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>ANNULLA SCRITTURA</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Annullamento...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>ANNULLA VERIFICA</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Finalizzazione...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +610,205 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleziona questo pulsante per avviare la scrittura del file immagine</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Seleziona questo pulsante per accedere alle impostazioni avanzate</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Usa repository personalizzato: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Navigazione da tastiera: &lt;tab&gt; vai al prossimo pulsante &lt;spazio&gt; premi il pulsante/seleziona la voce &lt;freccia su/giù&gt; vai su/giù negli elenchi</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Lingua: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
-        <translation type="unfinished"></translation>
+        <translation>Tastiera: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
+        <translation>Modello Pi:</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
-        <translation type="unfinished"></translation>
+        <translation>[ Tutti ]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Indietro</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Torna al menu principale</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Rilasciato: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Memorizzato temporaneamente nel computer</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>File locale</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Online - Download %1 GB</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Montato come %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[PROTETTA DA SCRITTURA]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Image è occupato.&lt;br&gt;Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Attenzione</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Preparazione scrittura...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Tutti i dati esistenti in &apos;%1&apos; verranno eliminati.&lt;br&gt;Sei sicuro di voler continuare?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Aggiornamento disponibile</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>È disponibile una nuova versione di Imager.&lt;br&gt;Vuoi visitare il sito web per scaricare la nuova versione?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante download elenco SO da internet</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Scrittura...%1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifica...%1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Preparazione scrittura... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Scrittura completata senza errori</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Azzeramento di &lt;b&gt;%1&lt;/b&gt; completato&lt;br&gt;&lt;br&gt;Ora puoi rimuovere la scheda SD dal lettore</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Scrittura di &lt;b&gt;%1&lt;/b&gt; in &lt;b&gt;%2&lt;/b&gt;completata&lt;br&gt;&lt;br&gt;Ora puoi rimuovere la scheda SD dal lettore</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Errore durante analisi file os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatta scheda come FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Usa immagine personalizzata</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleziona un file immagine .img personalizzato</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Prima collega una chiavetta USB contenente il file immagine.&lt;br&gt;Il file immagine deve essere presente nella cartella principale della chiavetta USB.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>La scheda SD è protetta da scrittura.&lt;br&gt;Sposta verso l&apos;alto l&apos;interruttore LOCK sul lato sinistro della scheda SD e riprova.</translation>
+    </message>
+    <message>
+        <source>Select this button to change the destination SD card</source>
+        <translation type="vanished">Seleziona questo pulsante per modificare la scheda SD destinazione</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">Scrittura di &lt;b&gt;%1&lt;/b&gt; in &lt;b&gt;%2&lt;/b&gt;completata</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_ja.ts
+++ b/src/i18n/rpi-imager_ja.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>アーカイブを展開するのに失敗しました</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>FAT32パーティションをマウントできませんでした</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>OSがFAT32パーティションをマウントしませんでした</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>カレントディレクトリを%1に変更できませんでした</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">ストレージに書き込むのに失敗しました</translation>
     </message>
 </context>
 <context>
@@ -35,119 +39,155 @@
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>デバイスを開いています</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>diskpartの実行に失敗しました: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>既に有るパーティションを削除する際にエラーが発生しました。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>認証がキャンセルされました</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>ディスク%1にアクセスするための権限を取得するためにauthopenを実行するのに失敗しました</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Raspberry Pi Imagerがリムーバブルボリュームへアクセスすることがプライバシー設定(「ファイルとフォルダー」の中、またはディスクへのすべてのアクセス権限を付与する)で許可されているかを確認してください。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>ストレージを開けませんでした。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>ドライブの現存するすべてのデータを破棄します</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>ドライブの最初と最後のMBを削除しています</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>MBRを削除している際にエラーが発生しました。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>カードの最後のパートを0で書き込む際書き込みエラーが発生しました。カードが示している容量と実際のカードの容量が違う可能性があります。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>ダウンロードを開始中</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1をダウンロードする際エラーが発生しました</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>ディスクにファイルを書き込む際にアクセスが拒否されました。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>フォルダーへのアクセスが制限されています。許可されたアプリにrpi-imager.exeとfat32format.exeを入れてもう一度お試しください。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>ファイルをディスクに書き込んでいる際にエラーが発生しました</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>ダウンロードに失敗しました。ハッシュ値が一致していません。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>ストレージへの書き込み中にエラーが発生しました (フラッシング中)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>ストレージへの書き込み中にエラーが発生しました（fsync中)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>最初のブロック（パーティションテーブル）を書き込み中にエラーが発生しました</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>ストレージを読むのに失敗しました。SDカードが壊れている可能性があります。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>確認中にエラーが発生しました。書き込んだはずのデータが実際にSDカードに記録されたデータと一致していません。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>イメージをカスタマイズしています</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">FATパーティションがマウントされるのを待っています</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">FAT32パーティションをマウントする際にエラーが発生しました。</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">OSがFAT32パーティションをマウントしませんでした。</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">カスタマイズできません。%1が存在しません。</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">FATパーティションにfirstrun.shを作成する際にエラーが発生しました</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">FATパーティションにconfig.txtを書き込むときにエラーが発生しました</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">FATパーティションにCloud-initのuser-dataファイル名前を作成するときにエラーが発生しました</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">FATパーティションにCloud-initのnetwork-configファイルを作成するときにエラーが発生しました</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">FATパーティションにcmdline.txtを書き込む際にエラーが発生しました</translation>
     </message>
 </context>
 <context>
@@ -157,85 +197,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>パーティショニングに失敗しました: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>fat32formatを開始中にエラーが発生しました</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>fat32formatを実行中にエラーが発生しました</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>新しいドライブレターを判断している際にエラーが発生しました</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>不適切なデバイス: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>udisk2を介してフォーマットするのに失敗しました</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>sfdiskを開始中にエラーが発生しました</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>パーティショニングが想定したFATパーティション %1を作りませんでした</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>mkfs.fatを開始中にエラーが発生しました</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>mkfs.fatを実行中にエラーが発生しました: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>このプラットフォームではフォーマットできません。</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>ストレージの容量が足りません。少なくとも%1GBは必要です。</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>入力されたファイルは適切なディスクイメージファイルではありません。ファイルサイズの%1は512バイトの倍数ではありません。</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>イメージをダウンロードして書き込んでいます</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>イメージを選ぶ</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Wifiのパスワードをシステムのキーチェーンから読み取って設定しますか？</translation>
     </message>
 </context>
 <context>
@@ -243,12 +283,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>イメージファイルを開いています</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>イメージファイルを開く際にエラーが発生しました</translation>
     </message>
 </context>
 <context>
@@ -256,22 +296,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>いいえ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>はい</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>続ける</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>やめる</translation>
     </message>
 </context>
 <context>
@@ -279,22 +319,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>詳細な設定</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>カスタマイズオプション</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>このセッションでのみ有効にする</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>いつも使う設定にする</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,83 +354,83 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>ホスト名:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>ユーザー名とパスワードを設定する</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>ユーザー名</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>パスワード:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Wi-Fiを設定する</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>パスワードを見る</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>ステルスSSID</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>Wifiを使う国:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>ロケール設定をする</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>タイムゾーン:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>キーボードレイアウト:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>SSHを有効化する</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>パスワード認証を使う</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>公開鍵認証のみを許可する</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>ユーザー%1のためのauthorized_keys</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +440,34 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>終わったときに音を鳴らす</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>終わったときにメディアを取り出す</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">テレメトリーを有効化する</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <source>Disable overscan</source>
+        <translation type="vanished">オーバースキャンを無効化する</translation>
+    </message>
+    <message>
+        <source>Skip first-run wizard</source>
+        <translation type="vanished">最初のセットアップウィザートをスキップする</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">永続的な設定</translation>
     </message>
 </context>
 <context>
@@ -423,7 +475,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>SDカードリーダー</translation>
     </message>
 </context>
 <context>
@@ -434,29 +486,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">いいえ</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>いいえ、設定をクリアする</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>はい</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>設定を編集する</translation>
     </message>
 </context>
 <context>
@@ -464,7 +516,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +535,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>OS</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>OSを選ぶ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>OSを変更するにはこのボタンを押してください</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>ストレージ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>ストレージを選ぶ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>書き込む</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>書き込み先のストレージデバイスを選択するにはこのボタンを押してください</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>書き込みをキャンセル</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>キャンセル中です...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>確認をやめる</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>最終処理をしています...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +601,201 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>書き込みをスタートさせるにはこのボタンを押してください</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>詳細な設定を変更するのならこのボタンを押してください</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>カスタムレポジトリを使います: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>キーボードの操作: 次のボタンに移動する→Tabキー  ボタンを押す/選択する→Spaceキー  上に行く/下に行く→矢印キー（上下）</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>言語: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>キーボード: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>戻る</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>メインメニューへ戻る</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>リリース日時: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>コンピュータにキャッシュされたファイル</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>ローカルファイル</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">インターネットからダウンロードする (%1GB)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1としてマウントされています</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[書き込み禁止]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>本当にやめますか？</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imagerは現在まだ処理中です。&lt;bt&gt;本当にやめますか？</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>警告</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>書き込み準備中...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1に存在するすべてのデータは完全に削除されます。本当に続けますか？</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>アップデートがあります</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>新しいバージョンのImagerがあります。&lt;br&gt;ダウンロードするためにウェブサイトに行きますか？</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>OSのリストをダウンロードする際にエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>書き込み中... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>確認中... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>書き込み準備中... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>書き込みが正常に終了しました</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>削除</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b%gt;%1&lt;/b&gt; は削除されました。&lt;br&gt;&lt;bt&gt;SDカードをSDカードリーダーから取り出しても良いです。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; は&lt;b&gt;%2&lt;/b&gt;に書き込まれました。&lt;br&gt;&lt;br&gt;SDカードをSDカードリーダーから取り出しても良いです。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>os_list.jsonの処理中にエラーが発生しました</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>カードをFAT32でフォーマットする</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>カスタムイメージを使う</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>自分で用意したイメージファイルを使う</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>最初にイメージファイルがあるUSBメモリを接続してください。&lt;br&gt;イメージファイルはUSBメモリの一番上（ルートフォルダー）に入れてください。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>SDカードは書き込みが制限されています。&lt;br&gt;カードの左上にあるロックスイッチを上げてロックを解除し、もう一度お試しください。</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; は&lt;b&gt;%2&lt;/b&gt;に書き込まれました。</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_ko.ts
+++ b/src/i18n/rpi-imager_ko.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>보관 파일 추출 오류: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>FAT32 파티션 마운트 오류</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>운영 체제에서 FAT32 파티션을 마운트하지 않음</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>디렉토리 변경 오류 &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">저장소에 쓰는 중 오류 발생</translation>
     </message>
 </context>
 <context>
@@ -30,124 +34,160 @@
     <message>
         <location filename="../downloadthread.cpp" line="118"/>
         <source>unmounting drive</source>
-        <translation type="unfinished"></translation>
+        <translation>드라이브 마운트 해제</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>드라이브 열기</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>디스크 파트를 실행하는 동안 오류 발생 : %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>기존 파티션 제거 오류</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>인증 취소됨</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>디스크 디바이스에 대한 액세스 권한을 얻기 위해 authopen을 실행하는 중 오류 발생 &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;Raspberry Pi Imager&apos;가 개인 정보 설정(&apos;파일 및 폴더&apos;에서 또는 &apos;전체 디스크 액세스&apos;를 부여)에서 &apos;제거 가능한 볼륨&apos;에 액세스할 수 있는지 확인하세요.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>저장 장치를 열 수 없습니다 &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>드라이브의 기존 데이터 삭제</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>드라이브의 처음과 마지막 MB를 비웁니다.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>MBR을 zero&apos;ing out 하는 동안 쓰기 오류 발생 </translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>SD card의 마지막 부분을 비워내는 동안 오류가 발생했습니다.&lt;br&gt;카드가 잘못된 용량을 표기하고 있을 수 있습니다(위조 품목).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>다운로드 시작</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>다운로드 중 오류: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>디스크에 파일을 쓰는 동안 액세스 거부 오류가 발생했습니다.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>제어된 폴더 액세스가 설정된 것 같습니다. rpi-imager.exe 및 fat32format.exe를 허용된 앱 리스트에서 추가하고 다시 시도하십시오.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>디스크에 파일 쓰기 오류</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>다운로드가 손상되었습니다. 해시가 일치하지 않습니다.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>저장소에 쓰는 중 오류 발생(flushing..)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>스토리지에 쓰는 중 오류 발생(fsync..)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>첫 번째 블록을 쓰는 중 오류 발생 (파티션 테이블)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>저장소에서 읽는 동안 오류가 발생했습니다.&lt;br&gt;SD 카드가 고장 났을 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>쓰기를 확인하지 못했습니다. SD카드 내용과 쓰인 내용이 다릅니다.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지 사용자 정의</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">FAT 파티션이 마운트되기를 기다리는 중</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">FAT32 파티션 마운트 오류</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">운영 체제 FAT32 파티션이 마운트되지 않았습니다.</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">지정할 수 없습니다. 파일이 &apos;%1&apos; 존재하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">FAT 파티션에 firstrun.sh을 만드는 동안 오류 발생</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">FAT 파티션에 config.txt 쓰던 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">FAT 파티션에 사용자 데이터 cloudinit 파일을 만드는 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">FAT 파티션에 네트워크 구성 cloudinit 파일을 생성하는 중 오류 발생</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">FAT 파티션에 cmdline.txt 쓰던 중 오류 발생</translation>
     </message>
 </context>
 <context>
@@ -157,85 +197,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>분할 오류: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>시작 오류 fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>실행 중 오류 fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>새 드라이브 문자 확인 오류</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>유효하지 않는 디바이스: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>포맷 오류 (udisks2 통해)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>시작 오류 sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>FAT partition %1을 분할하여 생성하지 못했습니다.</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>시작 오류 mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>실행 오류 mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>이 플랫폼에 대해 포맷이 구현되지 않았습니다.</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>저장소 공간이 충분하지 않습니다.&lt;br&gt;최소 %1 GB 이상이어야 합니다.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>입력 파일이 올바른 디스크 이미지가 아닙니다.&lt;br&gt;파일사이즈 %1 바이트가 512바이트의 배수가 아닙니다.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지 다운로드 및 쓰기</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지 선택하기</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>wifi password를 미리 입력하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +283,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지 파일 열기</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지 파일 열기 오류</translation>
     </message>
 </context>
 <context>
@@ -256,22 +296,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>아니요</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>예</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>계속</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>나가기</translation>
     </message>
 </context>
 <context>
@@ -279,22 +319,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>고급 옵션</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지 사용자 정의 옵션</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>이 세션에 한하여</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>항상 사용</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,83 +354,83 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>hostname 설정:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>사용자 이름 및 비밀번호 설정</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>사용자 이름:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>비밀번호:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>무선 LAN 설정</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>비밀번호 표시</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>숨겨진 SSID</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>무선 LAN 국가:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>로케일 설정 지정</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>시간대:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>키보드 레이아웃:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>SSH 사용</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>비밀번호 인증 사용</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>공개 키만 인증 허용</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; 인증키 설정:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +440,34 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>완료되면 효과음으로 알림</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>완료되면 미디어 꺼내기</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지 다운로드 통계 관하여 정보 수집 허용</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>저장</translation>
+    </message>
+    <message>
+        <source>Disable overscan</source>
+        <translation type="vanished">overscan 사용 안 함</translation>
+    </message>
+    <message>
+        <source>Skip first-run wizard</source>
+        <translation type="vanished">초기 실행 마법사 건너뛰기</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">영구적으로 설정</translation>
     </message>
 </context>
 <context>
@@ -423,7 +475,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>내장 SD 카드 리더기</translation>
     </message>
 </context>
 <context>
@@ -434,29 +486,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>아니요</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>아니요, 설정 지우기</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>예</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>설정을 편집하기</translation>
     </message>
 </context>
 <context>
@@ -464,7 +516,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +535,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>운영체제</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>운영체제 선택</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>운영 체제를 변경하려면 이 버튼을 선택합니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>저장소</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>저장소 선택</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>쓰기</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>저장 디바이스를 변경하려면 버튼을 선택합니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>쓰기 취소</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>취소 하는 중...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>확인 취소</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>마무리 중...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +601,201 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>이미지 쓰기를 시작하려면 버튼을 선택합니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>고급 설정에 액세스하려면 버튼을 선택합니다.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>사용자 지정 리포지토리 사용: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>키보드 탐색: &lt;tab&gt; 다음 버튼으로 이동 &lt;space&gt; 버튼 선택 및 항목 선택 &lt;arrow up/down&gt; 목록에서 위아래로 이동</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>언어: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>키보드: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>뒤로 가기</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>기본 메뉴로 돌아가기</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>릴리즈: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>컴퓨터에 캐시됨</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>로컬 파일</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>온라인 - %1 GB 다운로드</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1로 마운트</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[쓰기 보호됨]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>정말 그만두시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager가 사용 중입니다.&lt;br&gt;정말 그만두시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>주의</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>쓰기 준비 중...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos;에 존재하는 모든 데이터가 지워집니다.&lt;br&gt;계속하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>업데이트 가능</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager의 최신 버전을 사용할 수 있습니다.&lt;br&gt;다운받기 위해 웹사이트를 방문하시겠습니까??</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>인터넷에서 OS 목록을 다운로드하는 중 오류 발생</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>쓰는 중... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>확인 중... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>쓰기 준비 중... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>오류</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>쓰기 완료</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; 가 지워졌습니다.&lt;br&gt;&lt;br&gt;이제 SD card를 제거할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt;가 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;에 쓰여졌습니다. 이제 SD card를 제거할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>구문 분석 오류 os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>FAT32로 카드 형식 지정</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>사용자 정의 사용</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>컴퓨터에서 사용자 지정 .img를 선택합니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>먼저 이미지가 들어 있는 USB를 연결합니다.&lt;br&gt;이미지는 USB 루트 폴더에 있어야 합니다.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>쓰기 금지된 SD card&lt;br&gt;카드 왼쪽에 있는 잠금 스위치를 위쪽으로 누른 후 다시 시도하십시오.</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt;가 &lt;b&gt;%2&lt;/b&gt;에 쓰여졌습니다.</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_nl.ts
+++ b/src/i18n/rpi-imager_nl.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij uitpakken archiefbestand: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij mounten FAT32 partitie</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Besturingssysteem heeft FAT32 partitie niet gemount</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij openen map &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Fout bij schrijven naar opslag</translation>
     </message>
 </context>
 <context>
@@ -30,124 +34,160 @@
     <message>
         <location filename="../downloadthread.cpp" line="118"/>
         <source>unmounting drive</source>
-        <translation type="unfinished"></translation>
+        <translation>unmounten van schijf</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>openen van opslag</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij uitvoeren diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij verwijderen bestaande partities</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Authenticatie geannuleerd</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij uitvoeren authopen: &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Gelieve te controlleren of &apos;Raspberry Pi Imager&apos; toegang heeft tot &apos;verwijderbare volumes&apos; in de privacy instellingen (onder &apos;bestanden en mappen&apos; of anders via &apos;volledige schijftoegang&apos;).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij openen opslagapparaat &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>wissen bestaande gegevens</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>wissen eerste en laatste MB van opslag</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij wissen MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij wissen laatste deel van de SD kaart.&lt;br&gt;Kaart geeft mogelijk onjuiste capaciteit aan (mogelijk counterfeit).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>beginnen met downloaden</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij downloaden: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Toegang geweigerd bij het schrijven naar opslag.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Controller Folder Access lijkt aan te staan. Gelieve zowel rpi-imager.exe als fat32format.exe toe te voegen aan de lijst met uitsluitingen en het nogmaals te proberen.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij schrijven naar opslag</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Download corrupt. Hash komt niet overeen</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij schrijven naar opslag (tijdens flushen)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij schrijven naar opslag (tijdens fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij schrijven naar eerste deel van kaart (partitie tabel)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij lezen van SD kaart.&lt;br&gt;Kaart is mogelijk defect.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Verificatie mislukt. De gegevens die op de SD kaart staan wijken af van wat er naar geschreven is.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Bezig met aanpassen besturingssysteem</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">Wachten op mounten FAT partitie</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">Fout bij mounten FAT32 partitie</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">Besturingssysteem heeft FAT32 partitie niet gemount</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">Fout bij aanpassen besturingssysteem. Bestand &apos;%1&apos; bestaat niet.</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">Fout bij het aanmaken van firstrun.sh op FAT partitie</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">Fout bij schrijven naar config.txt op FAT partitie</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">Fout bij aanmaken user-data cloudinit bestand op FAT partitie</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">Fout bij aanmaken network-config cloudinit bestand op FAT paritie</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">Fout bij schrijven cmdline.txt op FAT partitie</translation>
     </message>
 </context>
 <context>
@@ -157,85 +197,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij partitioneren: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij starten fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij uitvoeren fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij vaststellen nieuwe letter van schijfstation</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ongeldig device: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij formatteren (via udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij starten sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Partitionering heeft geen FAT partitie %1 aangemaakt</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij starten mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij uitvoeren mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatteren is niet geimplementeerd op dit besturingssysteem</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>Opslagcapaciteit niet groot genoeg.&lt;br&gt;Deze dient minimaal %1 GB te zijn.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Invoerbestand is geen disk image.&lt;br&gt;Bestandsgrootte %1 bytes is geen veelvoud van 512 bytes.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Downloaden en schrijven van image</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecteer image</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Wilt u het wifi wachtwoord van het systeem overnemen?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +283,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>openen image</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij openen image bestand</translation>
     </message>
 </context>
 <context>
@@ -256,22 +296,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>Nee</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>Ja</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>VERDER GAAN</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>AFSLUITEN</translation>
     </message>
 </context>
 <context>
@@ -279,143 +319,163 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Geavanceerde instellingen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Image instellingen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>alleen voor deze sessie</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>om altijd te gebruiken</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>Algemeen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="79"/>
         <source>Services</source>
-        <translation type="unfinished"></translation>
+        <translation>Services</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="82"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Opties</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Hostnaam:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Gebruikersnaam en wachtwoord instellen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Gebruikersnaam:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Wachtwoord:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Wifi instellen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Wachtwoord laten zien</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>Verborgen SSID</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>Wifi land:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Regio instellingen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Tijdzone:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Toetsenbord indeling:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>SSH inschakelen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Gebruik wachtwoord authenticatie</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Gebruik uitsluitend public-key authenticatie</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>authorized_keys voor &apos;%1&apos;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
         <source>RUN SSH-KEYGEN</source>
-        <translation type="unfinished"></translation>
+        <translation>START SSH-KEYGEN</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Geluid afspelen zodra voltooid</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Media uitwerpen zodra voltooid</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Telemetry inschakelen</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>OPSLAAN</translation>
+    </message>
+    <message>
+        <source>Disable overscan</source>
+        <translation type="vanished">Overscan uitschakelen</translation>
+    </message>
+    <message>
+        <source>Set username:</source>
+        <translation type="vanished">Gebruikersnaam:</translation>
+    </message>
+    <message>
+        <source>Set password for &apos;%1&apos; user:</source>
+        <translation type="vanished">Wachtwoord voor &apos;%1&apos; gebruiker:</translation>
+    </message>
+    <message>
+        <source>Skip first-run wizard</source>
+        <translation type="vanished">Eerste gebruik wizard overslaan</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Permanente instellingen</translation>
     </message>
 </context>
 <context>
@@ -423,7 +483,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Interne SD kaart lezer</translation>
     </message>
 </context>
 <context>
@@ -434,29 +494,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>Nee</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>Nee, wis instellingen</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>Ja</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>Aanpassen</translation>
     </message>
 </context>
 <context>
@@ -464,7 +524,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +543,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Besturingssysteem</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>SELECTEER OS</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Kies deze knop om een besturingssysteem te kiezen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Opslagapparaat</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>KIES OPSLAGAPPARAAT</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>SCHRIJF</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Klik op deze knop om het opslagapparaat te wijzigen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuleer schrijven</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Annuleren...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>ANNULEER VERIFICATIE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Afronden...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +609,205 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Kies deze knop om te beginnen met het schrijven van de image</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Klik op deze knop om de geadvanceerde instellingen te openen</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Custom repository in gebruik: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Toetsenbord navigatie: &lt;tab&gt; ga naar volgende knop &lt;spatie&gt; druk op knop/selecteer item &lt;pijltje omhoog/omlaag&gt; ga omhoog/omlaag in lijsten</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Taal: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
-        <translation type="unfinished"></translation>
+        <translation>Toetsenbord: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
+        <translation>Pi model:</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
-        <translation type="unfinished"></translation>
+        <translation>[ Alle modellen ]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Terug</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Terug naar hoofdmenu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Release datum: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Opgeslagen op computer</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Lokaal bestand</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Online %1 GB download</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Mounted op %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[ALLEEN LEZEN]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager is nog niet klaar.&lt;br&gt;Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Voorbereiden...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle bestaande gegevens op &apos;%1&apos; zullen verwijderd worden.&lt;br&gt;Weet u zeker dat u door wilt gaan?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Update beschikbaar</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Er is een nieuwere versie van Imager beschikbaar.&lt;br&gt;Wilt u de website bezoeken om deze te downloaden?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij downloaden van lijst met besturingssystemen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Schrijven... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Verifiëren... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Voorbereiden... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Klaar met schrijven</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Wissen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; is gewist&lt;br&gt;&lt;br&gt;U kunt nu de SD kaart uit de lezer halen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; is geschreven naar &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;U kunt nu de SD kaart uit de lezer halen</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Fout bij parsen os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatteer kaart als FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Gebruik eigen bestand</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Selecteer een eigen .img bestand</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sluit eerst een USB stick met images aan.&lt;br&gt;De images moeten in de hoofdmap van de USB stick staan.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>SD kaart is tegen schrijven beveiligd.&lt;br&gt;Druk het schuifje aan de linkerkant van de SD kaart omhoog, en probeer nogmaals.</translation>
+    </message>
+    <message>
+        <source>Select this button to change the destination SD card</source>
+        <translation type="vanished">Kies deze knop om de SD kaart te kiezen</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; is geschreven naar &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_ru.ts
+++ b/src/i18n/rpi-imager_ru.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка извлечения архива: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка подключения раздела FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Операционная система не подключила раздел FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка перехода в каталог «%1»</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Ошибка записи на запоминающее устройство</translation>
     </message>
 </context>
 <context>
@@ -35,119 +39,155 @@
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>открытие диска</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка выполнения diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка удаления существующих разделов</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Аутентификация отменена</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка выполнения authopen для получения доступа к дисковому устройству «%1»</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Убедитесь, что в параметрах настройки конфиденциальности (privacy settings) в разделе «файлы и папки» («files and folders») программе Raspberry Pi Imager разрешён доступ к съёмным томам (removable volumes). Либо можно предоставить программе доступ ко всему диску (full disk access).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось открыть запоминающее устройство «%1».</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>удаление существующих данных на диске</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>обнуление первого и последнего мегабайта диска</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка записи при обнулении MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка записи при попытке обнулить последнюю часть карты.&lt;br&gt;Заявленный картой объём может не соответствовать действительности (возможно, карта является поддельной).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>начало загрузки</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка загрузки: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка доступа при записи файла на диск.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Похоже, что включён контролируемый доступ к папкам (Controlled Folder Access). Добавьте rpi-imager.exe и fat32format.exe в список разрешённых программ и попробуйте снова.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка записи файла на диск</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Загруженные данные повреждены. Хэш не совпадает</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка записи на запоминающее устройство (при сбросе)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка записи на запоминающее устройство (при выполнении fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка записи первого блока (таблица разделов)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка чтения с запоминающего устройства.&lt;br&gt;SD-карта может быть повреждена.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка по результатам проверки записи. Содержимое SD-карты отличается от того, что было на неё записано.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Настройка образа</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">Ожидание подключения раздела FAT</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">Ошибка подключения раздела FAT32</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">Операционная система не подключила раздел FAT32</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">Не удалось настроить. Файл «%1» не существует.</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">Ошибка создания firstrun.sh в разделе FAT</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">Ошибка записи в config.txt в разделе FAT</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">Ошибка создания файла user-data cloudinit в разделе FAT</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">Ошибка создания файла network-config cloudinit в разделе FAT</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">Ошибка записи в cmdline.txt в разделе FAT</translation>
     </message>
 </context>
 <context>
@@ -157,85 +197,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка создания разделов: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка запуска fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка выполнения fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка определения новой буквы диска</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Недопустимое устройство: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка форматирования (с помощью udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка запуска sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>При создании разделов не был создан ожидаемый раздел FAT %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка запуска mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка выполнения mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Для этой платформы не реализовано форматирование</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>Недостаточная ёмкость запоминающего устройства.&lt;br&gt;Требуется не менее %1 ГБ.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Входной файл не представляет собой корректный образ диска.&lt;br&gt;Размер файла %1 не кратен 512 байтам.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Загрузка и запись образа</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбор образа</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Указать пароль от WiFi автоматически (взяв его из системной цепочки ключей)?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +283,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>открытие файла образа</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка открытия файла образа</translation>
     </message>
 </context>
 <context>
@@ -256,22 +296,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>НЕТ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>ДА</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>ПРОДОЛЖИТЬ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>ВЫЙТИ</translation>
     </message>
 </context>
 <context>
@@ -279,22 +319,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Дополнительные параметры</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Параметры настройки образа</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>только для этого сеанса</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>для постоянного использования</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,83 +354,83 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя хоста:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Указать имя пользователя и пароль</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Имя пользователя:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Пароль:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Настроить Wi-Fi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Показывать пароль</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>Скрытый идентификатор SSID</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>Страна Wi-Fi:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Указать параметры региона</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Часовой пояс:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Раскладка клавиатуры:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить SSH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать аутентификацию по паролю</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Разрешить только аутентификацию с использованием открытого ключа</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>authorized_keys для «%1»:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +440,26 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Воспроизводить звук после завершения</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Извлекать носитель после завершения</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Включить телеметрию</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>СОХРАНИТЬ</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Постоянные параметры</translation>
     </message>
 </context>
 <context>
@@ -423,7 +467,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Внутреннее устройство чтения SD-карт</translation>
     </message>
 </context>
 <context>
@@ -434,29 +478,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>НЕТ</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>НЕТ, ОЧИСТИТЬ ПАРАМЕТРЫ</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>ДА</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>ИЗМЕНИТЬ ПАРАМЕТРЫ</translation>
     </message>
 </context>
 <context>
@@ -464,7 +508,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager, версия %1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +527,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Операционная система</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>ВЫБРАТЬ ОС</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Нажмите эту кнопку, чтобы изменить операционную систему</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Запоминающее устройство</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>ВЫБРАТЬ ЗАПОМ. УСТРОЙСТВО</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>ЗАПИСАТЬ</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Нажмите эту кнопку, чтобы изменить целевое запоминающее устройство</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>ОТМЕНИТЬ ЗАПИСЬ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Отмена...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>ОТМЕНИТЬ ПРОВЕРКУ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Завершение...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +593,197 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Нажмите эту кнопку, чтобы начать запись образа</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Нажмите эту кнопку для получения доступа к дополнительным параметрам</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Использование настраиваемого репозитория: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Навигация с помощью клавиатуры: клавиша &lt;Tab&gt; перемещает на следующую кнопку, клавиша &lt;Пробел&gt; нажимает кнопку/выбирает элемент, клавиши со &lt;стрелками вверх/вниз&gt; перемещают выше/ниже в списке</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Язык: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>Клавиатура: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Вернуться в главное меню</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Дата выпуска: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Кэш на компьютере</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Локальный файл</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Онлайн — объём загрузки составляет %1 ГБ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Подключено как %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[ЗАЩИЩЕНО ОТ ЗАПИСИ]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Действительно выполнить выход?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Программа Raspberry Pi Imager всё ещё занята.&lt;br&gt;Действительно выполнить выход из неё?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Внимание</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Подготовка к записи…</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Все существующие на «%1» данные будут стёрты.&lt;br&gt;Продолжить?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Доступно обновление</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Доступна новая версия Imager.&lt;br&gt;Перейти на веб-сайт для её загрузки?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка загрузки списка ОС из Интернета</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Запись... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Проверка... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Подготовка к записи... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Запись успешно выполнена</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Стереть</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Данные на &lt;b&gt;%1&lt;/b&gt; стёрты&lt;br&gt;&lt;br&gt;Теперь можно извлечь SD-карту из устройства чтения</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Запись &lt;b&gt;%1&lt;/b&gt; на &lt;b&gt;%2&lt;/b&gt; выполнена&lt;br&gt;&lt;br&gt;Теперь можно извлечь SD-карту из устройства чтения</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка синтаксического анализа os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Отформатировать карту как FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Использовать настраиваемый образ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Выбрать настраиваемый файл .img на компьютере</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Сначала подключите USB-накопитель с образами.&lt;br&gt;Образы должны находиться в корневой папке USB-накопителя.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>SD-карта защищена от записи.&lt;br&gt;Переместите вверх блокировочный переключатель, расположенный с левой стороны карты, и попробуйте ещё раз.</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_sk.ts
+++ b/src/i18n/rpi-imager_sk.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri rozbaľovaní archívu: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri pripájaní partície FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Operačný systém nepripojil partíciu FAT32</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri vstupe do adresára &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Chyba pri zápise na úložisko</translation>
     </message>
 </context>
 <context>
@@ -35,119 +39,155 @@
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>otváram disk</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba počas behu diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri odstraňovaní existujúcich partiícií</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Zrušená autentifikácia</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri spúšťaní authopen v snahe o získanie prístupu na diskové zariadenie &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Preverte, prosím, či má &apos;Raspberry Pi Imager&apos; prístup k &apos;vymeniteľným nosičom&apos; v nastaveniach súkromia (pod &apos;súbormi a priečinkami&apos;, prípadne mu udeľte &apos;plný prístup k diskom&apos;).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Nepodarilo sa otvoriť zariadenie úložiska &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>odstraňujem existujúce údaje z disku</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>prepisujem prvý a posledny megabajt disku</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba zápisu pri prepisovaní MBR nulami</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba zápisu pri prepisovaní poslednej časti karty nulami.&lt;br&gt;Karta pravdepodobne udáva nesprávnu kapacitu (a môže byť falošná).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>začína sťahovanie</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri sťahovaní: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Odopretý prístup pri zápise súboru na disk.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vyzerá, že máte zapnutý Controlled Folder Access. Pridajte, prosím, rpi-imager.exe a fat32format.exe do zoznamu povolených aplikácií a skúste to znovu.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri zápise na disk</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Stiahnutý súbor je poškodený. Kontrolný súčet nesedí</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri zápise na úložisko (počas volania flush)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri zápise na úložisko (počas volania fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri zápise prvého bloku (tabuľky partícií)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri čítaní z úložiska.&lt;br&gt;Karta SD môže byť poškodená.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Overovanie zápisu skončilo s chybou. Obsah karty SD sa nezhoduje s tým, čo na ňu bolo zapísané.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Upravujem obraz</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">Čakám a pripojenie FAT partície</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">Chyba pri pripájaní partície FAT32</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">Operačný systém nepripojil partíciu FAT32</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">Prispôsobenie skončilo s chybou. Súbor &apos;%1&apos; neexistuje.</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">Pri vytváraní firstrun.sh na partícii FAT nastala chyba</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">Chyba pri zápise config.txt na FAT partícii</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">Chyba pri vytváraní súboru cloudinit s údajmi používateľa na partícií FAT</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">Chyba pri vytváraní súboru cloudinit s nastavením siete na partícií FAT</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">Chyba pri zápise cmdline.txt na FAT partíciu</translation>
     </message>
 </context>
 <context>
@@ -157,85 +197,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri zápise partícií: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri spustení fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri spustení fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri zisťovaní písmena nového disku</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Neplatné zariadenie: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri formátovaní (pomocou udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri spustení sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Rozdelenie disku nevytvorilo očakávanú FAT partíciu %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri spustení mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri spustení mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Formátovanie nie je na tejto platforme implementované</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapacita úložiska je nedostatočná&lt;br&gt;Musí byť aspoň %1 GB.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vstupný súbor nie je platným obrazom disku.&lt;br&gt;Veľkosť súboru %1 bajtov nie je násobkom 512 bajtov.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Sťahujem a zapisujem obraz</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Vyberte obraz</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Chcete predvyplniť heslo pre wifi zo systémovej kľúčenky?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +283,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>otváram súbor s obrazom</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri otváraní súboru s obrazom</translation>
     </message>
 </context>
 <context>
@@ -256,22 +296,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NIE</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>ÁNO</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>POKRAČOVAŤ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>UKONČIŤ</translation>
     </message>
 </context>
 <context>
@@ -279,22 +319,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokročilé možnosti</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Možnosti úprav obrazu</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>iba pre toto sedenie</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>použiť vždy</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,83 +354,83 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastaviť meno počítača (hostname):</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastaviť meno používateľa a heslo</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Meno používateľa:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Heslo:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastaviť wifi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Zobraziť heslo</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>Skryté SSID</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>Wifi krajina:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastavenia miestnych zvyklostí</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Časové pásmo:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Rozloženie klávesnice:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>Povoliť SSH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Použiť heslo na prihlásenie</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Povoliť iba prihlásenie pomocou verejného kľúča</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastaviť authorized_keys pre &apos;%1&apos;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +440,42 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Po skončení prehrať zvuk</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Po skončení vysunúť médium</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Povoliť telemetriu</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>ULOŽIŤ</translation>
+    </message>
+    <message>
+        <source>Disable overscan</source>
+        <translation type="vanished">Vypnúť presnímanie (overscan)</translation>
+    </message>
+    <message>
+        <source>Set password for &apos;pi&apos; user:</source>
+        <translation type="vanished">Nastaviť heslo pre používateľa &apos;pi&apos;:</translation>
+    </message>
+    <message>
+        <source>Set authorized_keys for &apos;pi&apos;:</source>
+        <translation type="vanished">Nastaviť authorized_keys pre &apos;pi&apos;:</translation>
+    </message>
+    <message>
+        <source>Skip first-run wizard</source>
+        <translation type="vanished">Vypnúť sprievodcu prvým spustením</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Trvalé nastavenia</translation>
     </message>
 </context>
 <context>
@@ -423,7 +483,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Interná čítačka SD kariet</translation>
     </message>
 </context>
 <context>
@@ -434,29 +494,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">NIE</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>NIE, VYČISTIŤ NASTAVENIA</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>ÁNO</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>UPRAVIŤ NASTAVENIA</translation>
     </message>
 </context>
 <context>
@@ -464,7 +524,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +543,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Operačný systém</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>VYBERTE OS</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Pre zmenu operačného systému kliknite na toto tlačidlo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>SD karta</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>VYBERTE SD KARTU</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>ZAPÍSAŤ</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Pre zmenu cieľového zariadenia úložiska kliknite na toto tlačidlo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>ZRUŠIŤ ZÁPIS</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Ruším operáciu...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>ZRUŠIŤ OVEROVANIE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Ukončujem...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +609,205 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Kliknutím na toto tlačidlo spustíte zápis</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Použite toto tlačidlo na prístup k pokročilým nastaveniam</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Používa sa vlastný repozitár: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Ovládanie pomocou klávesnice: &lt;tabulátor&gt; prechod na ďalšie tlačidlo &lt;medzerník&gt; stlačenie tlačidla/výber položky &lt;šípka hore/dole&gt; posun hore/dole v zoznamoch</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Jazyk:</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>Klávesnica: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Späť</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Prejsť do hlavnej ponuky</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Vydané: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Uložené na počítači</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Miestny súbor</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Online %1 GB na stiahnutie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Pripojená ako %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[OCHRANA PROTI ZÁPISU]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Skutočne chcete skončiť?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager ešte neskončil.&lt;br&gt;Ste si istý, že chcete skončiť?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Varovanie</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Príprava zápisu...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Všetky existujúce dáta na &apos;%1&apos; budú odstránené.&lt;br&gt;Naozaj chcete pokračovať?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Je dostupná aktualizácia</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Je dostupná nová verzia Imagera.&lt;br&gt;Chcete prejsť na webovú stránku s programom a stiahnuť ho?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri sťahovaní zoznamu OS z Internetu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapisujem... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Overujem... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Príprava zápisu... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Zápis úspešne skončil</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Vymazať</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; bola vymazaná&lt;br&gt;&lt;br&gt;Teraz môžete odstrániť SD kartu z čítačky</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; bol zapísaný na &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;Teraz môžete odstrániť SD kartu z čítačky</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Chyba pri spracovaní os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Formátovať kartu ako FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Použiť vlastný</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Použiť vlastný súbor img. na Vašom počítači</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Najprv pripojte USB kľúč, ktorý obsahuje diskové obrazy.&lt;br&gt;Obrazy sa musia nachádzať v koreňovom priečinku USB kľúča.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>SD karta je chránená proti zápisu.&lt;br&gt;Presuňte prepínač zámku na ľavej strane karty smerom hore a skúste to znova.</translation>
+    </message>
+    <message>
+        <source>Select this button to change the destination SD card</source>
+        <translation type="vanished">Pre zmenu cieľovej SD karty kliknite na toto tlačidlo</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; bol zapísaný na &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_sl.ts
+++ b/src/i18n/rpi-imager_sl.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka razširjanja arhiva: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka priklopa FAT32 particije</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Operacijski sistem, ni priklopil FAT32 particije</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka spremembe direktorija &apos;%1%&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Napaka pisanja na disk</translation>
     </message>
 </context>
 <context>
@@ -35,119 +39,155 @@
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Odpiranje pogona</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka zagona diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka odstranjevanja obstoječih particij</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Avtentifikacija preklicana</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka zagona authopen za pridobitev dostopa do naprave diska &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Prosim preverite če ima &apos;Raspberry Pi Imager&apos; pravico dostopa do &apos;odstranljivih mediev&apos; pod nastavitvami zasebnosti (pod &apos;datoteke in mape&apos; ali pa mu dajte &apos;popolni dostop do diska&apos;).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ne morem odpreti diska &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Brisanje obstoječih podatkov na disku</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>Ničenje prvega in zadnjega MB diska</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka zapisovanja med ničenjem MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka ničenja zadnjega dela diska.&lt;br&gt;Disk morebiti sporoča napačno velikost(možen ponaredek).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>Začetek prenosa</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka prenosa:%1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka zavrnitve dostopa med pisanjem na disk.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Izgleda, da jevklopljen nadzor dostopa do map. Prosim dodajte oba rpi-imager.exe in fat32format.exe na seznam dovoljenih aplikacij in poizkusite znova.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka pisanja na disk</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Prenos poškodovan.Hash se ne ujema</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka pisanja na disk (med brisanjem)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka pisanja na disk (med fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka pisanja prvega bloka (particijska tabela)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka branja iz diska.&lt;br&gt;SD kartica/disk je mogoče v okvari.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Preverjanje pisanja spodletelo. Vsebina diska je drugačna, od tega, kar je bilo nanj zapisano.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Prilagajanje slike diska</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">Čakanje na priklop FAT particije</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">Napaka priklopa FAT32 particije</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">Operacijski sisitem ni priklopil FAT32 particijo</translation>
+    </message>
+    <message>
+        <source>Unable to customize. File &apos;%1&apos; does not exist.</source>
+        <translation type="vanished">Prilagoditev ni možna. Datoteka &apos;%1&apos; ne obstaja.</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">Napaka ustvarjanja firstrun.sh na FAT particiji</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">Napaka pisanja v config.txt na FAT particiji</translation>
+    </message>
+    <message>
+        <source>Error creating user-data cloudinit file on FAT partition</source>
+        <translation type="vanished">Napaka ustvarjanja user-data cloudinit datoteke na FAT particiji</translation>
+    </message>
+    <message>
+        <source>Error creating network-config cloudinit file on FAT partition</source>
+        <translation type="vanished">Napaka ustvarjanja network-config cloudinit datoteke na FAT particiji</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">Napaka pisanja v cmdline.txt na FAT particiji</translation>
     </message>
 </context>
 <context>
@@ -157,85 +197,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka izdelave particij: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka zagona fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka delovanja fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka določitve nove črke pogona</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Neveljavna naprava: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka fromatiranja (z uporabo udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka zagona sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Ustvarjanje particij ni ustvarilo pričakovano FAT particijo %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka zagona mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka delovanja mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatiranje ni implemntirano za to platformo</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapaciteta diska ni zadostna.&lt;br&gt;Biti mora vsaj %1 GB.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Vhodna datoteka ni veljavna slika diska.&lt;br&gt;Velikost datoteke %1 bajtov ni večkratnik od 512 bajtov.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Prenašanje in zapisovanje slike</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Izberite sliko</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>A bi želeli uporabiti WiFi geslo iz kjučev tega sistema?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +283,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Odpiranje slike diska</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka odpiranja slike diska</translation>
     </message>
 </context>
 <context>
@@ -256,22 +296,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NE</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>DA</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>NADALJUJ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>IZHOD</translation>
     </message>
 </context>
 <context>
@@ -279,22 +319,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Napredne možnosti</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi opcije prilagoditve slike diska</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>samo za to sejo</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>vedno</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,7 +354,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ime naprave:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
@@ -330,22 +370,22 @@
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Geslo:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastavi WiFi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Pokaži geslo</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
@@ -355,42 +395,42 @@
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>WiFi je v državi:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastavitve jezika</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Časovni pas:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Razporeditev tipkovnice:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>Omogoči SSH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi geslo za avtentifikacijo</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>Dovoli le avtentifikacijo z javnim kjučem</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>Nastavi authorized_keys za &apos;%1&apos;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +440,42 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Zaigraj zvok, ko končaš</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Izvrzi medij, ko končaš</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Omogoči telemetrijo</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>SHRANI</translation>
+    </message>
+    <message>
+        <source>Disable overscan</source>
+        <translation type="vanished">Onemogoči overscan</translation>
+    </message>
+    <message>
+        <source>Set username:</source>
+        <translation type="vanished">Nastavi uporabniško ime:</translation>
+    </message>
+    <message>
+        <source>Set password for &apos;%1&apos; user:</source>
+        <translation type="vanished">Nastavi geslo za uporabnika &apos;%1&apos;:</translation>
+    </message>
+    <message>
+        <source>Skip first-run wizard</source>
+        <translation type="vanished">Preskoči čarovnika prvega zagona</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Trajne nastavitve</translation>
     </message>
 </context>
 <context>
@@ -423,7 +483,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Vgrajeni čitalec SD kartic</translation>
     </message>
 </context>
 <context>
@@ -434,29 +494,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>NE</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>NE, POBRIŠI NASTAVITVE</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>DA</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>UREDI NASTAVITVE</translation>
     </message>
 </context>
 <context>
@@ -464,7 +524,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +543,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Operacijski Sistem</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>IZBERI OS</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Izberite ta gumb za menjavo operacijskega sistema</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>SD kartica ali USB disk</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>IZBERI DISK</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>ZAPIŠI</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabite ta gumb za spremembo ciljnega diska</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>PREKINI ZAPISOVANJE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Prekinjam...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>PREKINI PREVERJANJE</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Zakjučujem...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +609,201 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
+        <translation>Izberite za gumb za začetek pisanja slike diska</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabljam repozitorij po meri: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Navigacija s tipkovnico: &lt;tab&gt; pojdi na naslednji gumb &lt;preslednica&gt; pritisni gumb/izberi element &lt;puščica gor/dol&gt; premakni gor/dol po seznamu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Jezik: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>Tipkovnica: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Nazaj</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Pojdi nazaj na glavni meni</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Izdano: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Predpolnjeno na vaš računalnik</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Lokalna datoteka</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Iz spleta - %1 GB prenos</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Priklopljen kot %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[ZAŠČITENO PRED PISANJEM]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>A ste prepričani, da želite končat?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager je še vedno zaposlen.&lt;br&gt;A ste prepričani, da želite končati?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Opozorilo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Priprava na pisanje...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>VSI obstoječi podatki na &apos;%1&apos; bodo izbrisani.&lt;br&gt;A ste prepričani, da želite nadaljevati?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Posodobitev na voljo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Na voljo je nova verzija tega programa. &lt;br&gt;Želite obiskati spletno stran za prenos?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka prenosa seznama OS iz interneta</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Pišem...%1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Preverjam... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Priprava na zapisovanje... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Zapisovanje uspešno</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Odstrani</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; je pobrisan&lt;br&gt;&lt;br&gt;Sedaj lahko odstranite SD kartico iz čitalca oz iztaknete USB disk</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; je zapisan na &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;Sedaj lahko odstranite SD kartico iz čitalca oz iztaknete USB disk</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Napaka procesiranja os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Formatiraj disk v FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Uporabi drugo</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Izberite drug .img iz vašega računalnika</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Najprej prikopite USB disk, ki vsebuje slike diskov.&lt;br&gt;Slike diskov se morajo nahajati v korenski mapi USB diska.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>SD kartica je zaščitena pred pisanjem.&lt;br&gt;Premaknite stikalo zaklepanja, na levi strani kartice in poizkusite znova.</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; je zapisan na &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_tr.ts
+++ b/src/i18n/rpi-imager_tr.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Arşiv çıkarılırken hata oluştu: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>FAT32 bölümü bağlanırken hata oluştu</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>İşletim sistemi FAT32 bölümünü bağlamadı</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Dizin değiştirirken hata oluştu &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Depolama birimine yazma hatası</translation>
     </message>
 </context>
 <context>
@@ -35,119 +39,127 @@
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>sürücü açılıyor</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Diskpart çalıştırılırken hata oluştu: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut bölümler kaldırılırken hata oluştu </translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Kimlik doğrulama iptal edildi</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; disk aygıtına erişmek için authopen çalıştırılırken hata oluştu</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Lütfen &apos;Raspberry Pi Imager&apos;ın gizlilik ayarlarında (&apos;dosyalar ve klasörler&apos; altında veya alternatif olarak &apos;tam disk erişimi&apos;) &apos;çıkarılabilir birimlere erişim&apos; izin verilip verilmediğini doğrulayın.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Depolama cihazı açılamıyor &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>sürücüdeki mevcut verileri sil</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>sürücünün ilk ve son MB&apos;sini sıfırlama</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>MBR sıfırlanırken yazma hatası</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Kartın son kısmını sıfırlamaya çalışırken yazma hatası. Kart yanlış kapasitenin tanımını yapıyor olabilir (olası sahte bölüm boyutu tanımı)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>indirmeye başlanıyor</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>İndirilirken hata oluştu: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyayı diske yazarken erişim reddedildi hatası</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kontrollü Klasör Erişimi etkin görünüyor. Lütfen izin verilen uygulamalar listesine hem rpi-imager.exe&apos;yi hem de fat32format.exe&apos;yi ekleyin ve tekrar deneyin.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyayı diske yazma hatası</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>İndirme bozuk. Hash eşleşmiyor</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Depolama alanına yazma hatası (flushing sırasında)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Depoya yazma hatası (fsync sırasında)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>İlk bloğu yazma hatası (bölüm tablosu)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Depolamadan okuma hatası.&lt;br&gt;SD kart arızalı olabilir.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazma doğrulanamadı. SD kartın içeriği, üzerine yazılandan farklı.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="obsolete">FAT32 bölümü bağlanırken hata oluştu</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="obsolete">İşletim sistemi FAT32 bölümünü bağlamadı</translation>
     </message>
 </context>
 <context>
@@ -157,37 +169,37 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Bölümleme hatası: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>fat32format başlatılırken hata oluştu</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>fat32format çalıştırılırken hata oluştu: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni sürücü harfi belirlenirken hata oluştu</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçersiz cihaz: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Hatalı biçimlendirme (udisks2 aracılığıyla)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>sfdisk başlatılırken hata oluştu</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
@@ -197,43 +209,43 @@
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>mkfs.fat başlatılırken hata oluştu</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>mkfs.fat çalıştırılırken hata oluştu: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu platform için biçimlendirme uygulanmadı</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>Depolama kapasitesi yeterince büyük değil.&lt;br&gt;En az %1 GB olması gerekiyor</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Giriş dosyası geçerli bir disk görüntüsü değil.&lt;br&gt;%1 bayt dosya boyutu 512 baytın katı değil.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntü indirme ve yazma</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Imaj seç</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -243,12 +255,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>imaj dosyası açılıyor</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Imaj dosyası açılırken hata oluştu</translation>
     </message>
 </context>
 <context>
@@ -256,17 +268,17 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>HAYIR</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>EVET</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>DEVAM ET</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
@@ -423,7 +435,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Dahili SD kart okuyucu</translation>
     </message>
 </context>
 <context>
@@ -434,28 +446,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
+        <source>NO</source>
+        <translation>HAYIR</translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
         <source>NO, CLEAR SETTINGS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">EVET</translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
-        <source>NO</source>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -464,7 +476,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imaj Yöneticisi v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +495,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>İşletim sistemi</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>İŞLETİM SİSTEMİ SEÇİN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>İşletim sistemini değiştirmek için bu düğmeyi seçin</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>SD Kart</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>SD KART SEÇİN</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>YAZ</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>YAZMAYI İPTAL ET</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>İptal ediliyor...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>DOĞRULAMA İPTALİ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Bitiriliyor...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +561,206 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
+        <translation>Görüntüyü yazmaya başlamak için bu düğmeyi seçin</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Geri</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Ana menüye dön</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Yayın: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilgisayarınızda önbelleğe alındı
+</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel dosya</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Çevrimiçi -%1 GB indir</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 olarak bağlandı.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[YAZMA KORUMALI]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Çıkmak istediğine emin misin?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager hala meşgul.&lt;br&gt;Çıkmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Uyarı</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazdırmaya hazırlanıyor...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; üzerindeki mevcut tüm veriler silinecek.&lt;br&gt;Devam etmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Güncelleme bulunuyor</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Görüntüleyicinin daha yeni bir sürümü var. &lt;br&gt; İndirmek için web sitesini ziyaret etmek ister misiniz?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>İnternetten işletim sistemi listesi indirilirken hata oluştu</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazılıyor... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Doğrulanıyor... %1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazdırmaya hazırlanıyor... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Hata</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Başarılı Yazıldı</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; silindi &lt;br&gt;&lt;br&gt; Artık SD kartı okuyucudan çıkarabilirsiniz</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt; üzerine yazıldı. Artık SD kartı okuyucudan çıkarabilirsiniz</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>os_list.json ayrıştırma hatası</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Kartı FAT32 olarak biçimlendir</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel imaj kullan</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilgisayarınızdan özel bir .img seçin</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Önce görüntüler içeren bir USB bellek bağlayın.&lt;br&gt; Görüntüler USB belleğin kök klasöründe bulunmalıdır.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>SD kart yazma korumalı. &lt;br&gt; Kartın sol tarafındaki kilit anahtarını yukarı itin ve tekrar deneyin.</translation>
+    </message>
+    <message>
+        <source>Select this button to change the destination SD card</source>
+        <translation type="vanished">Hedef SD kartı değiştirmek için bu düğmeyi seçin</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt; üzerine yazıldı</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_uk.ts
+++ b/src/i18n/rpi-imager_uk.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка розпакування архіва: %1</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка монтування FAT32 розділу</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>Операційна система не монтувала FAT32 розділ</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка при зміні каталогу на &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">Помилка запису на накопичувач</translation>
     </message>
 </context>
 <context>
@@ -30,124 +34,124 @@
     <message>
         <location filename="../downloadthread.cpp" line="118"/>
         <source>unmounting drive</source>
-        <translation type="unfinished"></translation>
+        <translation>диск від&apos;єднується</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>диск відкривається</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка при виконанні diskpart: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка при видаленні існуючих розділів</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Аутентифікація скасована</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка виконання authopen для отримання доступу до пристроя &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>Переконайтеся, що у Raspberry Pi Imager у налаштуваннях приватності (у розділі &quot;файли та каталоги&quot;) є доступ до змінних розділів. Або дайте програмі доступ до усього диску.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>Не вдалося відкрити накопичувач &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>видалення існуючих даних на диску</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>обнулювання першого і останнього мегабайта диску</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка при обнулюванні MBR</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка запису під час обнулювання останнього розділу карти пам&apos;яті.&lt;br&gt;Можливо заявлений об&apos;єм карти не збігається з реальним (можливо карта є підробленою).</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>початок завантаження</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка завантаження: %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка доступу при записі файлу на диск.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Схоже, що увімкнено контрольований доступ до каталогу (Controlled Folder Access). Додайте rpi-imager.exe і fat32format.exe в список виключення та спробуйте ще раз.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка запису файлу на диск</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>Завантаження пошкоджено. Хеш сума не збігається</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка запису на накопичувач (при скидуванні)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка запису на накопичувач (при виконанні fsync)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка під час запису першого блоку (таблиця розділів)</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка читання накопичувача.&lt;br&gt;SD-карта пам&apos;яті може бути пошкоджена.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка перевірки запису. Зміст SD-карти пам&apos;яті відрізняється від того, що було записано туди.</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Налаштування образа</translation>
     </message>
 </context>
 <context>
@@ -157,85 +161,85 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка створення роздіу: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка запуску fat32format</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка під час виконання fat32format: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка визначення  нової букви диску</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Не правильний пристрій: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка форматування (через udisks2)</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка запуску sfdisk</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>При створенні розділів не було створено очікуваний розділ FAT %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка запуску mkfs.fat</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка виконання mkfs.fat: %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>Форматування не доступно на цій платформі</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>Місця на накопичувачі недостатньо.&lt;br&gt;Треба, щоб було хоча б %1 ГБ.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Обраний файл не є правильним образом диску.&lt;br&gt;Розмір файла %1 байт не є кратним 512 байт.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Завантаження і запис образу</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>Обрати образ</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>Вказати пароль від Wi-Fi автоматично із системного ланцюга ключів?</translation>
     </message>
 </context>
 <context>
@@ -243,12 +247,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>відкривання файлу образа</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка при відкриванні файлу образу</translation>
     </message>
 </context>
 <context>
@@ -256,22 +260,22 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>НІ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>ТАК</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>ПРОДОВЖИТИ</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>ВИЙТИ</translation>
     </message>
 </context>
 <context>
@@ -279,22 +283,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>Розширені опції</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>Налаштування образу</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>тільки для цієї сесії</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>завжди використовувати</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,73 +318,73 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>Змінити ім&apos;я хосту</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>Встановити ім&apos;я користувача і пароль</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="142"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>Ім&apos;я користувача:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Пароль:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>Налаштувати Wi-Fi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>Показати пароль</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>Схована SSID</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>Країна Wi-Fi:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Змінити налаштування регіону</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Часова зона:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>Розкладка клавіатури:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>Увімкнути SHH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Використовувати аутентефікацію черз пароль</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
@@ -390,7 +394,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>Встановити authorized_keys для &apos;%1&apos;:</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +404,26 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Відтворити звук після завершення</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>Витягнути накопичувач після завершення</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Увімкнути телеметрію</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>ЗБЕРЕГТИ</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">Постійні налаштування</translation>
     </message>
 </context>
 <context>
@@ -423,7 +431,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Внутрішній считувач SD карт</translation>
     </message>
 </context>
 <context>
@@ -434,29 +442,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>НІ</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>НІ, ОЧИСТИТИ НАЛАШТУВАННЯ</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>ТАК</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>РЕДАГУВАТИ НАЛАШТУВАННЯ</translation>
     </message>
 </context>
 <context>
@@ -464,7 +472,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager, версія %1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +491,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>Операційна система</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>ОБРАТИ ОС</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Натисніть на цю кнопку, щоб змінити операційну систему</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>Накопичувач</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>ОБРАТИ НАКОПИЧУВАЧ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>ЗАПИСАТИ</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>Натисніть цю кнопку, щоб змінити пристрій призначення</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>СКАСУВАТИ ЗАПИСУВАННЯ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>Скасування...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>СКАСУВАТИ ПЕРЕВІРКУ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>Завершення...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +557,197 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
-        <translation type="unfinished"></translation>
+        <translation>Натисніть цю кнопку, щоб розпочати запис образу</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
+        <translation>Натисніть цю кнопку, щоб отримати доступ до розширених опцій</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Користуючись власним репозиторієм: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>Навігація клавіатурою: клавіша &lt;Tab&gt; переміститися на наступну кнопку, клавіша &lt;Пробіл&gt; натиснути кнопку/обрати елемент, клавіши з &lt;стрілками вниз/вгору&gt; переміститися вниз/вгору по списку</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>Мова: </translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
+        <translation>Клавіатура: </translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>Назад</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Повернутися у головне меню</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Випущено: %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Кешовано на вашому комп&apos;ютері</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>Локальний файл</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>Онлайн - потрібно завантажити %1 ГБ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Примонтовано як %1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>ЗАХИЩЕНО ВІД ЗАПИСУ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Бажаєте вийти?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager все ще зайнятий.&lt;br&gt;Ви впевнені, що бажаєте вийти?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Увага</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>Підготовка до запису...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>Усі уснуючі дані у &apos;%1&apos; будуть видалені.&lt;br&gt; Ви впевнені, що бажаєте продовжити?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>Доступно оновлення</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Доступна нова версія Imager.&lt;br&gt;Бажаєте завітати на сайт та завантажити її?</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка завантаження списку ОС із Інтернету</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Записування...%1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>Перевірка...%1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Підготовка до запису... (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>Успішно записано</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; був успішно видалено.br&gt;&lt;br&gt; тепер можна дістати SD карту із считувача</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>Записування &lt;b&gt;%1&lt;/b&gt; на &lt;b&gt;%2&lt;/b&gt; виконано &lt;br&gt;&lt;br&gt; Тепер можна дістати SD карту із считувача</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>Помилка парсування os_list.json</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>Форматувати карту у FAT32</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Власний образ</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>Обрати власний .img з вашого комп&apos;ютера</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>Спочатку під&apos;єднайте USB-накопичувач з образами.&lt;br&gt;Образи повинні знаходитися у корінному каталогу USB-накопичувача.</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>SD карта захищена від запису.&lt;br&gt;перетягніть перемикач на лівій стороні картки вгору, і спробуйте ще раз.</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -7,22 +7,26 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>解压 %1 时出错</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>挂载FAT32分区错误</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation type="unfinished"></translation>
+        <translation>操作系统未能挂载FAT32分区</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>进入文件夹 “%1” 错误</translation>
+    </message>
+    <message>
+        <source>Error writing to storage</source>
+        <translation type="vanished">写入时出错</translation>
     </message>
 </context>
 <context>
@@ -35,119 +39,143 @@
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation type="unfinished"></translation>
+        <translation>打开驱动器</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>运行 “diskpart” 命令错误 %1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation type="unfinished"></translation>
+        <translation>删除现有分区时出错</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>认证已取消</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>运行authopen以获得对磁盘设备&apos;%1&apos;的访问权限时出错</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation type="unfinished"></translation>
+        <translation>请验证是否在隐私设置中允许“ Raspberry Pi Imager”访问“可移动卷”（在“文件和文件夹”下，或者为它提供“完全磁盘访问”）的权限。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>无法打开存储设备&apos;%1&apos;。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation type="unfinished"></translation>
+        <translation>删除现有数据</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation type="unfinished"></translation>
+        <translation>清空驱动器未使用的数据</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation type="unfinished"></translation>
+        <translation>将MBR清零时写入错误</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation type="unfinished"></translation>
+        <translation>写入镜像失败&lt;br&gt;SD卡可能损坏。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
         <source>starting download</source>
-        <translation type="unfinished"></translation>
+        <translation>开始下载</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="466"/>
         <source>Error downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>下载文件错误，已下载：%1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="663"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation type="unfinished"></translation>
+        <translation>将文件写入磁盘时访问被拒绝。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="668"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>受控文件夹访问似乎已启用。 请将rpi-imager.exe和fat32format.exe都添加到允许的应用程序列表中，然后重试。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="675"/>
         <source>Error writing file to disk</source>
-        <translation type="unfinished"></translation>
+        <translation>将文件写入磁盘时出错</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="697"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation type="unfinished"></translation>
+        <translation>下载的文件损坏。 哈希值不匹配</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="709"/>
         <location filename="../downloadthread.cpp" line="761"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation type="unfinished"></translation>
+        <translation>刷写存储时出错</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="716"/>
         <location filename="../downloadthread.cpp" line="768"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation type="unfinished"></translation>
+        <translation>在fsync时写入存储时出错</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="751"/>
         <source>Error writing first block (partition table)</source>
-        <translation type="unfinished"></translation>
+        <translation>写入第一个块（分区表）时出错</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="826"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished"></translation>
+        <translation>从存储读取数据时错误。&lt;br&gt;SD卡可能已损坏。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="845"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished"></translation>
+        <translation>验证写入失败。 SD卡的内容与写入的内容不同。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>使用自定义镜像</translation>
+    </message>
+    <message>
+        <source>Waiting for FAT partition to be mounted</source>
+        <translation type="vanished">等待FAT分区挂载</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation type="vanished">挂载FAT32分区错误</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation type="vanished">操作系统未能挂载FAT32分区</translation>
+    </message>
+    <message>
+        <source>Error creating firstrun.sh on FAT partition</source>
+        <translation type="vanished">在FAT分区上创建firstrun.sh脚本文件时出错</translation>
+    </message>
+    <message>
+        <source>Error writing to config.txt on FAT partition</source>
+        <translation type="vanished">在FAT分区上写入config.txt时出错</translation>
+    </message>
+    <message>
+        <source>Error writing to cmdline.txt on FAT partition</source>
+        <translation type="vanished">在FAT分区上写入cmdline.txt时出错</translation>
     </message>
 </context>
 <context>
@@ -157,37 +185,37 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>错误分区：%1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation type="unfinished"></translation>
+        <translation>启动fat32format命令时出错</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>运行fat32format时出错：%1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation type="unfinished"></translation>
+        <translation>确定新驱动器号时出错</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
         <source>Invalid device: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>无效的设备：%1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation type="unfinished"></translation>
+        <translation>格式化错误</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation type="unfinished"></translation>
+        <translation>启动sfdisk命令时出错</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
@@ -197,43 +225,43 @@
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation type="unfinished"></translation>
+        <translation>启动mkfs.fat时出错</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>运行mkfs.fat时出错：%1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation type="unfinished"></translation>
+        <translation>暂不支持此平台的格式化</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <location filename="../imagewriter.cpp" line="252"/>
+        <location filename="../imagewriter.cpp" line="248"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation type="unfinished"></translation>
+        <translation>存储容量不足。&lt;br&gt;至少需要%1 GB的空白空间.</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="258"/>
+        <location filename="../imagewriter.cpp" line="254"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation type="unfinished"></translation>
+        <translation>输入文件不是有效的磁盘映像。&lt;br&gt;文件大小%1字节不是512字节的倍数。</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="446"/>
+        <location filename="../imagewriter.cpp" line="442"/>
         <source>Downloading and writing image</source>
-        <translation type="unfinished"></translation>
+        <translation>下载和写入镜像</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="579"/>
+        <location filename="../imagewriter.cpp" line="575"/>
         <source>Select image</source>
-        <translation type="unfinished"></translation>
+        <translation>选择镜像</translation>
     </message>
     <message>
-        <location filename="../imagewriter.cpp" line="971"/>
+        <location filename="../imagewriter.cpp" line="896"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -243,12 +271,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>导入系统镜像</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation type="unfinished"></translation>
+        <translation>打开图像文件时出错</translation>
     </message>
 </context>
 <context>
@@ -256,17 +284,17 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation>不</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="109"/>
         <source>YES</source>
-        <translation type="unfinished"></translation>
+        <translation>是</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="120"/>
         <source>CONTINUE</source>
-        <translation type="unfinished"></translation>
+        <translation>继续</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="130"/>
@@ -279,22 +307,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>Advanced options</source>
-        <translation type="unfinished"></translation>
+        <translation>高级设置</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>Image customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>镜像自定义选项</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
         <source>for this session only</source>
-        <translation type="unfinished"></translation>
+        <translation>仅限本次</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="58"/>
         <source>to always use</source>
-        <translation type="unfinished"></translation>
+        <translation>永久保存</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="71"/>
@@ -314,7 +342,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="98"/>
         <source>Set hostname:</source>
-        <translation type="unfinished"></translation>
+        <translation>设置主机名：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="120"/>
@@ -330,22 +358,22 @@
         <location filename="../OptionsPopup.qml" line="158"/>
         <location filename="../OptionsPopup.qml" line="219"/>
         <source>Password:</source>
-        <translation type="unfinished"></translation>
+        <translation>密码：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="186"/>
         <source>Configure wireless LAN</source>
-        <translation type="unfinished"></translation>
+        <translation>配置WiFi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="205"/>
         <source>SSID:</source>
-        <translation type="unfinished"></translation>
+        <translation>热点名：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="238"/>
         <source>Show password</source>
-        <translation type="unfinished"></translation>
+        <translation>显示密码</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="244"/>
@@ -355,42 +383,42 @@
     <message>
         <location filename="../OptionsPopup.qml" line="250"/>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished"></translation>
+        <translation>WIFI国家：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="261"/>
         <source>Set locale settings</source>
-        <translation type="unfinished"></translation>
+        <translation>语言设置</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="271"/>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>时区：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="281"/>
         <source>Keyboard layout:</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘布局：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="298"/>
         <source>Enable SSH</source>
-        <translation type="unfinished"></translation>
+        <translation>开启SSH服务</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="317"/>
         <source>Use password authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>使用密码登录</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="327"/>
         <source>Allow public-key authentication only</source>
-        <translation type="unfinished"></translation>
+        <translation>只允许使用公匙登录</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="345"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation type="unfinished"></translation>
+        <translation>设置%1用户的登录密匙：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="357"/>
@@ -400,22 +428,38 @@
     <message>
         <location filename="../OptionsPopup.qml" line="375"/>
         <source>Play sound when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>完成后播放提示音</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="379"/>
         <source>Eject media when finished</source>
-        <translation type="unfinished"></translation>
+        <translation>完成后弹出磁盘</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="383"/>
         <source>Enable telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>启用遥测</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="397"/>
         <source>SAVE</source>
-        <translation type="unfinished"></translation>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <source>Disable overscan</source>
+        <translation type="vanished">禁用扫描</translation>
+    </message>
+    <message>
+        <source>Set password for &apos;%1&apos; user:</source>
+        <translation type="vanished">设置&apos;%1&apos;用户的密码：</translation>
+    </message>
+    <message>
+        <source>Skip first-run wizard</source>
+        <translation type="vanished">跳过首次启动向导</translation>
+    </message>
+    <message>
+        <source>Persistent settings</source>
+        <translation type="vanished">永久设置</translation>
     </message>
 </context>
 <context>
@@ -423,7 +467,7 @@
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation type="unfinished"></translation>
+        <translation>内置SD卡读卡器</translation>
     </message>
 </context>
 <context>
@@ -434,29 +478,29 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="88"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="87"/>
         <source>Would you like to apply image customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="98"/>
-        <source>EDIT SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="108"/>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="119"/>
-        <source>YES</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../UseSavedSettingsPopup.qml" line="130"/>
+        <location filename="../UseSavedSettingsPopup.qml" line="97"/>
         <source>NO</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">不</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="107"/>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>清空所有设置</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="117"/>
+        <source>YES</source>
+        <translation>是</translation>
+    </message>
+    <message>
+        <location filename="../UseSavedSettingsPopup.qml" line="127"/>
+        <source>EDIT SETTINGS</source>
+        <translation>编辑设置</translation>
     </message>
 </context>
 <context>
@@ -464,7 +508,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation type="unfinished"></translation>
+        <translation>树莓派镜像烧录器 v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="114"/>
@@ -483,60 +527,65 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="152"/>
-        <location filename="../main.qml" line="576"/>
+        <location filename="../main.qml" line="97"/>
+        <location filename="../main.qml" line="413"/>
         <source>Operating System</source>
-        <translation type="unfinished"></translation>
+        <translation>请选择需要写入的操作系统</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="163"/>
+        <location filename="../main.qml" line="109"/>
         <source>CHOOSE OS</source>
-        <translation type="unfinished"></translation>
+        <translation>选择操作系统</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="175"/>
+        <location filename="../main.qml" line="121"/>
         <source>Select this button to change the operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>更改操作系统</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="189"/>
-        <location filename="../main.qml" line="957"/>
+        <location filename="../main.qml" line="133"/>
+        <location filename="../main.qml" line="780"/>
         <source>Storage</source>
-        <translation type="unfinished"></translation>
+        <translation>储存卡</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="200"/>
-        <location filename="../main.qml" line="1286"/>
+        <location filename="../main.qml" line="145"/>
+        <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>
-        <translation type="unfinished"></translation>
+        <translation>选择SD卡</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="214"/>
+        <location filename="../main.qml" line="155"/>
         <source>Select this button to change the destination storage device</source>
-        <translation type="unfinished"></translation>
+        <translation>选择此按钮以更改目标存储设备</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="261"/>
+        <location filename="../main.qml" line="171"/>
+        <source>WRITE</source>
+        <translation>烧录</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="216"/>
         <source>CANCEL WRITE</source>
-        <translation type="unfinished"></translation>
+        <translation>取消写入</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="264"/>
-        <location filename="../main.qml" line="1213"/>
+        <location filename="../main.qml" line="219"/>
+        <location filename="../main.qml" line="1035"/>
         <source>Cancelling...</source>
-        <translation type="unfinished"></translation>
+        <translation>取消...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="276"/>
+        <location filename="../main.qml" line="227"/>
         <source>CANCEL VERIFY</source>
-        <translation type="unfinished"></translation>
+        <translation>取消验证</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="279"/>
-        <location filename="../main.qml" line="1236"/>
-        <location filename="../main.qml" line="1305"/>
+        <location filename="../main.qml" line="230"/>
+        <location filename="../main.qml" line="1058"/>
+        <location filename="../main.qml" line="1127"/>
         <source>Finalizing...</source>
-        <translation type="unfinished"></translation>
+        <translation>正在完成...</translation>
     </message>
     <message>
         <location filename="../main.qml" line="288"/>
@@ -544,187 +593,213 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="294"/>
+        <location filename="../main.qml" line="175"/>
         <source>Select this button to start writing the image</source>
+        <translation>开始写入</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="245"/>
+        <source>Select this button to access advanced settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="316"/>
+        <location filename="../main.qml" line="259"/>
         <source>Using custom repository: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="325"/>
+        <location filename="../main.qml" line="268"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="346"/>
+        <location filename="../main.qml" line="289"/>
         <source>Language: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="369"/>
+        <location filename="../main.qml" line="312"/>
         <source>Keyboard: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="490"/>
+        <location filename="../main.qml" line="437"/>
+        <source>Pi model:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="448"/>
         <source>[ All ]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../main.qml" line="638"/>
+        <location filename="../main.qml" line="528"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation>返回</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="639"/>
+        <location filename="../main.qml" line="529"/>
         <source>Go back to main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>回到主页</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="872"/>
+        <location filename="../main.qml" line="695"/>
         <source>Released: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>发布时间：%1</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="882"/>
+        <location filename="../main.qml" line="705"/>
         <source>Cached on your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>缓存在本地磁盘里</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="884"/>
+        <location filename="../main.qml" line="707"/>
         <source>Local file</source>
-        <translation type="unfinished"></translation>
+        <translation>本地文件</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="708"/>
         <source>Online - %1 GB download</source>
-        <translation type="unfinished"></translation>
+        <translation>需要下载：%1 GB</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1010"/>
-        <location filename="../main.qml" line="1062"/>
-        <location filename="../main.qml" line="1068"/>
+        <location filename="../main.qml" line="833"/>
+        <location filename="../main.qml" line="885"/>
+        <location filename="../main.qml" line="891"/>
         <source>Mounted as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>挂载到：%1 上</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1064"/>
+        <location filename="../main.qml" line="887"/>
         <source>[WRITE PROTECTED]</source>
-        <translation type="unfinished"></translation>
+        <translation>[写保护]</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1106"/>
+        <location filename="../main.qml" line="929"/>
         <source>Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>你确定你要退出吗？</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1107"/>
+        <location filename="../main.qml" line="930"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager还未完成任务。&lt;br&gt;您确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1118"/>
+        <location filename="../main.qml" line="941"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>警告</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1126"/>
+        <location filename="../main.qml" line="949"/>
         <source>Preparing to write...</source>
-        <translation type="unfinished"></translation>
+        <translation>准备写入...</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1140"/>
+        <location filename="../main.qml" line="962"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos;上的所有现有数据将被删除。&lt;br&gt;确定要继续吗？</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1151"/>
+        <location filename="../main.qml" line="973"/>
         <source>Update available</source>
-        <translation type="unfinished"></translation>
+        <translation>检测到更新</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1152"/>
+        <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>有较新版本的rpi-imager。&lt;br&gt;需要下载更新吗？</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1195"/>
+        <location filename="../main.qml" line="1017"/>
         <source>Error downloading OS list from Internet</source>
-        <translation type="unfinished"></translation>
+        <translation>下载镜像列表错误</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1216"/>
+        <location filename="../main.qml" line="1038"/>
         <source>Writing... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>写入中...%1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1239"/>
+        <location filename="../main.qml" line="1061"/>
         <source>Verifying... %1%</source>
-        <translation type="unfinished"></translation>
+        <translation>验证文件中...%1%</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1246"/>
+        <location filename="../main.qml" line="1068"/>
         <source>Preparing to write... (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>写入中 (%1)</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1262"/>
+        <location filename="../main.qml" line="1084"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation>错误</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1269"/>
+        <location filename="../main.qml" line="1091"/>
         <source>Write Successful</source>
-        <translation type="unfinished"></translation>
+        <translation>烧录成功</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1270"/>
-        <location filename="../main.qml" line="1523"/>
+        <location filename="../main.qml" line="572"/>
+        <location filename="../main.qml" line="1092"/>
         <source>Erase</source>
-        <translation type="unfinished"></translation>
+        <translation>擦除</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1271"/>
+        <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1 &lt;/ b&gt;已被删除&lt;br&gt; &lt;br&gt;您现在可以从读取器中取出SD卡</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1278"/>
+        <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; 已经成功烧录到 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;上了，你可以卸载SD卡了</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1423"/>
+        <location filename="../main.qml" line="1202"/>
         <source>Error parsing os_list.json</source>
-        <translation type="unfinished"></translation>
+        <translation>解析 os_list.json 错误</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1524"/>
+        <location filename="../main.qml" line="573"/>
         <source>Format card as FAT32</source>
-        <translation type="unfinished"></translation>
+        <translation>将SD卡格式化为FAT32格式</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1533"/>
+        <location filename="../main.qml" line="582"/>
         <source>Use custom</source>
-        <translation type="unfinished"></translation>
+        <translation>使用自定义镜像</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1534"/>
+        <location filename="../main.qml" line="583"/>
         <source>Select a custom .img from your computer</source>
-        <translation type="unfinished"></translation>
+        <translation>使用下载的系统镜像文件烧录</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1681"/>
+        <location filename="../main.qml" line="1391"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation type="unfinished"></translation>
+        <translation>连接包含镜像的U盘。&lt;br&gt;镜像必须位于U盘的根文件夹中。</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="1697"/>
+        <location filename="../main.qml" line="1407"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation type="unfinished"></translation>
+        <translation>SD卡具有写保护。&lt;br&gt;尝试向上推SD卡的左侧的锁定开关，然后重试。</translation>
+    </message>
+    <message>
+        <source>Select this button to change the destination SD card</source>
+        <translation type="vanished">更改目标SD卡</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; 已经成功烧录到 &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <source>QUIT APP</source>
+        <translation type="vanished">退出</translation>
+    </message>
+    <message>
+        <source>CONTINUE</source>
+        <translation type="vanished">继续</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
This reverts commit 2fb58dc01c1159f1ea11b056f086e9fc21c5c281.

The original commit included an unexpected deletion of _all_ translations in certain languages. This was unintented, and appears to have been a merging artefact.

This change will be re-submitted as a separate PR.