### PR TITLE
config: Use ImageList v4

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -8,10 +8,10 @@
 
 
 /* Repository URL */
-#define OSLIST_URL                        "https://downloads.raspberrypi.org/os_list_imagingutility_v3.json"
+#define OSLIST_URL                        "https://downloads.raspberrypi.org/os_list_imagingutility_v4.json"
 
 /* Time synchronization URL (only used on eglfs QPA platform, URL must be HTTP) */
-#define TIME_URL                          "http://downloads.raspberrypi.org/os_list_imagingutility_v3.json?time_synchronization"
+#define TIME_URL                          "http://downloads.raspberrypi.org/os_list_imagingutility_v4.json?time_synchronization"
 
 /* Phone home the name of images downloaded for image popularity ranking */
 #define TELEMETRY_URL                     "https://rpi-imager-stats.raspberrypi.com/downloads"


### PR DESCRIPTION
In order to ensure the 'Recommended' tag shows up for older versions of the Imager, we should migrate to using V4 for the version where we move the tag out of the JSON file.