### PR TITLE
qml: Impose limits on usernames, hostnames

### DIFF
--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -98,6 +98,7 @@ Window {
                                     enabled: chkHostname.checked
                                     text: "raspberrypi"
                                     selectByMouse: true
+                                    maximumLength: 253
                                     validator: RegularExpressionValidator { regularExpression: /[0-9A-Za-z][0-9A-Za-z-]{0,62}/ }
                                 }
                                 Text {
@@ -139,6 +140,7 @@ Window {
                                         Layout.minimumWidth: 200
                                         selectByMouse: true
                                         property bool indicateError: false
+                                        maximumLength: 31
 
                                         onTextEdited: {
                                             indicateError = false


### PR DESCRIPTION
Resolves #739 by constaining the size of the username field to match the limit imposed by systemd, and the hostname to the limit specified on man7.