### PR TITLE
Corrected the spelling for Kyiv

### DIFF
--- a/src/timezones.txt
+++ b/src/timezones.txt
@@ -429,7 +429,7 @@ Europe/Isle_of_Man
 Europe/Istanbul
 Europe/Jersey
 Europe/Kaliningrad
-Europe/Kiev
+Europe/Kyiv
 Europe/Lisbon
 Europe/Ljubljana
 Europe/London


### PR DESCRIPTION
Currently the timezone setting for Kyiv is spelled as `Europe/Kiev`. This is incorrect as the official spelling is `Kyiv`, more info can be found [here](https://en.wikipedia.org/wiki/KyivNotKiev). This PR corrects the spelling.

Thank you.