### PR TITLE
appstream metainfo: Fix appstream-builder generation

### DIFF
--- a/src/linux/rpi-imager.metainfo.xml.in
+++ b/src/linux/rpi-imager.metainfo.xml.in
@@ -27,7 +27,7 @@
       download the file again.
     </p>
   </description>
-  <launchable type="desktop-id">rpi-imager.desktop</launchable>
+  <launchable type="desktop-id">org.raspberrypi.rpi-imager.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-MAIN.png</image>


### PR DESCRIPTION
launchable desktop-id type was no longer matching after 06abbadbb501869c29076df0f0409b977869e992 causing appstream-builder to fail to generate appdata for this package.