### PR TITLE
qml: Disable disk cache entirely

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,6 +140,16 @@ int main(int argc, char *argv[])
     }
 
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
+    /** QtQuick on QT5 exhibits spurious disk cache failures that cannot be
+     * resolved by a user in a trivial manner (they have to delete the cache manually).
+     * 
+     * This flag can potentially noticeably increase the start time of the application, however
+     * between this and a hard-to-detect spurious failure affecting Linux, macOS and Windows,
+     * this trade is the one most likely to result in a good experience for the widest group
+     * of users.
+     */
+    qputenv("QML_DISABLE_DISK_CACHE", "true");
 #ifdef Q_OS_WIN
     // prefer ANGLE (DirectX) over desktop OpenGL
     QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);


### PR DESCRIPTION
This is a compromised change. Essentially, I'm working around a poorly-understood failure mode in Qt5, where the disk cache can occasionally fail to invalidate, resulting in stale compiled units being used.

This will increase application start times in favour of correctness.

Likely to resolve #707