### PR TITLE
imagewriter: Disable customisation of custom IMGs

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -1293,6 +1293,10 @@ void ImageWriter::clearSavedCustomizationSettings()
     _settings.sync();
 }
 
+void ImageWriter::disableImageCustomization() {
+    _initFormat.clear();
+}
+
 bool ImageWriter::hasSavedCustomizationSettings()
 {
     _settings.sync();

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -124,6 +124,7 @@ public:
 
     Q_INVOKABLE bool getBoolSetting(const QString &key);
     Q_INVOKABLE void setSetting(const QString &key, const QVariant &value);
+    Q_INVOKABLE void disableImageCustomization();
     Q_INVOKABLE void setImageCustomization(const QByteArray &config, const QByteArray &cmdline, const QByteArray &firstrun, const QByteArray &cloudinit, const QByteArray &cloudinitNetwork);
     Q_INVOKABLE void setSavedCustomizationSettings(const QVariantMap &map);
     Q_INVOKABLE QVariantMap getSavedCustomizationSettings();

--- a/src/main.qml
+++ b/src/main.qml
@@ -1320,6 +1320,7 @@ ApplicationWindow {
 
     function onFileSelected(file) {
         imageWriter.setSrc(file)
+        imageWriter.disableImageCustomization()
         osbutton.text = imageWriter.srcFileName()
         ospopup.close()
         osswipeview.decrementCurrentIndex()


### PR DESCRIPTION
Resolves #831 by not offering customisation for custom image sources.

We have no associated metadata for these images, so customisation isn't something we can offer in a clear and easy to understand way.