### PR TITLE
Swap order of "yes" and "no" buttons in OS customisation popup

### DIFF
--- a/src/UseSavedSettingsPopup.qml
+++ b/src/UseSavedSettingsPopup.qml
@@ -121,6 +121,14 @@ Popup {
             }
 
             ImButtonRed {
+                text: qsTr("NO")
+                onClicked: {
+                    msgpopup.close()
+                    msgpopup.no()
+                }
+            }
+
+            ImButtonRed {
                 id: yesButton
                 text: qsTr("YES")
                 onClicked: {
@@ -128,14 +136,6 @@ Popup {
                     msgpopup.yes()
                 }
                 enabled: hasSavedSettings
-            }
-
-            ImButtonRed {
-                text: qsTr("NO")
-                onClicked: {
-                    msgpopup.close()
-                    msgpopup.no()
-                }
             }
 
             Text { text: " " }


### PR DESCRIPTION
Swaps the order of the "yes" and "no" button in the OS customisation popup, making this popup conform to the convention of keeping the _confirmation_ option to the right.

Resolves https://github.com/raspberrypi/rpi-imager/issues/757

<img width="529" alt="Screenshot 2024-02-06 at 3 28 00 PM" src="https://github.com/raspberrypi/rpi-imager/assets/12530451/3d9f136e-e3a3-488e-a7bf-60c1f08101cf">
