### PR TITLE
i18n: Remove broken translations

### DIFF
--- a/src/i18n/rpi-imager_ca.ts
+++ b/src/i18n/rpi-imager_ca.ts
@@ -282,7 +282,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -438,12 +438,12 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
+        <source>Use OS customization?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
+        <source>Would you like to apply OS customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/rpi-imager_de.ts
+++ b/src/i18n/rpi-imager_de.ts
@@ -319,7 +319,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -487,13 +487,13 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
+        <source>Use OS customization?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation>Möchten Sie die vorher festgelegten OS-Modifizierungen anwenden?</translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_en.ts
+++ b/src/i18n/rpi-imager_en.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en_US">
+<TS version="2.1" language="en_GB">
 <context>
     <name>DownloadExtractThread</name>
     <message>
@@ -147,7 +147,7 @@
     <message>
         <location filename="../downloadthread.cpp" line="898"/>
         <source>Customizing image</source>
-        <translation type="unfinished"></translation>
+        <translation>Customising OS</translation>
     </message>
 </context>
 <context>
@@ -278,13 +278,13 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
-        <translation type="unfinished"></translation>
+        <source>OS Customization</source>
+        <translation>OS Customisation</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="52"/>
         <source>OS customization options</source>
-        <translation type="unfinished"></translation>
+        <translation>OS customisation options</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="57"/>
@@ -430,13 +430,13 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
-        <translation type="unfinished"></translation>
+        <source>Use OS customization?</source>
+        <translation>Use OS customisation?</translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation type="unfinished"></translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation>Would you like to apply OS customisation settings?</translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_es.ts
+++ b/src/i18n/rpi-imager_es.ts
@@ -282,7 +282,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -438,13 +438,13 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
-        <translation>¿Usar la personalización de imágenes?</translation>
+        <source>Use OS customization?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation>¿Desea aplicar los ajustes de personalización de la imagen?</translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_fr.ts
+++ b/src/i18n/rpi-imager_fr.ts
@@ -318,7 +318,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -474,13 +474,13 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
-        <translation>Utiliser la personnalisation&#xa0;?</translation>
+        <source>Use OS customization?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation>Voulez-vous applquer les réglages personnalisés de l&apos;image&#xa0;?</translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_it.ts
+++ b/src/i18n/rpi-imager_it.ts
@@ -319,7 +319,7 @@ Aggiungi sia &apos;rpi-imager.exe&apos; che &apos;fat32format.exe&apos; all&apos
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -491,13 +491,13 @@ Aggiungi sia &apos;rpi-imager.exe&apos; che &apos;fat32format.exe&apos; all&apos
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
-        <translation>Vuoi usare personalizzazione immagini?</translation>
+        <source>Use OS customization?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation>Vuoi applicare impostazioni personalizzazione immagine?</translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_ja.ts
+++ b/src/i18n/rpi-imager_ja.ts
@@ -318,7 +318,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -482,13 +482,13 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
-        <translation>イメージカスタマイズを使用しますか？</translation>
+        <source>Use OS customization?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation>イメージカスタマイズ設定を適用しますか？</translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_ko.ts
+++ b/src/i18n/rpi-imager_ko.ts
@@ -318,7 +318,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -482,12 +482,12 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
+        <source>Use OS customization?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
+        <source>Would you like to apply OS customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/rpi-imager_nl.ts
+++ b/src/i18n/rpi-imager_nl.ts
@@ -318,7 +318,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -490,13 +490,13 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
-        <translation>Image aanpassen?</translation>
+        <source>Use OS customization?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation>Wilt u uw eigen instellingen op de image toepassen?</translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_ru.ts
+++ b/src/i18n/rpi-imager_ru.ts
@@ -318,7 +318,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -474,13 +474,13 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
-        <translation>Использовать настройку образа?</translation>
+        <source>Use OS customization?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation>Применить параметры настройки образа?</translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_sk.ts
+++ b/src/i18n/rpi-imager_sk.ts
@@ -318,7 +318,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -490,12 +490,12 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
+        <source>Use OS customization?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
+        <source>Would you like to apply OS customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/rpi-imager_sl.ts
+++ b/src/i18n/rpi-imager_sl.ts
@@ -318,7 +318,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -490,12 +490,12 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
+        <source>Use OS customization?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
+        <source>Would you like to apply OS customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/rpi-imager_tr.ts
+++ b/src/i18n/rpi-imager_tr.ts
@@ -290,7 +290,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -442,12 +442,12 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
+        <source>Use OS customization?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
+        <source>Would you like to apply OS customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/i18n/rpi-imager_uk.ts
+++ b/src/i18n/rpi-imager_uk.ts
@@ -282,7 +282,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -438,13 +438,13 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
-        <translation>Використовувати кастомізацію образу?</translation>
+        <source>Use OS customization?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
-        <translation>Чи бажаєте ви прийняти налаштування кастомізації образу?</translation>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="97"/>

--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -306,7 +306,7 @@
     <name>OptionsPopup</name>
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
-        <source>OS customization</source>
+        <source>OS Customization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -474,12 +474,12 @@
     <name>UseSavedSettingsPopup</name>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="73"/>
-        <source>Use image customisation?</source>
+        <source>Use OS customization?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="87"/>
-        <source>Would you like to apply image customization settings?</source>
+        <source>Would you like to apply OS customization settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
As part of changing the reference string, these translations will require a rework.

Without this change, any translations would use both the wrong string _and_ fail to get relfected in the UI.