### PR TITLE
Switch YES and NO button to make order consistent across the application

### DIFF
--- a/src/MsgPopup.qml
+++ b/src/MsgPopup.qml
@@ -95,21 +95,21 @@ Popup {
             spacing: 20
 
             ImButtonRed {
-                text: qsTr("NO")
-                onClicked: {
-                    msgpopup.close()
-                    msgpopup.no()
-                }
-                visible: msgpopup.noButton
-            }
-
-            ImButtonRed {
                 text: qsTr("YES")
                 onClicked: {
                     msgpopup.close()
                     msgpopup.yes()
                 }
                 visible: msgpopup.yesButton
+            }
+
+            ImButtonRed {
+                text: qsTr("NO")
+                onClicked: {
+                    msgpopup.close()
+                    msgpopup.no()
+                }
+                visible: msgpopup.noButton
             }
 
             ImButtonRed {


### PR DESCRIPTION
The order of YES and NO buttons differs between windows, causing confusion, as reported in https://github.com/raspberrypi/rpi-imager/issues/757.

There are plans for a more perfect fix but those plans has not been acted on in months. I'd rather have a good fix now than continue to press the wrong button until somebody has time to implement that.