### PR TITLE
localectl doesn't work on modern Debian/Ubuntu

### DIFF
--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -787,8 +787,9 @@ Window {
             addFirstRun("fi")
 
             addCloudInit("timezone: "+fieldTimezone.editText)
-            addCloudInitRun("localectl set-x11-keymap \""+fieldKeyboardLayout.editText+"\" pc105")
-            addCloudInitRun("setupcon -k --force || true")
+            addCloudInit("keyboard:")
+            addCloudInit("  model: pc105")
+            addCloudInit("  layout: \"" + fieldKeyboardLayout.editText + "\"")
         }
 
         if (firstrun.length) {


### PR DESCRIPTION
On modern Debian and Ubuntu releases (23.10 onwards for Ubuntu), `localectl` does not (currently) operate [1] [2]. The `keyboard:` section should be used instead, which should do the right thing on whatever platform cloud-init is being used on (writes `/etc/default/keyboard` on Debian/Ubuntu, uses `localectl` on RHEL/Fedora, runs `setup-keymap` on Alpine).

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1038762

[2]: https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2030788