### PR TITLE
Make escape key close OS customisation window

### DIFF
--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -36,6 +36,12 @@ Window {
         spacing: 10
         anchors.fill: parent
 
+        // Keys handlers can only be attached to Items. Window is not an
+        // Item, but ColumnLayout is, so put this handler here.
+        Keys.onEscapePressed: {
+            popup.close()
+        }
+
         ScrollView {
             id: popupbody
             font.family: roboto.name


### PR DESCRIPTION
With the move from OS customisation being a popup to being a separate window, it is no longer closed by the escape key.  Add a handler to restore this behaviour.