### PR TITLE
Embedded: Automatically apply patches

### DIFF
--- a/embedded/imager/package/rpi-imager/0001-rpi-imager-change-window-to-popup.patch
+++ b/embedded/imager/package/rpi-imager/0001-rpi-imager-change-window-to-popup.patch
@@ -1,7 +1,7 @@
-diff --git a/src/OptionsPopup.qml b/src/OptionsPopup.qml
+diff --git src/OptionsPopup.qml src/OptionsPopup.qml
 index 568d1cd..9e36607 100644
---- a/src/OptionsPopup.qml
-+++ b/src/OptionsPopup.qml
+--- src/OptionsPopup.qml
++++ src/OptionsPopup.qml
 @@ -10,13 +10,19 @@ import QtQuick.Controls.Material 2.2
  import QtQuick.Window 2.15
  import "qmlcomponents"

--- a/embedded/imager/package/rpi-imager/rpi-imager.mk
+++ b/embedded/imager/package/rpi-imager/rpi-imager.mk
@@ -12,4 +12,12 @@ RPI_IMAGER_LICENSE = Apache-2.0
 
 RPI_IMAGER_DEPENDENCIES = qt5base qt5declarative qt5quickcontrols2 qt5svg qt5tools libarchive libcurl openssl
 
+# Patches are automatically applied after download and extract, but when using
+# a local site there is no download-extract so the patches don't get applied.
+# Add a hook to do it manually when using the local site.
+define RPI_IMAGER_APPLY_PATCHES
+	$(APPLY_PATCHES) $(@D) $(RPI_IMAGER_PKGDIR) *.patch
+endef
+RPI_IMAGER_POST_RSYNC_HOOKS += RPI_IMAGER_APPLY_PATCHES
+
 $(eval $(cmake-package))


### PR DESCRIPTION
When using local site, buildroot does not automatically apply patches. The buildroot manual recommends using the POST_RSYNC hook to apply patches if needed, so implement this to automatically apply patches.

Resolves #671