### PR TITLE
OS customization rebrand, consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ On macOS, disable it by editing the property list for the application:
 defaults write org.raspberrypi.Imager.plist telemetry -bool NO
 ```
 
-### Advanced options
+### OS Customization
 
-When using the app, press <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>X</kbd> to reveal the **Advanced options** dialog.
+When using the app, press <kbd>CTRL</kbd> + <kbd>SHIFT</kbd> + <kbd>X</kbd> to reveal the **OS Customization** dialog.
 
 In here, you can specify several things you would otherwise set in the boot configuration files. For example, you can enable SSH, set the Wi-Fi login, and specify your locale settings for the system image.

--- a/embedded/imager/package/rpi-imager/0001-rpi-imager-change-window-to-popup.patch
+++ b/embedded/imager/package/rpi-imager/0001-rpi-imager-change-window-to-popup.patch
@@ -24,6 +24,6 @@ index 568d1cd..9e36607 100644
 +    function raise() { }
 +    /*  */
 +
-     title: qsTr("Advanced options")
+     title: qsTr("OS Customization")
  
      property bool initialized: false

--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -830,22 +830,46 @@ Window {
 
     function clearCustomizationFields()
     {
-        fieldHostname.clear()
-        fieldUserName.clear()
+        /* Bind copies of the lists */
+        fieldTimezone.model = imageWriter.getTimezoneList()
+        fieldKeyboardLayout.model = imageWriter.getKeymapLayoutList()
+        fieldWifiCountry.model = imageWriter.getCountryList()
+
+        fieldHostname.text = "raspberrypi"
+        fieldUserName.text = imageWriter.getCurrentUser()
         fieldUserPassword.clear()
         radioPubKeyAuthentication.checked = false
         radioPasswordAuthentication.checked = false
         fieldPublicKey.clear()
-        fieldWifiSSID.clear()
-        fieldWifiCountry.currentIndex = -1
-        fieldWifiPassword.clear()
-        fieldTimezone.currentIndex = -1
-        fieldKeyboardLayout.currentIndex = -1
+
+        /* Timezone Settings*/
+        fieldTimezone.currentIndex = fieldTimezone.find(imageWriter.getTimezone())
+        /* Lacking an easy cross-platform to fetch keyboard layout
+            from host system, just default to "gb" for people in
+            UK time zone for now, and "us" for everyone else */
+        if (imageWriter.getTimezone() === "Europe/London") {
+            fieldKeyboardLayout.currentIndex = fieldKeyboardLayout.find("gb")
+        } else {
+            fieldKeyboardLayout.currentIndex = fieldKeyboardLayout.find("us")
+        }
+        
         chkSetUser.checked = false
         chkSSH.checked = false
         chkLocale.checked = false
-        chkWifi.checked = false
         chkWifiSSIDHidden.checked = false
         chkHostname.checked = false
+
+        /* WiFi Settings */
+        fieldWifiSSID.text = imageWriter.getSSID()
+        if (fieldWifiSSID.text.length) {
+            fieldWifiPassword.text = imageWriter.getPSK()
+            if (fieldWifiPassword.text.length) {
+                chkShowPassword.checked = false
+                if (Qt.platform.os == "osx") {
+                    /* User indicated wifi must be prefilled */
+                    chkWifi.checked = true
+                }
+            }
+        }
     }
 }

--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -17,7 +17,7 @@ Window {
     maximumWidth: width
     minimumHeight: 125
     height: Math.min(750, cl.implicitHeight)
-    title: qsTr("Advanced options")
+    title: qsTr("OS Customization")
 
     property bool initialized: false
     property bool hasSavedSettings: false
@@ -49,7 +49,7 @@ Window {
 
                 RowLayout {
                     Label {
-                        text: qsTr("Image customization options")
+                        text: qsTr("OS customization options")
                     }
                     ComboBox {
                         id: comboSaveSettings
@@ -539,7 +539,7 @@ Window {
                 /* Lacking an easy cross-platform to fetch keyboard layout
                    from host system, just default to "gb" for people in
                    UK time zone for now, and "us" for everyone else */
-                if (tz == "Europe/London") {
+                if (tz === "Europe/London") {
                     fieldKeyboardLayout.currentIndex = fieldKeyboardLayout.find("gb")
                 } else {
                     fieldKeyboardLayout.currentIndex = fieldKeyboardLayout.find("us")

--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -48,13 +48,6 @@ Window {
             //ScrollBar.vertical.policy: ScrollBar.AlwaysOn
 
             ColumnLayout {
-
-                RowLayout {
-                    Label {
-                        text: qsTr("OS customization options")
-                    }
-                }
-
                 TabBar {
                     id: bar
                     Layout.fillWidth: true

--- a/src/UseSavedSettingsPopup.qml
+++ b/src/UseSavedSettingsPopup.qml
@@ -70,7 +70,7 @@ Popup {
             Layout.topMargin: 10
             font.family: roboto.name
             font.bold: true
-            text: qsTr("Use image customisation?")
+            text: qsTr("Use OS customization?")
         }
 
         Text {
@@ -85,7 +85,7 @@ Popup {
             Layout.topMargin: 25
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
             Accessible.name: text.replace(/<\/?[^>]+(>|$)/g, "")
-            text: qsTr("Would you like to apply image customization settings?")
+            text: qsTr("Would you like to apply OS customization settings?")
         }
 
         RowLayout {
@@ -95,10 +95,10 @@ Popup {
             id: buttons
 
             ImButton {
-                text: qsTr("NO")
+                text: qsTr("EDIT SETTINGS")
                 onClicked: {
                     msgpopup.close()
-                    msgpopup.no()
+                    msgpopup.editSettings()
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
                 Material.background: "#c51a4a"
@@ -127,10 +127,10 @@ Popup {
             }
 
             ImButton {
-                text: qsTr("EDIT SETTINGS")
+                text: qsTr("NO")
                 onClicked: {
                     msgpopup.close()
-                    msgpopup.editSettings()
+                    msgpopup.no()
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
                 Material.background: "#c51a4a"

--- a/src/UseSavedSettingsPopup.qml
+++ b/src/UseSavedSettingsPopup.qml
@@ -18,6 +18,8 @@ Popup {
     padding: 0
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
+    property bool hasSavedSettings: false
+
     signal yes()
     signal no()
     signal noClearSettings()
@@ -105,6 +107,7 @@ Popup {
             }
 
             ImButton {
+                id: noAndClearButton
                 text: qsTr("NO, CLEAR SETTINGS")
                 onClicked: {
                     msgpopup.close()
@@ -112,10 +115,11 @@ Popup {
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
                 Material.background: "#c51a4a"
-                enabled: imageWriter.hasSavedCustomizationSettings() ? true : false
+                enabled: false
             }
 
             ImButton {
+                id: yesButton
                 text: qsTr("YES")
                 onClicked: {
                     msgpopup.close()
@@ -123,7 +127,7 @@ Popup {
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
                 Material.background: "#c51a4a"
-                enabled: imageWriter.hasSavedCustomizationSettings() ? true : false
+                enabled: false
             }
 
             ImButton {
@@ -142,6 +146,16 @@ Popup {
 
     function openPopup() {
         open()
+        if (hasSavedSettings) {
+            /* HACK: Bizarrely, the button enabled characteristics are not re-evaluated on open.
+             * So, let's manually _force_ these buttons to be enabled */
+            yesButton.enabled = true
+            noAndClearButton.enabled = true
+        } else {
+            yesButton.enabled = false
+            noAndClearButton.enabled = false
+        }
+
         // trigger screen reader to speak out message
         msgpopupbody.forceActiveFocus()
     }

--- a/src/i18n/rpi-imager_ca.ts
+++ b/src/i18n/rpi-imager_ca.ts
@@ -282,13 +282,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Opcions avançades</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Opcions de personalització de les imatges</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_de.ts
+++ b/src/i18n/rpi-imager_de.ts
@@ -319,13 +319,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Erweiterte Optionen</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>OS-Modifizierungen</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_en.ts
+++ b/src/i18n/rpi-imager_en.ts
@@ -278,12 +278,12 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
+        <source>OS customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
+        <source>OS customization options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/rpi-imager_es.ts
+++ b/src/i18n/rpi-imager_es.ts
@@ -282,13 +282,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Opciones avanzadas</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Opciones de personalización de imagen</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_fr.ts
+++ b/src/i18n/rpi-imager_fr.ts
@@ -318,13 +318,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Réglages avancés</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Options de personnalisation de l&apos;image</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_it.ts
+++ b/src/i18n/rpi-imager_it.ts
@@ -319,13 +319,13 @@ Aggiungi sia &apos;rpi-imager.exe&apos; che &apos;fat32format.exe&apos; all&apos
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Opzioni avanzate</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Opzioni personalizzazione immagine</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_ja.ts
+++ b/src/i18n/rpi-imager_ja.ts
@@ -318,13 +318,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>詳細な設定</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>イメージカスタマイズオプション</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_ko.ts
+++ b/src/i18n/rpi-imager_ko.ts
@@ -318,13 +318,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>고급 옵션</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>이미지 사용자 정의 옵션</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_nl.ts
+++ b/src/i18n/rpi-imager_nl.ts
@@ -318,13 +318,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Geavanceerde instellingen</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Image instellingen</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_ru.ts
+++ b/src/i18n/rpi-imager_ru.ts
@@ -318,13 +318,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Дополнительные параметры</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Параметры настройки образа</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_sk.ts
+++ b/src/i18n/rpi-imager_sk.ts
@@ -318,13 +318,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Pokročilé možnosti</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Možnosti úprav obrazu</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_sl.ts
+++ b/src/i18n/rpi-imager_sl.ts
@@ -318,13 +318,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Napredne možnosti</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Uporabi opcije prilagoditve slike diska</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_tr.ts
+++ b/src/i18n/rpi-imager_tr.ts
@@ -290,12 +290,12 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
+        <source>OS customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
+        <source>OS customization options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/rpi-imager_uk.ts
+++ b/src/i18n/rpi-imager_uk.ts
@@ -282,13 +282,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>Розширені налаштування</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>Налаштування образу</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -306,13 +306,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>Advanced options</source>
-        <translation>高级设置</translation>
+        <source>OS customization</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
-        <source>Image customization options</source>
-        <translation>镜像自定义选项</translation>
+        <source>OS customization options</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -1039,6 +1039,7 @@ void ImageWriter::setSavedCustomizationSettings(const QVariantMap &map)
         _settings.setValue(key, map.value(key));
     }
     _settings.endGroup();
+    _settings.sync();
 }
 
 QVariantMap ImageWriter::getSavedCustomizationSettings()
@@ -1060,10 +1061,12 @@ void ImageWriter::clearSavedCustomizationSettings()
     _settings.beginGroup("imagecustomization");
     _settings.remove("");
     _settings.endGroup();
+    _settings.sync();
 }
 
 bool ImageWriter::hasSavedCustomizationSettings()
 {
+    _settings.sync();
     _settings.beginGroup("imagecustomization");
     bool result = !_settings.childKeys().isEmpty();
     _settings.endGroup();

--- a/src/main.qml
+++ b/src/main.qml
@@ -1183,6 +1183,10 @@ ApplicationWindow {
 
     OptionsPopup {
         id: optionspopup
+        onSaveSettingsSignal: {
+            imageWriter.setSavedCustomizationSettings(settings)
+            usesavedsettingspopup.hasSavedSettings = true
+        }
     }
 
     UseSavedSettingsPopup {
@@ -1196,6 +1200,8 @@ ApplicationWindow {
             confirmwritepopup.askForConfirmation()
         }
         onNoClearSettings: {
+            hasSavedSettings = false
+            optionspopup.clearCustomizationFields()
             imageWriter.clearSavedCustomizationSettings()
             confirmwritepopup.askForConfirmation()
         }


### PR DESCRIPTION
In the new flow, it doesn't make sense to _not_ save the OS
customization parameters, so remove the ComboBox.

Additionally, our data model was failing to notify the UI of changes to
the saved settings state. Due to time constraints, I'm not able to
resolve the binding in the 'correct' manner, but I can introduce a
makeshift status signalling mechanism to prevent UI inconsistency