### PR TITLE
Don't hide "use customization" msgbox when editing settings

### DIFF
--- a/src/UseSavedSettingsPopup.qml
+++ b/src/UseSavedSettingsPopup.qml
@@ -17,6 +17,7 @@ Popup {
     height: msgpopupbody.implicitHeight+150
     padding: 0
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    modal: true
 
     property bool hasSavedSettings: false
 
@@ -24,6 +25,7 @@ Popup {
     signal no()
     signal noClearSettings()
     signal editSettings()
+    signal closeSettings()
 
     // background of title
     Rectangle {
@@ -99,7 +101,11 @@ Popup {
             ImButton {
                 text: qsTr("EDIT SETTINGS")
                 onClicked: {
-                    msgpopup.close()
+                    // Don't close this dialog when "edit settings" is
+                    // clicked, as we don't want the user to fall back to the
+                    // start of the flow. After editing the settings we want
+                    // then to once again have the choice about whether to use
+                    // customisation or not.
                     msgpopup.editSettings()
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
@@ -115,7 +121,7 @@ Popup {
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
                 Material.background: "#c51a4a"
-                enabled: false
+                enabled: hasSavedSettings
             }
 
             ImButton {
@@ -127,7 +133,7 @@ Popup {
                 }
                 Material.foreground: activeFocus ? "#d1dcfb" : "#ffffff"
                 Material.background: "#c51a4a"
-                enabled: false
+                enabled: hasSavedSettings
             }
 
             ImButton {
@@ -146,17 +152,20 @@ Popup {
 
     function openPopup() {
         open()
-        if (hasSavedSettings) {
+        if (imageWriter.hasSavedCustomizationSettings()) {
             /* HACK: Bizarrely, the button enabled characteristics are not re-evaluated on open.
              * So, let's manually _force_ these buttons to be enabled */
-            yesButton.enabled = true
-            noAndClearButton.enabled = true
-        } else {
-            yesButton.enabled = false
-            noAndClearButton.enabled = false
+            hasSavedSettings = true
         }
 
         // trigger screen reader to speak out message
         msgpopupbody.forceActiveFocus()
+    }
+
+    onClosed: {
+        // Close the advanced options window if this msgbox is dismissed,
+        // in order to prevent the user from starting writing while the
+        // advanced options window is open.
+        closeSettings()
     }
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -1208,6 +1208,9 @@ ApplicationWindow {
         onEditSettings: {
             optionspopup.openPopup()
         }
+        onCloseSettings: {
+            optionspopup.close()
+        }
     }
 
     /* Utility functions */


### PR DESCRIPTION
Previously, if you clicked "edit settings" in the "use customisation" msgbox then the flow got a bit confusing, when you saved settings the "use customisation" msgbox would have disappeared and you had to click "next" and go back through again.  Instead, keep the "use customisation" msgbox open when editing settings so when you save settings you are back where you left it.

Also:
- Make "use customisation" modal so you can't click other things while it's open
- Separate windows in QtQuick can't be modal so we can't stop the user interacting with the main window while "edit settings" is open.  This could get confusing, so if they close the "use customisation" modal in the main window then close the settings window.
- Fix a bug where saved settings weren't recognised on startup, only after being saved during the session