### PR TITLE
Remove default asignees from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Thanks for the report!
 title: "[BUG]"
 labels: bug
-assignees: cillian64, tdewey-rpi
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature request
 about: What would you like to see from rpi-imager?
 title: "[FEATURE]"
 labels: enhancement
-assignees: cillian64, tdewey-rpi
 
 ---
 


### PR DESCRIPTION
We'll set assignees when actually working on issues instead of having every issue assigned when created.