### PR TITLE
qml: move OS list fetch to backend

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -472,6 +472,12 @@ namespace {
 } // namespace anonymous
 
 
+void ImageWriter::setHWFilterList(const QByteArray &json) {
+    QJsonDocument json_document = QJsonDocument::fromJson(json);
+
+    _deviceFilter = json_document.array();
+}
+
 void ImageWriter::handleNetworkRequestFinished(QNetworkReply *data) {
     // Defer deletion
     data->deleteLater();

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -486,18 +486,18 @@ void ImageWriter::handleNetworkRequestFinished(QNetworkReply *data) {
         auto httpStatusCode = data->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
         if (httpStatusCode >= 200 && httpStatusCode < 300) {
-            auto responseDoc = QJsonDocument::fromJson(data->readAll()).object();
+            auto response_object = QJsonDocument::fromJson(data->readAll()).object();
 
-            if (responseDoc.contains("os_list")) {
+            if (response_object.contains("os_list")) {
                 // Step 1: Insert the items into the canonical JSON document.
                 //         It doesn't matter that these may still contain subitems_url items
                 //         As these will be fixed up as the subitems_url instances are blinked in
                 if (_completeOsList.isEmpty()) {
                     std::lock_guard<std::mutex> lock(_deviceListMutationMutex);
-                    _completeOsList = QJsonDocument(responseDoc);
+                    _completeOsList = QJsonDocument(response_object);
                 } else {
                     std::lock_guard<std::mutex> lock(_deviceListMutationMutex);
-                    auto new_list = findAndInsertJsonResult(_completeOsList["os_list"].toArray(), responseDoc["os_list"].toArray(), data->url());
+                    auto new_list = findAndInsertJsonResult(_completeOsList["os_list"].toArray(), response_object["os_list"].toArray(), data->url());
                     auto imager_meta = _completeOsList["imager"].toObject();
                     _completeOsList = QJsonDocument(QJsonObject({
                         {"imager", imager_meta},
@@ -505,7 +505,7 @@ void ImageWriter::handleNetworkRequestFinished(QNetworkReply *data) {
                     }));
                 }
 
-                findAndQueueUnresolvedSubitemsJson(responseDoc["os_list"].toArray(), _networkManager.get());
+                findAndQueueUnresolvedSubitemsJson(response_object["os_list"].toArray(), _networkManager.get());
                 emit osListPrepared();
             } else {
                 qDebug() << "Incorrectly formatted OS list at: " << data->url();

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -476,7 +476,6 @@ namespace {
 
 
 void ImageWriter::setHWFilterList(const QByteArray &json, const bool &inclusive) {
-    std::lock_guard<std::mutex> lock(_deviceListMutationMutex);
     QJsonDocument json_document = QJsonDocument::fromJson(json);
     _deviceFilter = json_document.array();
     _deviceFilterIsInclusive = inclusive;
@@ -497,10 +496,8 @@ void ImageWriter::handleNetworkRequestFinished(QNetworkReply *data) {
                 //         It doesn't matter that these may still contain subitems_url items
                 //         As these will be fixed up as the subitems_url instances are blinked in
                 if (_completeOsList.isEmpty()) {
-                    std::lock_guard<std::mutex> lock(_deviceListMutationMutex);
                     _completeOsList = QJsonDocument(response_object);
                 } else {
-                    std::lock_guard<std::mutex> lock(_deviceListMutationMutex);
                     auto new_list = findAndInsertJsonResult(_completeOsList["os_list"].toArray(), response_object["os_list"].toArray(), data->request().url());
                     auto imager_meta = _completeOsList["imager"].toObject();
                     _completeOsList = QJsonDocument(QJsonObject({
@@ -579,8 +576,6 @@ namespace {
                     }
                 }
             }
-
-            //returnArray += ositemObject;
         }
 
         return returnArray;
@@ -591,7 +586,6 @@ QByteArray ImageWriter::getFilteredOSlist() {
     QJsonArray reference_os_list_array = {};
     QJsonObject reference_imager_metadata = {};
     {
-        std::lock_guard<std::mutex> lock(_deviceListMutationMutex);
         if (!_completeOsList.isEmpty()) {
             reference_os_list_array = filterOsListWithHWTags(_completeOsList.object()["os_list"].toArray(), _deviceFilter, _deviceFilterIsInclusive);
             reference_imager_metadata = _completeOsList.object()["imager"].toObject();

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -533,22 +533,24 @@ void ImageWriter::handleNetworkRequestFinished(QNetworkReply *data) {
 }
 
 QByteArray ImageWriter::getFilteredOSlist() {
-    QJsonArray referenceArray = {};
-    QJsonObject referenceImagerMeta = {};
-    if (!_completeOsList.isEmpty()) {
+    QJsonArray reference_os_list_array = {};
+    QJsonObject reference_imager_metadata = {};
+    {
         std::lock_guard<std::mutex> lock(_deviceListMutationMutex);
-        referenceArray = _completeOsList.object()["os_list"].toArray();
-        referenceImagerMeta = _completeOsList.object()["imager"].toObject();
+        if (!_completeOsList.isEmpty()) {
+            reference_os_list_array = _completeOsList.object()["os_list"].toArray();
+            reference_imager_metadata = _completeOsList.object()["imager"].toObject();
+        }
     }
 
-    referenceArray.append(QJsonObject({
+    reference_os_list_array.append(QJsonObject({
             {"name",  tr("Erase")},
             {"description", tr("Format card as FAT32")},
             {"icon", "icons/erase.png"},
             {"url", "internal://format"},
         }));
 
-    referenceArray.append(QJsonObject({
+    reference_os_list_array.append(QJsonObject({
             {"name",  tr("Use custom")},
             {"description", tr("Select a custom .img from your computer")},
             {"icon", "icons/use_custom.png"},
@@ -557,8 +559,8 @@ QByteArray ImageWriter::getFilteredOSlist() {
 
     return QJsonDocument(
         QJsonObject({
-            {"imager", referenceImagerMeta},
-            {"os_list", referenceArray},
+            {"imager", reference_imager_metadata},
+            {"os_list", reference_os_list_array},
         }
     )).toJson();
 }

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -472,12 +472,6 @@ namespace {
 } // namespace anonymous
 
 
-void ImageWriter::setHWFilterList(const QByteArray &json) {
-    QJsonDocument json_document = QJsonDocument::fromJson(json);
-
-    _deviceFilter = json_document.array();
-}
-
 void ImageWriter::handleNetworkRequestFinished(QNetworkReply *data) {
     // Defer deletion
     data->deleteLater();

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -86,7 +86,7 @@ public:
     Q_INVOKABLE void beginOSListFetch();
 
     /** Set the HW filter, for a filtered view of the OS list */
-    Q_INVOKABLE void setHWFilterList(const QByteArray &json);
+    Q_INVOKABLE void setHWFilterList(const QByteArray &json, const bool &inclusive);
 
     /* Set custom cache file */
     void setCustomCacheFile(const QString &cacheFile, const QByteArray &sha256);
@@ -184,6 +184,7 @@ private:
     QNetworkAccessManager _networkManager;
     QJsonDocument _completeOsList;
     QJsonArray _deviceFilter;
+    bool _deviceFilterIsInclusive;
     std::mutex _deviceListMutationMutex;
 
 protected:

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -181,7 +181,7 @@ private:
     // Recursively walk all the entries with subitems and, for any which
     // refer to an external JSON list, fetch the list and put it in place.
     void fillSubLists(QJsonArray &topLevel);
-    std::unique_ptr<QNetworkAccessManager> _networkManager;
+    QNetworkAccessManager _networkManager;
     QJsonDocument _completeOsList;
     QJsonArray _deviceFilter;
     std::mutex _deviceListMutationMutex;

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -185,7 +185,6 @@ private:
     QJsonDocument _completeOsList;
     QJsonArray _deviceFilter;
     bool _deviceFilterIsInclusive;
-    std::mutex _deviceListMutationMutex;
 
 protected:
     QUrl _src, _repo;

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -85,9 +85,6 @@ public:
     /** Begin the asynchronous fetch of the OS lists, and associated sublists. */
     Q_INVOKABLE void beginOSListFetch();
 
-    /** Set the HW filter, for a filtered view of the OS list */
-    Q_INVOKABLE void setHWFilterList(const QByteArray &json);
-
     /* Set custom cache file */
     void setCustomCacheFile(const QString &cacheFile, const QByteArray &sha256);
 

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -85,6 +85,9 @@ public:
     /** Begin the asynchronous fetch of the OS lists, and associated sublists. */
     Q_INVOKABLE void beginOSListFetch();
 
+    /** Set the HW filter, for a filtered view of the OS list */
+    Q_INVOKABLE void setHWFilterList(const QByteArray &json);
+
     /* Set custom cache file */
     void setCustomCacheFile(const QString &cacheFile, const QByteArray &sha256);
 

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -6,6 +6,11 @@
  * Copyright (C) 2020 Raspberry Pi Ltd
  */
 
+#include <memory>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QNetworkAccessManager>
 #include <QObject>
 #include <QTimer>
 #include <QUrl>
@@ -73,6 +78,15 @@ public:
 
     /* Set custom repository */
     Q_INVOKABLE void setCustomOsListUrl(const QUrl &url);
+
+    /* Get the cached OS list. This may be empty if network connectivity is not available. */
+    Q_INVOKABLE QByteArray getFilteredOSlist();
+
+    /** Begin the asynchronous fetch of the OS lists, and associated sublists. */
+    Q_INVOKABLE void beginOSListFetch();
+
+    /** Set the HW filter, for a filtered view of the OS list */
+    Q_INVOKABLE void setHWFilterList(const QByteArray &json);
 
     /* Set custom cache file */
     void setCustomCacheFile(const QString &cacheFile, const QByteArray &sha256);
@@ -144,6 +158,7 @@ signals:
     void finalizing();
     void networkOnline();
     void preparationStatusUpdate(QVariant msg);
+    void osListPrepared();
 
 protected slots:
 
@@ -160,6 +175,16 @@ protected slots:
     void onFinalizing();
     void onTimeSyncReply(QNetworkReply *reply);
     void onPreparationStatusUpdate(QString msg);
+    void handleNetworkRequestFinished(QNetworkReply *data);
+
+private:
+    // Recursively walk all the entries with subitems and, for any which
+    // refer to an external JSON list, fetch the list and put it in place.
+    void fillSubLists(QJsonArray &topLevel);
+    std::unique_ptr<QNetworkAccessManager> _networkManager;
+    QJsonDocument _completeOsList;
+    QJsonArray _deviceFilter;
+    std::mutex _deviceListMutationMutex;
 
 protected:
     QUrl _src, _repo;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -346,6 +346,7 @@ int main(int argc, char *argv[])
     qmlwindow->connect(&imageWriter, SIGNAL(cancelled()), qmlwindow, SLOT(onCancelled()));
     qmlwindow->connect(&imageWriter, SIGNAL(finalizing()), qmlwindow, SLOT(onFinalizing()));
     qmlwindow->connect(&imageWriter, SIGNAL(networkOnline()), qmlwindow, SLOT(fetchOSlist()));
+    qmlwindow->connect(&imageWriter, SIGNAL(osListPrepared()), qmlwindow, SLOT(onOsListPrepared()));
 
 #ifndef QT_NO_WIDGETS
     /* Set window position */
@@ -373,6 +374,8 @@ int main(int argc, char *argv[])
     qmlwindow->setProperty("x", x);
     qmlwindow->setProperty("y", y);
 #endif
+
+    imageWriter.beginOSListFetch();
 
     int rc = app.exec();
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -1221,29 +1221,6 @@ ApplicationWindow {
         }
     }
 
-    /* Utility functions */
-    function httpRequest(url, callback) {
-        var xhr = new XMLHttpRequest();
-        xhr.timeout = 5000
-        xhr.onreadystatechange = (function(x) {
-            return function() {
-                if (x.readyState === x.DONE)
-                {
-                    if (x.status === 200)
-                    {
-                        callback(x)
-                    }
-                    else
-                    {
-                        onError(qsTr("Error downloading OS list from Internet"))
-                    }
-                }
-            }
-        })(xhr)
-        xhr.open("GET", url)
-        xhr.send()
-    }
-
     /* Slots for signals imagewrite emits */
     function onDownloadProgress(now,total) {
         var newPos
@@ -1287,6 +1264,11 @@ ApplicationWindow {
 
     function onPreparationStatusUpdate(msg) {
         progressText.text = qsTr("Preparing to write... (%1)").arg(msg)
+    }
+
+    function onOsListPrepared() {
+        console.log("OS list updated.");
+        fetchOSlist()
     }
 
     function resetWriteButton() {
@@ -1454,42 +1436,42 @@ ApplicationWindow {
     }
 
     function oslistFromJson(o) {
-        var oslist = false
+        var oslist_parsed = false
         var lang_country = Qt.locale().name
         if ("os_list_"+lang_country in o) {
-            oslist = o["os_list_"+lang_country]
+            oslist_parsed = o["os_list_"+lang_country]
         }
         else if (lang_country.includes("_")) {
             var lang = lang_country.substr(0, lang_country.indexOf("_"))
             if ("os_list_"+lang in o) {
-                oslist = o["os_list_"+lang]
+                oslist_parsed = o["os_list_"+lang]
             }
         }
 
-        if (!oslist) {
+        if (!oslist_parsed) {
             if (!"os_list" in o) {
                 onError(qsTr("Error parsing os_list.json"))
                 return false
             }
 
-            oslist = o["os_list"]
+            oslist_parsed = o["os_list"]
         }
 
         if (hwTags != "") {
-            filterItems(oslist, JSON.parse(hwTags), hwTagMatchingType)
+            filterItems(oslist_parsed, JSON.parse(hwTags), hwTagMatchingType)
         }
-        checkForRandom(oslist)
+        checkForRandom(oslist_parsed)
 
         /* Flatten subitems to subitems_json */
-        for (var i in oslist) {
-            var entry = oslist[i];
+        for (var i in oslist_parsed) {
+            var entry = oslist_parsed[i];
             if ("subitems" in entry) {
                 entry["subitems_json"] = JSON.stringify(entry["subitems"])
                 delete entry["subitems"]
             }
         }
 
-        return oslist
+        return oslist_parsed
     }
 
     function selectNamedOS(name, collection)
@@ -1508,80 +1490,54 @@ ApplicationWindow {
     }
 
     function fetchOSlist() {
-        httpRequest(imageWriter.constantOsListUrl(), function (x) {
-            var o = JSON.parse(x.responseText)
-            var oslist = oslistFromJson(o)
-            if (oslist === false)
-                return
-            osmodel.clear()
-            for (var i in oslist) {
-                osmodel.append(oslist[i])
-            }
+        var oslist_json = imageWriter.getFilteredOSlist();
+        var o = JSON.parse(oslist_json)
+        var oslist_parsed = oslistFromJson(o)
+        if (oslist_parsed === false)
+            return
+        osmodel.clear()
+        for (var i in oslist_parsed) {
+            osmodel.append(oslist_parsed[i])
+        }
 
-            if ("imager" in o) {
-                var imager = o["imager"]
+        if ("imager" in o) {
+            var imager = o["imager"]
 
-                if ("devices" in imager)
+            if ("devices" in imager)
+            {
+                deviceModel.clear()
+                var devices = imager["devices"]
+                for (var j in devices)
                 {
-                    deviceModel.clear()
-                    var devices = imager["devices"]
-                    for (var j in devices)
+                    devices[j]["tags"] = JSON.stringify(devices[j]["tags"])
+                    deviceModel.append(devices[j])
+                    if ("default" in devices[j] && devices[j]["default"])
                     {
-                        devices[j]["tags"] = JSON.stringify(devices[j]["tags"])
-                        deviceModel.append(devices[j])
-                        if ("default" in devices[j] && devices[j]["default"])
-                        {
-                            hwlist.currentIndex = deviceModel.count-1
-                        }
-                    }
-                }
-
-                if (imageWriter.getBoolSetting("check_version") && "latest_version" in imager && "url" in imager) {
-                    if (!imageWriter.isEmbeddedMode() && imageWriter.isVersionNewer(imager["latest_version"])) {
-                        updatepopup.url = imager["url"]
-                        updatepopup.openPopup()
-                    }
-                }
-                if ("default_os" in imager) {
-                    selectNamedOS(imager["default_os"], osmodel)
-                }
-                if (imageWriter.isEmbeddedMode()) {
-                    if ("embedded_default_os" in imager) {
-                        selectNamedOS(imager["embedded_default_os"], osmodel)
-                    }
-                    if ("embedded_default_destination" in imager) {
-                        imageWriter.startDriveListPolling()
-                        setDefaultDest.drive = imager["embedded_default_destination"]
-                        setDefaultDest.start()
+                        hwlist.currentIndex = deviceModel.count-1
                     }
                 }
             }
 
-            /* Add in our 'special' items. */
-            osmodel.append({
-                url: "internal://format",
-                icon: "icons/erase.png",
-                extract_size: 0,
-                image_download_size: 0,
-                extract_sha256: "",
-                contains_multiple_files: false,
-                release_date: "",
-                subitems_url: "",
-                subitems_json: "",
-                name: qsTr("Erase"),
-                description: qsTr("Format card as FAT32"),
-                tooltip: "",
-                website: "",
-                init_format: ""
-            })
-
-            osmodel.append({
-                url: "",
-                icon: "icons/use_custom.png",
-                name: qsTr("Use custom"),
-                description: qsTr("Select a custom .img from your computer")
-            })
-        })
+            if (imageWriter.getBoolSetting("check_version") && "latest_version" in imager && "url" in imager) {
+                if (!imageWriter.isEmbeddedMode() && imageWriter.isVersionNewer(imager["latest_version"])) {
+                    updatepopup.url = imager["url"]
+                    updatepopup.openPopup()
+                }
+            }
+            if ("default_os" in imager) {
+                selectNamedOS(imager["default_os"], osmodel)
+            }
+            if (imageWriter.isEmbeddedMode()) {
+                if ("embedded_default_os" in imager) {
+                    selectNamedOS(imager["embedded_default_os"], osmodel)
+                }
+                if ("embedded_default_destination" in imager) {
+                    imageWriter.startDriveListPolling()
+                    setDefaultDest.drive = imager["embedded_default_destination"]
+                    setDefaultDest.start()
+                }
+            }
+        }
     }
 
     Timer {
@@ -1648,30 +1604,29 @@ ApplicationWindow {
         }
 
         /* Reload list */
-        httpRequest(imageWriter.constantOsListUrl(), function (x) {
-            var o = JSON.parse(x.responseText)
-            var oslist = oslistFromJson(o)
-            if (oslist === false)
-                return
+        var oslist_json = imageWriter.getFilteredOSlist();
+        var o = JSON.parse(oslist_json)
+        var oslist_parsed = oslistFromJson(o)
+        if (oslist_parsed === false)
+            return
 
-            /* As we're filtering the OS list, we need to ensure we present a 'Recommended' OS.
-             * To do this, we exploit a convention of how we build the OS list. By convention,
-             * the preferred OS for a device is listed at the top level of the list, and is at the
-             * lowest index. So..
-             */
-            if (oslist.length != 0) {
-                var candidate = oslist[0]
+        /* As we're filtering the OS list, we need to ensure we present a 'Recommended' OS.
+            * To do this, we exploit a convention of how we build the OS list. By convention,
+            * the preferred OS for a device is listed at the top level of the list, and is at the
+            * lowest index. So..
+            */
+        if (oslist_parsed.length != 0) {
+            var candidate = oslist_parsed[0]
 
-                if ("description" in candidate && !("subitems" in candidate)) {
-                    candidate["description"] += " (Recommended)"
-                }
+            if ("description" in candidate && !("subitems" in candidate)) {
+                candidate["description"] += " (Recommended)"
             }
+        }
 
-            osmodel.remove(0, osmodel.count-2)
-            for (var i in oslist) {
-                osmodel.insert(osmodel.count-2, oslist[i])
-            }
-        })
+        osmodel.clear()
+        for (var i in oslist_parsed) {
+            osmodel.append(oslist_parsed[i])
+        }
 
         // When the HW device is changed, reset the OS selection otherwise
         // you get a weird effect with the selection moving around in the list
@@ -1732,19 +1687,7 @@ ApplicationWindow {
             }
             else
             {
-                ospopup.categorySelected = d.name
-                var suburl = d.subitems_url
-                var m = newSublist()
-
-                httpRequest(suburl, function (x) {
-                    var o = JSON.parse(x.responseText)
-                    var oslist = oslistFromJson(o)
-                    if (oslist === false)
-                        return
-                    for (var i in oslist) {
-                        m.append(oslist[i])
-                    }
-                })
+                console.log("Failure: Backend should have pre-flattened the JSON!");
 
                 osswipeview.itemAt(osswipeview.currentIndex+1).currentIndex = (selectFirstSubitem === true) ? 0 : -1
                 osswipeview.incrementCurrentIndex()
@@ -1757,9 +1700,9 @@ ApplicationWindow {
                 if (imageWriter.mountUsbSourceMedia()) {
                     var m = newSublist()
 
-                    var oslist = JSON.parse(imageWriter.getUsbSourceOSlist())
-                    for (var i in oslist) {
-                        m.append(oslist[i])
+                    var usboslist = JSON.parse(imageWriter.getUsbSourceOSlist())
+                    for (var i in usboslist) {
+                        m.append(usboslist[i])
                     }
                     osswipeview.itemAt(osswipeview.currentIndex+1).currentIndex = (selectFirstSubitem === true) ? 0 : -1
                     osswipeview.incrementCurrentIndex()

--- a/src/main.qml
+++ b/src/main.qml
@@ -25,20 +25,6 @@ ApplicationWindow {
     FontLoader {id: robotoLight; source: "fonts/Roboto-Light.ttf"}
     FontLoader {id: robotoBold;  source: "fonts/Roboto-Bold.ttf"}
 
-    /** hw device list storage
-      *
-      * To allow us to filter the OS list, we maintain an application-wide record of the selected device
-      * tags.
-      */
-    property string hwTags
-
-    /** 0: Exclusive, must match explicit device names only, no untagged
-        1: Exclusive by prefix, must match the device name as a prefix, no untagged
-        2: Inclusive, match explicit device names and untagged
-        3: Inclusive by prefix, match explicit device names and untagged
-        */
-    property int hwTagMatchingType
-
     onClosing: {
         if (progressBar.visible) {
             close.accepted = false
@@ -1267,7 +1253,6 @@ ApplicationWindow {
     }
 
     function onOsListPrepared() {
-        console.log("OS list updated.");
         fetchOSlist()
     }
 
@@ -1457,9 +1442,6 @@ ApplicationWindow {
             oslist_parsed = o["os_list"]
         }
 
-        if (hwTags != "") {
-            filterItems(oslist_parsed, JSON.parse(hwTags), hwTagMatchingType)
-        }
         checkForRandom(oslist_parsed)
 
         /* Flatten subitems to subitems_json */
@@ -1581,27 +1563,20 @@ ApplicationWindow {
     }
 
     function selectHWitem(hwmodel) {
-        hwTags = hwmodel.tags
+        /* Default is exclusive matching */
+        var inclusive = false
 
         if (hwmodel.matching_type) {
             switch (hwmodel.matching_type) {
                 case "exclusive":
-                    hwTagMatchingType = 0
-                    break;
-                case "exclusive_prefix":
-                    hwTagMatchingType = 1
                     break;
                 case "inclusive":
-                    hwTagMatchingType = 2
-                    break;
-                case "inclusive_prefix":
-                    hwTagMatchingType = 3
+                    inclusive = true
                     break;
             }
-        } else {
-            /* Default is exclusive exact matching */
-            hwTagMatchingType = 0
         }
+
+        imageWriter.setHWFilterList(hwmodel.tags, inclusive)
 
         /* Reload list */
         var oslist_json = imageWriter.getFilteredOSlist();


### PR DESCRIPTION
- Simple implementation of OS list fetching in backend
- Replace frontend OS list fetching by calls to backend
- OS list updates are brought in asynchronously, avoiding excessive UI blockage.
- "Erase" and "Custom" OS list options are always present, even in a no-internet scenario

Based-On: cillian64/rpi-imager/oslist_backend
Resolves #714