### PR TITLE
cli: Add disable-eject

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -213,6 +213,7 @@ int Cli::main()
 
     _imageWriter->setDst(args[1]);
     _imageWriter->setVerifyEnabled(!parser.isSet("disable-verify"));
+    _imageWriter->setSetting("eject", !parser.isSet("disable-eject"));
 
     /* Run startWrite() in event loop (otherwise calling _app->exit() on error does not work) */
     QTimer::singleShot(1, _imageWriter, &ImageWriter::startWrite);


### PR DESCRIPTION
Add a new CLI flag, `--disable-eject`, which maps to the option in the UI to not automatically eject the storage media after writing.

While we're here, use a more concise declaration form for the cli options.

Resolves #851 