### PR TITLE
Fix file being passed to --repo

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -488,7 +488,7 @@ void ImageWriter::handleNetworkRequestFinished(QNetworkReply *data) {
     if (data->error() == QNetworkReply::NoError) {
         auto httpStatusCode = data->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
-        if (httpStatusCode >= 200 && httpStatusCode < 300) {
+        if (httpStatusCode >= 200 && httpStatusCode < 300 || httpStatusCode == 0) {
             auto response_object = QJsonDocument::fromJson(data->readAll()).object();
 
             if (response_object.contains("os_list")) {


### PR DESCRIPTION
Since #719, you can no longer use a local json file with --repo (At least in Qt 6). A network request to a file:// url has statusCode 0, which caused this check to fail previously.