### PR TITLE
Also customize image if only a cloudinit payload exists

### DIFF
--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -730,7 +730,7 @@ void DownloadThread::_writeComplete()
 
     emit finalizing();
 
-    if (!_config.isEmpty() || !_cmdline.isEmpty() || !_firstrun.isEmpty())
+    if (!_config.isEmpty() || !_cmdline.isEmpty() || !_firstrun.isEmpty() || !_cloudinit.isEmpty())
     {
         if (!_customizeImage())
         {


### PR DESCRIPTION
Currently you can configure cloudinit-userdata and cloudinit-networkconfig via the CLI, however due to a check around the customizeImage call it would never be applied.