### PR TITLE
Fix timeout on systems with large numbers of loops

### DIFF
--- a/src/linux/linuxdrivelist.cpp
+++ b/src/linux/linuxdrivelist.cpp
@@ -48,7 +48,7 @@ namespace Drivelist
         std::vector<DeviceDescriptor> deviceList;
 
         QProcess p;
-        QStringList args = { "--bytes", "--json", "--paths", "--output-all" };
+        QStringList args = { "--bytes", "--json", "--paths", "--output-all", "--exclude", "7" };
         p.start("lsblk", args);
         p.waitForFinished(2000);
         QByteArray output = p.readAll();


### PR DESCRIPTION
On systems with a very large number of snap packages installed (for example), there are a considerable number of loop devices. In this case, the `lsblk` command in `linuxdrivelist` fills the stdout pipe, blocks, and the rpi-imager process assumes it has timed out [1].

This PR is a trivial work-around that simply excludes loop devices (major=7) from the `lsblk` output. Given subsequent code [2] excludes everything starting with `/dev/loop` anyway, there should be no change in user experience with this exclusion other than rpi-imager not failing on such systems (with a very large number of loop devices).

However, it may be preferable to fix the call to `lsblk` so that it doesn't (potentially) block the main UI thread for up to two seconds and die when the `lsblk` output is sufficiently large to block the pipe (i.e. have it loop on `QProcess.waitForReadyRead` instead of just blocking on `QProcess.waitForFinished`). If this is preferred, I'm happy to submit a PR for that instead.

[1]: https://github.com/waveform80/imager-snap/issues/6

[2]: https://github.com/raspberrypi/rpi-imager/blob/16c298beb43a9b3fc52a7d802df2707c2b7e688b/src/linux/linuxdrivelist.cpp#L70