### PR TITLE
i18n: Japanese minor wording corrections

### DIFF
--- a/src/i18n/rpi-imager_ja.ts
+++ b/src/i18n/rpi-imager_ja.ts
@@ -715,7 +715,7 @@
     <message>
         <location filename="../main.qml" line="974"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation>新しいバージョンのImagerがあります。&lt;br&gt;ダウンロードするためにウェブサイトに行きますか？</translation>
+        <translation>新しいバージョンのImagerがあります。&lt;br&gt;ダウンロードするためにウェブサイトを開きますか？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1017"/>
@@ -756,12 +756,12 @@
     <message>
         <location filename="../main.qml" line="1093"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>&lt;b%gt;%1&lt;/b&gt; は削除されました。&lt;br&gt;&lt;bt&gt;SDカードをSDカードリーダーから取り出しても良いです。</translation>
+        <translation>&lt;b%gt;%1&lt;/b&gt; は削除されました。&lt;br&gt;&lt;bt&gt;SDカードをSDカードリーダーから取り出すことができます。</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1100"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>&lt;b&gt;%1&lt;/b&gt; は&lt;b&gt;%2&lt;/b&gt;に書き込まれました。&lt;br&gt;&lt;br&gt;SDカードをSDカードリーダーから取り出しても良いです。</translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; は&lt;b&gt;%2&lt;/b&gt;に書き込まれました。&lt;br&gt;&lt;br&gt;SDカードをSDカードリーダーから取り出すことができます。</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1202"/>


### PR DESCRIPTION
The original translation is correct, but this can be made better.

For your reference, I am attaching the number of results from the search with the original wording and my wording. It is one reference.

![Screenshot 2023-11-17 125247](https://github.com/raspberrypi/rpi-imager/assets/29700428/da27c31f-cddd-4c95-9605-6eb0c3e28869)
![Screenshot 2023-11-17 125304](https://github.com/raspberrypi/rpi-imager/assets/29700428/db51f09d-f189-4a9f-97ef-702823558c0e)

---
![Screenshot 2023-11-17 124945](https://github.com/raspberrypi/rpi-imager/assets/29700428/b1bf6a6d-5f2c-4431-8d00-4d5fe27b6fe7)
![Screenshot 2023-11-17 125017](https://github.com/raspberrypi/rpi-imager/assets/29700428/e06131c8-d81b-446a-b478-1ba13876ad97)
