### PR TITLE
Fix various keyboard focus issues

### DIFF
--- a/embedded/imager/package/rpi-imager/0001-rpi-imager-change-window-to-popup.patch
+++ b/embedded/imager/package/rpi-imager/0001-rpi-imager-change-window-to-popup.patch
@@ -1,5 +1,5 @@
 diff --git src/OptionsPopup.qml src/OptionsPopup.qml
-index 568d1cd..9e36607 100644
+index c333098..011d7d6 100644
 --- src/OptionsPopup.qml
 +++ src/OptionsPopup.qml
 @@ -10,13 +10,19 @@ import QtQuick.Controls.Material 2.2
@@ -27,3 +27,24 @@ index 568d1cd..9e36607 100644
      title: qsTr("OS Customization")
  
      property bool initialized: false
+diff --git src/main.qml src/main.qml
+index bd76442..f74300c 100644
+--- src/main.qml
++++ src/main.qml
+@@ -1195,6 +1195,16 @@ ApplicationWindow {
+             imageWriter.setSavedCustomizationSettings(settings)
+             usesavedsettingspopup.hasSavedSettings = true
+         }
++        onClosed: {
++            // When the options popup closes on embedded focus doesn't
++            // automatically return to the usesavedsettings msgpopup, so
++            // set the focus manually (but only if this msgpopup is actually
++            // open. It might not be, e.g. if the user opened settings via
++            // the keyboard shortcut).
++            if (usesavedsettingspopup.opened) {
++                usesavedsettingspopup.forceActiveFocus()
++            }
++        }
+     }
+ 
+     UseSavedSettingsPopup {

--- a/src/main.qml
+++ b/src/main.qml
@@ -151,7 +151,7 @@ ApplicationWindow {
                         Layout.fillWidth: true
                         onClicked: {
                             hwpopup.open()
-                            hwlist.currentItem.forceActiveFocus()
+                            hwlist.forceActiveFocus()
                         }
                         Accessible.ignored: ospopup.visible || dstpopup.visible || hwpopup.visible
                         Accessible.description: qsTr("Select this button to choose your target Raspberry Pi")
@@ -1122,6 +1122,9 @@ ApplicationWindow {
 
     MsgPopup {
         id: msgpopup
+        onOpened: {
+            forceActiveFocus()
+        }
     }
 
     MsgPopup {
@@ -1142,6 +1145,7 @@ ApplicationWindow {
         yesButton: true
         noButton: true
         title: qsTr("Warning")
+        modal: true
         onYes: {
             langbarRect.visible = false
             writebutton.visible = false
@@ -1165,6 +1169,10 @@ ApplicationWindow {
         {
             text = qsTr("All existing data on '%1' will be erased.<br>Are you sure you want to continue?").arg(dstbutton.text)
             openPopup()
+        }
+
+        onOpened: {
+            forceActiveFocus()
         }
     }
 


### PR DESCRIPTION
- Make write confirmation popup modal
- Force focus on the write confirmation popup when it opens
- Force focus on the error popup when it opens
- When the hw select popup opens, force focus on the ListView instead of on the currentItem, because the latter doesn't work when the list is empty.
- On embedded, when the settings popup closes, force focus back to the usecustomisation dialog