### PR TITLE
Updated Branding, URLs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+rpi-imager (1.8.5) unstable; urgency=medium
+
+  * Downloader: Fixed #767, which caused terminated downloads
+                            when connections stalled for >60s
+  * Branding: Update the URL, application name to match branding
+              guidelines.
+
+ -- Floris Bos <bos@je-eigen-domein.nl>  Wed, 10 Jan 2024 16:00:00 +0200
+
 rpi-imager (1.8.4) unstable; urgency=medium
 
   * OS customisation: Fixed #531, which caused password entry

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 10), cmake, libarchive-dev, liblzma-dev, libcurl4-g
  qtbase5-dev, qtbase5-dev-tools, qtdeclarative5-dev, libqt5svg5-dev, qttools5-dev, libgnutls28-dev,
  qml-module-qtquick2, qml-module-qtquick-controls2, qml-module-qtquick-layouts, qml-module-qtquick-templates2, qml-module-qtquick-window2, qml-module-qtgraphicaleffects
 Standards-Version: 4.1.2
-Homepage: https://www.raspberrypi.org/
+Homepage: https://www.raspberrypi.com/software
 
 Package: rpi-imager
 Architecture: any

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -30,8 +30,8 @@ Cli::Cli(int &argc, char *argv[]) : QObject(nullptr)
 #endif
     _app = new QCoreApplication(argc, argv);
     _app->setOrganizationName("Raspberry Pi");
-    _app->setOrganizationDomain("raspberrypi.org");
-    _app->setApplicationName("Imager");
+    _app->setOrganizationDomain("raspberrypi.com");
+    _app->setApplicationName("Raspberry Pi Imager");
     _imageWriter = new ImageWriter;
     connect(_imageWriter, &ImageWriter::success, this, &Cli::onSuccess);
     connect(_imageWriter, &ImageWriter::error, this, &Cli::onError);

--- a/src/config.h
+++ b/src/config.h
@@ -8,10 +8,10 @@
 
 
 /* Repository URL */
-#define OSLIST_URL                        "https://downloads.raspberrypi.org/os_list_imagingutility_v4.json"
+#define OSLIST_URL                        "https://downloads.raspberrypi.com/os_list_imagingutility_v4.json"
 
 /* Time synchronization URL (only used on eglfs QPA platform, URL must be HTTP) */
-#define TIME_URL                          "http://downloads.raspberrypi.org/os_list_imagingutility_v4.json?time_synchronization"
+#define TIME_URL                          "http://downloads.raspberrypi.com/os_list_imagingutility_v4.json?time_synchronization"
 
 /* Phone home the name of images downloaded for image popularity ranking */
 #define TELEMETRY_URL                     "https://rpi-imager-stats.raspberrypi.com/downloads"

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -61,7 +61,7 @@ ImageWriter::ImageWriter(QObject *parent)
     : QObject(parent), _repo(QUrl(QString(OSLIST_URL))), _dlnow(0), _verifynow(0),
       _engine(nullptr), _thread(nullptr), _verifyEnabled(false), _cachingEnabled(false),
       _embeddedMode(false), _online(false), _customCacheFile(false), _trans(nullptr),
-      _networkManager(this)
+      _networkManager(this), _settings("Raspberry Pi", "Imager", nullptr)
 {
     connect(&_polltimer, SIGNAL(timeout()), SLOT(pollProgress()));
 

--- a/src/linux/rpi-imager.desktop
+++ b/src/linux/rpi-imager.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Name=Imager
+Name=Raspberry Pi Imager
 Comment=Raspberry Pi Imager
 Icon=rpi-imager
 Exec=rpi-imager %F

--- a/src/linux/rpi-imager.metainfo.xml.in
+++ b/src/linux/rpi-imager.metainfo.xml.in
@@ -30,23 +30,23 @@
   <launchable type="desktop-id">rpi-imager.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-MAIN.png</image>
+      <image>http://downloads.raspberrypi.com/imager/IMAGING-UTILITY-MAIN.png</image>
       <caption>Main window</caption>
     </screenshot>
     <screenshot>
-      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-OS.png</image>
+      <image>http://downloads.raspberrypi.com/imager/IMAGING-UTILITY-OS.png</image>
       <caption>Choose OS</caption>
     </screenshot>
     <screenshot>
-      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-SD.png</image>
+      <image>http://downloads.raspberrypi.com/imager/IMAGING-UTILITY-SD.png</image>
       <caption>Choose SD</caption>
     </screenshot>
     <screenshot>
-      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-WRITE.png</image>
+      <image>http://downloads.raspberrypi.com/imager/IMAGING-UTILITY-WRITE.png</image>
       <caption>Write in progress</caption>
     </screenshot>
     <screenshot>
-      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-DONE.png</image>
+      <image>http://downloads.raspberrypi.com/imager/IMAGING-UTILITY-DONE.png</image>
       <caption>Write done</caption>
     </screenshot>
   </screenshots>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,8 +173,8 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
 #endif
     app.setOrganizationName("Raspberry Pi");
-    app.setOrganizationDomain("raspberrypi.org");
-    app.setApplicationName("Imager");
+    app.setOrganizationDomain("raspberrypi.com");
+    app.setApplicationName("Raspberry Pi Imager");
     app.setWindowIcon(QIcon(":/icons/rpi-imager.ico"));
     ImageWriter imageWriter;
     NetworkAccessManagerFactory namf;


### PR DESCRIPTION
raspberrypi.org is owned by the Raspberry Pi Foundation, and for cleanliness, we should point instead to raspberrypi.com (which is run by Raspberry Pi Ltd) instead.

Additionally, let's make sure the application name reflects the...application name! "Imager" was unfortunately a little too short to distinguish from tools included in various Linux distros, and avoiding confusion is the aim.