### PR TITLE
Add a message when there are no storage devices. Fixes #798

### DIFF
--- a/src/i18n/rpi-imager_ca.ts
+++ b/src/i18n/rpi-imager_ca.ts
@@ -513,6 +513,11 @@
         <translation>Emmagatzematge</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_de.ts
+++ b/src/i18n/rpi-imager_de.ts
@@ -562,6 +562,11 @@
         <translation>SD-Karte</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_en.ts
+++ b/src/i18n/rpi-imager_en.ts
@@ -505,6 +505,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_es.ts
+++ b/src/i18n/rpi-imager_es.ts
@@ -513,6 +513,11 @@
         <translation>Almacenamiento</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_fr.ts
+++ b/src/i18n/rpi-imager_fr.ts
@@ -549,6 +549,11 @@
         <translation>Stockage</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_it.ts
+++ b/src/i18n/rpi-imager_it.ts
@@ -506,6 +506,11 @@ Aggiungi sia &apos;rpi-imager.exe&apos; che &apos;fat32format.exe&apos; all&apos
         <translation>Scheda SD</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_ja.ts
+++ b/src/i18n/rpi-imager_ja.ts
@@ -557,6 +557,11 @@
         <translation>ストレージ</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_ko.ts
+++ b/src/i18n/rpi-imager_ko.ts
@@ -557,6 +557,11 @@
         <translation>저장소</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_nl.ts
+++ b/src/i18n/rpi-imager_nl.ts
@@ -565,6 +565,11 @@
         <translation>Opslagapparaat</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_pl.ts
+++ b/src/i18n/rpi-imager_pl.ts
@@ -562,6 +562,11 @@
         <translation>Dysk</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_ru.ts
+++ b/src/i18n/rpi-imager_ru.ts
@@ -549,6 +549,11 @@
         <translation>Запоминающее устройство</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_tr.ts
+++ b/src/i18n/rpi-imager_tr.ts
@@ -517,6 +517,11 @@
         <translation>SD Kart</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_uk.ts
+++ b/src/i18n/rpi-imager_uk.ts
@@ -513,6 +513,11 @@
         <translation>Накопичувач</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_zh-TW.ts
+++ b/src/i18n/rpi-imager_zh-TW.ts
@@ -505,6 +505,11 @@
         <translation>儲存裝置</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -549,6 +549,11 @@
         <translation>储存卡</translation>
     </message>
     <message>
+        <location filename="../main.qml" line="1007"/>
+        <source>No storage devices found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="145"/>
         <location filename="../main.qml" line="1108"/>
         <source>CHOOSE STORAGE</source>

--- a/src/main.qml
+++ b/src/main.qml
@@ -998,6 +998,16 @@ ApplicationWindow {
                     height: window.height-100
                     boundsBehavior: Flickable.StopAtBounds
                     highlight: Rectangle { color: "lightsteelblue"; radius: 5 }
+
+                    Label {
+                        anchors.fill: parent
+                        horizontalAlignment: Qt.AlignHCenter
+                        verticalAlignment: Qt.AlignVCenter
+                        visible: parent.count == 0
+                        text: qsTr("No storage devices found")
+                        font.bold: true
+                    }
+
                     ScrollBar.vertical: ScrollBar {
                         width: 10
                         policy: dstlist.contentHeight > dstlist.height ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded


### PR DESCRIPTION
Looks like I will need to learn qt/qml for work, thought I could start by contributing some small enhancements to rpi-imager.

https://github.com/raspberrypi/rpi-imager/assets/32407/78de5e3b-0b8a-444c-aa22-9c9084588a45

I updated the message to say "No storage devices found" instead of 'nothing to see here'