### PR TITLE
Remove padding from progress bar

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -237,7 +237,6 @@ ApplicationWindow {
 
                     ProgressBar {
                         Layout.bottomMargin: 25
-                        padding: 5
                         id: progressBar
                         Layout.fillWidth: true
                         visible: false


### PR DESCRIPTION
Seems like there's a weird Qt bug in the ProgressBar widget where giving it padding means the white progress indicator doesn't actually start at the left edge of the bar or extend to the right edge of the bar.  So just remove the padding from ProgressBar because it's not doing much.

Before: 
![image](https://github.com/raspberrypi/rpi-imager/assets/1373016/a196350d-bff7-412f-ad48-ff927e52cbb5)
After: 
![image](https://github.com/raspberrypi/rpi-imager/assets/1373016/e741da02-1755-4e57-ac2a-31464f5f55dd)
