### PR TITLE
qml: Clear saved password using onPressed handler

### DIFF
--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -153,7 +153,8 @@ Window {
                                     }
                                     TextField {
                                         id: fieldUserPassword
-                                        echoMode: TextInput.PasswordEchoOnEdit
+                                        echoMode: TextInput.Password
+                                        passwordMaskDelay: 2000 //ms
                                         Layout.minimumWidth: 200
                                         selectByMouse: true
                                         property bool alreadyCrypted: false

--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -153,19 +153,26 @@ Window {
                                     }
                                     TextField {
                                         id: fieldUserPassword
-                                        echoMode: TextInput.Password
+                                        echoMode: TextInput.PasswordEchoOnEdit
                                         Layout.minimumWidth: 200
                                         selectByMouse: true
                                         property bool alreadyCrypted: false
                                         property bool indicateError: false
 
-                                        onTextEdited: {
+                                        Keys.onPressed: (event)=> {
                                             if (alreadyCrypted) {
                                                 /* User is trying to edit saved
                                                    (crypted) password, clear field */
                                                 alreadyCrypted = false
                                                 clear()
                                             }
+
+                                            // Do not mark the event as accepted, so that it may
+                                            // propagate down to the underlying TextField.
+                                            event.accepted = false
+                                        }
+
+                                        onTextEdited: {
                                             if (indicateError) {
                                                 indicateError = false
                                             }


### PR DESCRIPTION
Using onTextEdited meant that the clear() call would happen after the edit had actually happened.

Instead, use the Keys.onPressed handler, which happens earlier in the input chain.

Resolves #531 