### PR TITLE
Update zh-CN (Simplified Chinese) translation

### DIFF
--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -380,12 +380,12 @@
     <message>
         <location filename="../OptionsPopup.qml" line="328"/>
         <source>Allow public-key authentication only</source>
-        <translation>仅使用公匙登录</translation>
+        <translation>仅使用公钥登录</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="346"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation>为用户 “%1” 设置登录密匙：</translation>
+        <translation>为用户 “%1” 设置 authorized_keys：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="358"/>

--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -7,26 +7,22 @@
         <location filename="../downloadextractthread.cpp" line="196"/>
         <location filename="../downloadextractthread.cpp" line="385"/>
         <source>Error extracting archive: %1</source>
-        <translation>解压 %1 时出错</translation>
+        <translation>解压至 %1 时发生错误</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation>挂载FAT32分区错误</translation>
+        <translation>FAT32 分区挂载错误</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
         <source>Operating system did not mount FAT32 partition</source>
-        <translation>操作系统未能挂载FAT32分区</translation>
+        <translation>操作系统未能挂载 FAT32 分区</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="304"/>
         <source>Error changing to directory &apos;%1&apos;</source>
-        <translation>进入文件夹 “%1” 错误</translation>
-    </message>
-    <message>
-        <source>Error writing to storage</source>
-        <translation type="vanished">写入时出错</translation>
+        <translation>进入文件夹 “%1” 时发生错误</translation>
     </message>
 </context>
 <context>
@@ -34,22 +30,22 @@
     <message>
         <location filename="../downloadthread.cpp" line="118"/>
         <source>unmounting drive</source>
-        <translation type="unfinished"></translation>
+        <translation>卸载存储设备</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="138"/>
         <source>opening drive</source>
-        <translation>打开驱动器</translation>
+        <translation>打开存储设备</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="166"/>
         <source>Error running diskpart: %1</source>
-        <translation>运行 “diskpart” 命令错误 %1</translation>
+        <translation>运行 “diskpart” 命令时发生错误：%1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="187"/>
         <source>Error removing existing partitions</source>
-        <translation>删除现有分区时出错</translation>
+        <translation>删除现有分区时发生错误</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
@@ -59,37 +55,37 @@
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
         <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation>运行authopen以获得对磁盘设备&apos;%1&apos;的访问权限时出错</translation>
+        <translation>在运行 authopen 以获取对磁盘设备 “%1” 的访问权限时发生错误</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation>请验证是否在隐私设置中允许“ Raspberry Pi Imager”访问“可移动卷”（在“文件和文件夹”下，或者为它提供“完全磁盘访问”）的权限。</translation>
+        <translation>请检查，在隐私设置中是否允许树莓派镜像烧录器（Raspberry Pi Imager）访问“可移动卷”（位于“文件和文件夹”下），或为其授予“完整磁盘访问权限”。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
         <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation>无法打开存储设备&apos;%1&apos;。</translation>
+        <translation>无法打开存储设备 “%1”。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation>删除现有数据</translation>
+        <translation>清除已有数据</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
         <source>zeroing out first and last MB of drive</source>
-        <translation>清空驱动器未使用的数据</translation>
+        <translation>将存储设备的首尾 1 M 清零</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="307"/>
         <source>Write error while zero&apos;ing out MBR</source>
-        <translation>将MBR清零时写入错误</translation>
+        <translation>清零 MBR 时写入错误</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation>写入镜像失败&lt;br&gt;SD卡可能损坏。</translation>
+        <translation>镜像写入失败&lt;br&gt;SD 卡可能已损坏。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
@@ -99,83 +95,59 @@
     <message>
         <location filename="../downloadthread.cpp" line="468"/>
         <source>Error downloading: %1</source>
-        <translation>下载文件错误，已下载：%1</translation>
+        <translation>下载错误，已下载：%1</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="665"/>
         <source>Access denied error while writing file to disk.</source>
-        <translation>将文件写入磁盘时访问被拒绝。</translation>
+        <translation>将文件写入磁盘时被拒绝访问。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="670"/>
         <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
-        <translation>受控文件夹访问似乎已启用。 请将rpi-imager.exe和fat32format.exe都添加到允许的应用程序列表中，然后重试。</translation>
+        <translation>似乎已启用受控文件夹访问权限。 请将 rpi-imager.exe 和 fat32format.exe 添加至允许的应用程序列表中，然后重试。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="677"/>
         <source>Error writing file to disk</source>
-        <translation>将文件写入磁盘时出错</translation>
+        <translation>将文件写入磁盘时发生错误</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="699"/>
         <source>Download corrupt. Hash does not match</source>
-        <translation>下载的文件损坏。 哈希值不匹配</translation>
+        <translation>下载的文件已损坏。校验值不匹配</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="711"/>
         <location filename="../downloadthread.cpp" line="763"/>
         <source>Error writing to storage (while flushing)</source>
-        <translation>刷写存储时出错</translation>
+        <translation>写入存储设备时发生错误</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="718"/>
         <location filename="../downloadthread.cpp" line="770"/>
         <source>Error writing to storage (while fsync)</source>
-        <translation>在fsync时写入存储时出错</translation>
+        <translation>在写入存储设备时（fsync）发生错误</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="753"/>
         <source>Error writing first block (partition table)</source>
-        <translation>写入第一个块（分区表）时出错</translation>
+        <translation>在写入第一个区块（分区表）时发生错误</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="828"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation>从存储读取数据时错误。&lt;br&gt;SD卡可能已损坏。</translation>
+        <translation>从存储设备读取数据时发生错误。&lt;br&gt;SD 卡可能已损坏。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="847"/>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation>验证写入失败。 SD卡的内容与写入的内容不同。</translation>
+        <translation>写入校验失败。SD 卡与写入的内容不一致。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="900"/>
         <source>Customizing image</source>
         <translation>使用自定义镜像</translation>
-    </message>
-    <message>
-        <source>Waiting for FAT partition to be mounted</source>
-        <translation type="vanished">等待FAT分区挂载</translation>
-    </message>
-    <message>
-        <source>Error mounting FAT32 partition</source>
-        <translation type="vanished">挂载FAT32分区错误</translation>
-    </message>
-    <message>
-        <source>Operating system did not mount FAT32 partition</source>
-        <translation type="vanished">操作系统未能挂载FAT32分区</translation>
-    </message>
-    <message>
-        <source>Error creating firstrun.sh on FAT partition</source>
-        <translation type="vanished">在FAT分区上创建firstrun.sh脚本文件时出错</translation>
-    </message>
-    <message>
-        <source>Error writing to config.txt on FAT partition</source>
-        <translation type="vanished">在FAT分区上写入config.txt时出错</translation>
-    </message>
-    <message>
-        <source>Error writing to cmdline.txt on FAT partition</source>
-        <translation type="vanished">在FAT分区上写入cmdline.txt时出错</translation>
     </message>
 </context>
 <context>
@@ -185,22 +157,22 @@
         <location filename="../driveformatthread.cpp" line="124"/>
         <location filename="../driveformatthread.cpp" line="185"/>
         <source>Error partitioning: %1</source>
-        <translation>错误分区：%1</translation>
+        <translation>分区时发生错误：%1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="84"/>
         <source>Error starting fat32format</source>
-        <translation>启动fat32format命令时出错</translation>
+        <translation>fat32format 执行错误</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="94"/>
         <source>Error running fat32format: %1</source>
-        <translation>运行fat32format时出错：%1</translation>
+        <translation>运行 fat32format 时发生错误：%1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="104"/>
         <source>Error determining new drive letter</source>
-        <translation>确定新驱动器号时出错</translation>
+        <translation>确定新驱动器号时发生错误</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="109"/>
@@ -215,27 +187,27 @@
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
         <source>Error starting sfdisk</source>
-        <translation>启动sfdisk命令时出错</translation>
+        <translation>sfdisk 执行时发生错误</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="199"/>
         <source>Partitioning did not create expected FAT partition %1</source>
-        <translation type="unfinished"></translation>
+        <translation>分区操作未能按预期创建 FAT 分区 %1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="208"/>
         <source>Error starting mkfs.fat</source>
-        <translation>启动mkfs.fat时出错</translation>
+        <translation>执行 mkfs.fat 时发生错误</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="218"/>
         <source>Error running mkfs.fat: %1</source>
-        <translation>运行mkfs.fat时出错：%1</translation>
+        <translation>运行 mkfs.fat 时发生错误：%1</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="225"/>
         <source>Formatting not implemented for this platform</source>
-        <translation>暂不支持此平台的格式化</translation>
+        <translation>暂不支持在平台上进行格式化</translation>
     </message>
 </context>
 <context>
@@ -243,12 +215,12 @@
     <message>
         <location filename="../imagewriter.cpp" line="253"/>
         <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation>存储容量不足。&lt;br&gt;至少需要%1 GB的空白空间.</translation>
+        <translation>存储容量不足。&lt;br&gt;至少需要 %1 GB 的剩余空间.</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="259"/>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
-        <translation>输入文件不是有效的磁盘映像。&lt;br&gt;文件大小%1字节不是512字节的倍数。</translation>
+        <translation>所选文件是无效的磁盘镜像。&lt;br&gt;文件大小 %1 B 不是 512 B 的整倍数。</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="654"/>
@@ -263,17 +235,17 @@
     <message>
         <location filename="../imagewriter.cpp" line="962"/>
         <source>Error synchronizing time. Trying again in 3 seconds</source>
-        <translation type="unfinished"></translation>
+        <translation>时间同步错误。将在 3 秒后重试</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="974"/>
         <source>STP is enabled on your Ethernet switch. Getting IP will take long time.</source>
-        <translation type="unfinished"></translation>
+        <translation>您的以太网交换机启用了 STP。获取 IP 地址可能需要较长时间。</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="1185"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation type="unfinished"></translation>
+        <translation>您想要通过系统钥匙串预填 WiFi 密码吗？</translation>
     </message>
 </context>
 <context>
@@ -281,12 +253,12 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation>导入系统镜像</translation>
+        <translation>打开镜像</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
         <source>Error opening image file</source>
-        <translation>打开图像文件时出错</translation>
+        <translation>读取镜像文件时发生错误</translation>
     </message>
 </context>
 <context>
@@ -294,12 +266,12 @@
     <message>
         <location filename="../MsgPopup.qml" line="98"/>
         <source>NO</source>
-        <translation>不</translation>
+        <translation>否</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="107"/>
         <source>YES</source>
-        <translation>是</translation>
+        <translation>确认</translation>
     </message>
     <message>
         <location filename="../MsgPopup.qml" line="116"/>
@@ -309,7 +281,7 @@
     <message>
         <location filename="../MsgPopup.qml" line="124"/>
         <source>QUIT</source>
-        <translation type="unfinished"></translation>
+        <translation>退出</translation>
     </message>
 </context>
 <context>
@@ -317,30 +289,22 @@
     <message>
         <location filename="../OptionsPopup.qml" line="20"/>
         <source>OS Customization</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>for this session only</source>
-        <translation type="vanished">仅限本次</translation>
-    </message>
-    <message>
-        <source>to always use</source>
-        <translation type="vanished">永久保存</translation>
+        <translation>自定义系统配置</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="62"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation>通用</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="70"/>
         <source>Services</source>
-        <translation type="unfinished"></translation>
+        <translation>服务</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="73"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation>选项</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="89"/>
@@ -350,12 +314,12 @@
     <message>
         <location filename="../OptionsPopup.qml" line="112"/>
         <source>Set username and password</source>
-        <translation type="unfinished"></translation>
+        <translation>设置用户名及密码</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="134"/>
         <source>Username:</source>
-        <translation type="unfinished"></translation>
+        <translation>用户名</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="151"/>
@@ -366,12 +330,12 @@
     <message>
         <location filename="../OptionsPopup.qml" line="187"/>
         <source>Configure wireless LAN</source>
-        <translation>配置WiFi</translation>
+        <translation>配置 WiFi</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="206"/>
         <source>SSID:</source>
-        <translation>热点名：</translation>
+        <translation>WIFI 名（SSID）：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="239"/>
@@ -381,12 +345,12 @@
     <message>
         <location filename="../OptionsPopup.qml" line="245"/>
         <source>Hidden SSID</source>
-        <translation type="unfinished"></translation>
+        <translation>隐藏的 WIFI 名（Hidden SSID）</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="251"/>
         <source>Wireless LAN country:</source>
-        <translation>WIFI国家：</translation>
+        <translation>WIFI 国家/地区：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="262"/>
@@ -406,7 +370,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="299"/>
         <source>Enable SSH</source>
-        <translation>开启SSH服务</translation>
+        <translation>开启 SSH</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="318"/>
@@ -421,12 +385,12 @@
     <message>
         <location filename="../OptionsPopup.qml" line="346"/>
         <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation>设置%1用户的登录密匙：</translation>
+        <translation>为用户 “%1” 设置登录密匙：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="358"/>
         <source>RUN SSH-KEYGEN</source>
-        <translation type="unfinished"></translation>
+        <translation>运行 SSH-KEYGEN</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="376"/>
@@ -448,29 +412,13 @@
         <source>SAVE</source>
         <translation>保存</translation>
     </message>
-    <message>
-        <source>Disable overscan</source>
-        <translation type="vanished">禁用扫描</translation>
-    </message>
-    <message>
-        <source>Set password for &apos;%1&apos; user:</source>
-        <translation type="vanished">设置&apos;%1&apos;用户的密码：</translation>
-    </message>
-    <message>
-        <source>Skip first-run wizard</source>
-        <translation type="vanished">跳过首次启动向导</translation>
-    </message>
-    <message>
-        <source>Persistent settings</source>
-        <translation type="vanished">永久设置</translation>
-    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <location filename="../linux/linuxdrivelist.cpp" line="119"/>
         <source>Internal SD card reader</source>
-        <translation>内置SD卡读卡器</translation>
+        <translation>内置 SD 卡读卡器</translation>
     </message>
 </context>
 <context>
@@ -478,17 +426,17 @@
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="77"/>
         <source>Use OS customization?</source>
-        <translation type="unfinished"></translation>
+        <translation>使用自定义系统配置？</translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="92"/>
         <source>Would you like to apply OS customization settings?</source>
-        <translation type="unfinished"></translation>
+        <translation>您想应用自定义系统配置吗？</translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="134"/>
         <source>NO</source>
-        <translation type="unfinished">不</translation>
+        <translation>否</translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="115"/>
@@ -498,7 +446,7 @@
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="125"/>
         <source>YES</source>
-        <translation>是</translation>
+        <translation>确认</translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="102"/>
@@ -517,23 +465,23 @@
         <location filename="../main.qml" line="119"/>
         <location filename="../main.qml" line="481"/>
         <source>Raspberry Pi Device</source>
-        <translation type="unfinished"></translation>
+        <translation>树莓派设备</translation>
     </message>
     <message>
         <location filename="../main.qml" line="131"/>
         <source>CHOOSE DEVICE</source>
-        <translation type="unfinished"></translation>
+        <translation>选择设备</translation>
     </message>
     <message>
         <location filename="../main.qml" line="143"/>
         <source>Select this button to choose your target Raspberry Pi</source>
-        <translation type="unfinished"></translation>
+        <translation>选择您的树莓派型号</translation>
     </message>
     <message>
         <location filename="../main.qml" line="157"/>
         <location filename="../main.qml" line="584"/>
         <source>Operating System</source>
-        <translation>请选择需要写入的操作系统</translation>
+        <translation>操作系统</translation>
     </message>
     <message>
         <location filename="../main.qml" line="168"/>
@@ -550,32 +498,28 @@
         <location filename="../main.qml" line="194"/>
         <location filename="../main.qml" line="979"/>
         <source>Storage</source>
-        <translation>储存卡</translation>
+        <translation>储存设备</translation>
     </message>
     <message>
         <location filename="../main.qml" line="330"/>
         <source>Network not ready yet</source>
-        <translation type="unfinished"></translation>
+        <translation>网络不可用</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1007"/>
         <source>No storage devices found</source>
-        <translation type="unfinished"></translation>
+        <translation>找不到存储设备</translation>
     </message>
     <message>
         <location filename="../main.qml" line="205"/>
         <location filename="../main.qml" line="1317"/>
         <source>CHOOSE STORAGE</source>
-        <translation>选择SD卡</translation>
+        <translation>选择储存设备</translation>
     </message>
     <message>
         <location filename="../main.qml" line="219"/>
         <source>Select this button to change the destination storage device</source>
-        <translation>选择此按钮以更改目标存储设备</translation>
-    </message>
-    <message>
-        <source>WRITE</source>
-        <translation type="vanished">烧录</translation>
+        <translation>更改所选存储设备</translation>
     </message>
     <message>
         <location filename="../main.qml" line="265"/>
@@ -586,12 +530,12 @@
         <location filename="../main.qml" line="268"/>
         <location filename="../main.qml" line="1240"/>
         <source>Cancelling...</source>
-        <translation>取消...</translation>
+        <translation>正在取消……</translation>
     </message>
     <message>
         <location filename="../main.qml" line="280"/>
         <source>CANCEL VERIFY</source>
-        <translation>取消验证</translation>
+        <translation>取消校验</translation>
     </message>
     <message>
         <location filename="../main.qml" line="283"/>
@@ -603,7 +547,7 @@
     <message>
         <location filename="../main.qml" line="292"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation>下一步</translation>
     </message>
     <message>
         <location filename="../main.qml" line="298"/>
@@ -613,27 +557,27 @@
     <message>
         <location filename="../main.qml" line="320"/>
         <source>Using custom repository: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>使用自定义存储库（repository）：%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="339"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation type="unfinished"></translation>
+        <translation>键盘导航：&lt;tab&gt; 切换选项：&lt;space&gt; 确认/选择后使用 &lt;arrow up/down&gt; 可在列表中上下移动</translation>
     </message>
     <message>
         <location filename="../main.qml" line="360"/>
         <source>Language: </source>
-        <translation type="unfinished"></translation>
+        <translation>语言：</translation>
     </message>
     <message>
         <location filename="../main.qml" line="383"/>
         <source>Keyboard: </source>
-        <translation type="unfinished"></translation>
+        <translation>键盘：</translation>
     </message>
     <message>
         <location filename="../main.qml" line="500"/>
         <source>[ All ]</source>
-        <translation type="unfinished"></translation>
+        <translation>[ All ]</translation>
     </message>
     <message>
         <location filename="../main.qml" line="651"/>
@@ -653,7 +597,7 @@
     <message>
         <location filename="../main.qml" line="904"/>
         <source>Cached on your computer</source>
-        <translation>缓存在本地磁盘里</translation>
+        <translation>缓存到本地磁盘</translation>
     </message>
     <message>
         <location filename="../main.qml" line="906"/>
@@ -670,7 +614,7 @@
         <location filename="../main.qml" line="1094"/>
         <location filename="../main.qml" line="1100"/>
         <source>Mounted as %1</source>
-        <translation>挂载到：%1 上</translation>
+        <translation>挂载为：%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1096"/>
@@ -680,12 +624,12 @@
     <message>
         <location filename="../main.qml" line="1141"/>
         <source>Are you sure you want to quit?</source>
-        <translation>你确定你要退出吗？</translation>
+        <translation>确定要退出吗？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1142"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation>Raspberry Pi Imager还未完成任务。&lt;br&gt;您确定要退出吗？</translation>
+        <translation>树莓派镜像烧录器还未完成任务。&lt;br&gt;您确定要退出吗？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1153"/>
@@ -695,12 +639,12 @@
     <message>
         <location filename="../main.qml" line="1162"/>
         <source>Preparing to write...</source>
-        <translation>准备写入...</translation>
+        <translation>准备写入……</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1176"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation>&apos;%1&apos;上的所有现有数据将被删除。&lt;br&gt;确定要继续吗？</translation>
+        <translation>&apos;%1&apos; 上的所有数据都将被删除。&lt;br&gt;是否继续？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1191"/>
@@ -710,26 +654,22 @@
     <message>
         <location filename="../main.qml" line="1192"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation>有较新版本的rpi-imager。&lt;br&gt;需要下载更新吗？</translation>
-    </message>
-    <message>
-        <source>Error downloading OS list from Internet</source>
-        <translation type="vanished">下载镜像列表错误</translation>
+        <translation>检测到新版树莓派镜像烧录器。&lt;br&gt; 是否转到网页进行下载？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1243"/>
         <source>Writing... %1%</source>
-        <translation>写入中...%1%</translation>
+        <translation>正在写入…… %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1266"/>
         <source>Verifying... %1%</source>
-        <translation>验证文件中...%1%</translation>
+        <translation>正在校验…… %1%</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1273"/>
         <source>Preparing to write... (%1)</source>
-        <translation>写入中 (%1)</translation>
+        <translation>正在写入…… (%1)</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1293"/>
@@ -739,33 +679,33 @@
     <message>
         <location filename="../main.qml" line="1300"/>
         <source>Write Successful</source>
-        <translation>烧录成功</translation>
+        <translation>写入成功</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1301"/>
         <location filename="../imagewriter.cpp" line="596"/>
         <source>Erase</source>
-        <translation>擦除</translation>
+        <translation>格式化</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1302"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>&lt;b&gt;%1 &lt;/ b&gt;已被删除&lt;br&gt; &lt;br&gt;您现在可以从读取器中取出SD卡</translation>
+        <translation>&lt;b&gt;%1 &lt;/ b&gt;已格式化&lt;br&gt; &lt;br&gt;您现在可以从读卡器上取下 SD 卡了</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1309"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>&lt;b&gt;%1&lt;/b&gt; 已经成功烧录到 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;上了，你可以卸载SD卡了</translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; 已经成功烧录至 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;上，您现在可以从读卡器上取下 SD 卡了</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1463"/>
         <source>Error parsing os_list.json</source>
-        <translation>解析 os_list.json 错误</translation>
+        <translation>os_list.json 解析错误</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="597"/>
         <source>Format card as FAT32</source>
-        <translation>将SD卡格式化为FAT32格式</translation>
+        <translation>将 SD 卡格式化为 FAT32</translation>
     </message>
     <message>
         <location filename="../imagewriter.cpp" line="603"/>
@@ -775,33 +715,17 @@
     <message>
         <location filename="../imagewriter.cpp" line="604"/>
         <source>Select a custom .img from your computer</source>
-        <translation>使用下载的系统镜像文件烧录</translation>
+        <translation>选择已有 .img 文件进行写入</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1712"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation>连接包含镜像的U盘。&lt;br&gt;镜像必须位于U盘的根文件夹中。</translation>
+        <translation>要连接包含镜像的 USB 设备。&lt;br&gt;其镜像必须位于该设备的根文件夹下。</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1728"/>
         <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation>SD卡具有写保护。&lt;br&gt;尝试向上推SD卡的左侧的锁定开关，然后重试。</translation>
-    </message>
-    <message>
-        <source>Select this button to change the destination SD card</source>
-        <translation type="vanished">更改目标SD卡</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt; 已经成功烧录到 &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>QUIT APP</source>
-        <translation type="vanished">退出</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">继续</translation>
+        <translation>SD 卡写保护。&lt;br&gt;尝试向上推动 SD 卡左侧的锁定开关，然后重试。</translation>
     </message>
 </context>
 </TS>

--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -85,7 +85,7 @@
     <message>
         <location filename="../downloadthread.cpp" line="319"/>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
-        <translation>镜像写入失败&lt;br&gt;SD 卡可能已损坏。</translation>
+        <translation>在对设备尾部清零时写入错误&lt;br&gt;SD 卡标称的容量错误（可能是扩容卡）。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="408"/>
@@ -182,7 +182,7 @@
     <message>
         <location filename="../driveformatthread.cpp" line="146"/>
         <source>Error formatting (through udisks2)</source>
-        <translation>格式化错误</translation>
+        <translation>格式化时发生错误</translation>
     </message>
     <message>
         <location filename="../driveformatthread.cpp" line="174"/>
@@ -355,7 +355,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="262"/>
         <source>Set locale settings</source>
-        <translation>语言设置</translation>
+        <translation>本地化设置</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="272"/>
@@ -380,7 +380,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="328"/>
         <source>Allow public-key authentication only</source>
-        <translation>只允许使用公匙登录</translation>
+        <translation>仅使用公匙登录</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="346"/>
@@ -395,12 +395,12 @@
     <message>
         <location filename="../OptionsPopup.qml" line="376"/>
         <source>Play sound when finished</source>
-        <translation>完成后播放提示音</translation>
+        <translation>在完成后播放提示音</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="380"/>
         <source>Eject media when finished</source>
-        <translation>完成后弹出磁盘</translation>
+        <translation>在完成后弹出磁盘</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="384"/>
@@ -441,7 +441,7 @@
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="115"/>
         <source>NO, CLEAR SETTINGS</source>
-        <translation>清空所有设置</translation>
+        <translation>否，将清空所有设置</translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="125"/>
@@ -562,7 +562,7 @@
     <message>
         <location filename="../main.qml" line="339"/>
         <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation>键盘导航：&lt;tab&gt; 切换选项：&lt;space&gt; 确认/选择后使用 &lt;arrow up/down&gt; 可在列表中上下移动</translation>
+        <translation>键盘导航：&lt;tab&gt; 切换选项 &lt;space&gt; 确认/选择后使用 &lt;arrow up/down&gt; 可在列表中上下移动</translation>
     </message>
     <message>
         <location filename="../main.qml" line="360"/>
@@ -669,7 +669,7 @@
     <message>
         <location filename="../main.qml" line="1273"/>
         <source>Preparing to write... (%1)</source>
-        <translation>正在写入…… (%1)</translation>
+        <translation>准备写入…… (%1)</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1293"/>
@@ -679,7 +679,7 @@
     <message>
         <location filename="../main.qml" line="1300"/>
         <source>Write Successful</source>
-        <translation>写入成功</translation>
+        <translation>烧录成功</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1301"/>
@@ -690,12 +690,12 @@
     <message>
         <location filename="../main.qml" line="1302"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>&lt;b&gt;%1 &lt;/ b&gt;已格式化&lt;br&gt; &lt;br&gt;您现在可以从读卡器上取下 SD 卡了</translation>
+        <translation>&lt;b&gt;%1 &lt;/ b&gt; 已成功格式化&lt;br&gt; &lt;br&gt;您现在可以从读卡器上取下 SD 卡了</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1309"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>&lt;b&gt;%1&lt;/b&gt; 已经成功烧录至 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;上，您现在可以从读卡器上取下 SD 卡了</translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; 已成功烧录至 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;，您现在可以从读卡器上取下 SD 卡了</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1463"/>
@@ -715,12 +715,12 @@
     <message>
         <location filename="../imagewriter.cpp" line="604"/>
         <source>Select a custom .img from your computer</source>
-        <translation>选择已有 .img 文件进行写入</translation>
+        <translation>选择已有 .img 文件</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1712"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation>要连接包含镜像的 USB 设备。&lt;br&gt;其镜像必须位于该设备的根文件夹下。</translation>
+        <translation>请先连接一个包含镜像的 USB 设备。&lt;br&gt;其镜像必须位于该设备的根文件夹下。</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1728"/>

--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -12,7 +12,7 @@
     <message>
         <location filename="../downloadextractthread.cpp" line="261"/>
         <source>Error mounting FAT32 partition</source>
-        <translation>FAT32 分区挂载错误</translation>
+        <translation>挂载 FAT32 分区时发生错误</translation>
     </message>
     <message>
         <location filename="../downloadextractthread.cpp" line="281"/>
@@ -60,7 +60,7 @@
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation>请检查，在隐私设置中是否允许树莓派镜像烧录器（Raspberry Pi Imager）访问“可移除的宗卷”（位于“文件和文件夹”下），或为其授予“完全磁盘访问权限”。</translation>
+        <translation>请检查，在隐私设置中是否允许树莓派启动盘制作工具（Raspberry Pi Imager）访问“可移除的宗卷”（位于“文件和文件夹”下），或为其授予“完全磁盘访问权限”。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
@@ -459,7 +459,7 @@
     <message>
         <location filename="../main.qml" line="22"/>
         <source>Raspberry Pi Imager v%1</source>
-        <translation>树莓派镜像烧录器 v%1</translation>
+        <translation>树莓派启动盘制作工具 v%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="119"/>
@@ -629,7 +629,7 @@
     <message>
         <location filename="../main.qml" line="1142"/>
         <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation>树莓派镜像烧录器还未完成任务。&lt;br&gt;您确定要退出吗？</translation>
+        <translation>树莓派启动盘制作工具还未完成任务。&lt;br&gt;您确定要退出吗？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1153"/>
@@ -654,7 +654,7 @@
     <message>
         <location filename="../main.qml" line="1192"/>
         <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation>检测到新版树莓派镜像烧录器。&lt;br&gt; 是否转到网页进行下载？</translation>
+        <translation>检测到新版树莓派启动盘制作工具。&lt;br&gt; 是否转到网页进行下载？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1243"/>
@@ -679,7 +679,7 @@
     <message>
         <location filename="../main.qml" line="1300"/>
         <source>Write Successful</source>
-        <translation>烧录成功</translation>
+        <translation>写入成功</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1301"/>
@@ -695,7 +695,7 @@
     <message>
         <location filename="../main.qml" line="1309"/>
         <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>&lt;b&gt;%1&lt;/b&gt; 已成功烧录至 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;，您现在可以从读卡器上取下 SD 卡了</translation>
+        <translation>&lt;b&gt;%1&lt;/b&gt; 已成功写入至 &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;，您现在可以从读卡器上取下 SD 卡了</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1463"/>

--- a/src/i18n/rpi-imager_zh.ts
+++ b/src/i18n/rpi-imager_zh.ts
@@ -50,7 +50,7 @@
     <message>
         <location filename="../downloadthread.cpp" line="213"/>
         <source>Authentication cancelled</source>
-        <translation>认证已取消</translation>
+        <translation>验证已取消</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="216"/>
@@ -60,7 +60,7 @@
     <message>
         <location filename="../downloadthread.cpp" line="217"/>
         <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation>请检查，在隐私设置中是否允许树莓派镜像烧录器（Raspberry Pi Imager）访问“可移动卷”（位于“文件和文件夹”下），或为其授予“完整磁盘访问权限”。</translation>
+        <translation>请检查，在隐私设置中是否允许树莓派镜像烧录器（Raspberry Pi Imager）访问“可移除的宗卷”（位于“文件和文件夹”下），或为其授予“完全磁盘访问权限”。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="239"/>
@@ -70,7 +70,7 @@
     <message>
         <location filename="../downloadthread.cpp" line="281"/>
         <source>discarding existing data on drive</source>
-        <translation>清除已有数据</translation>
+        <translation>清除存储设备上的已有数据</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="301"/>
@@ -137,7 +137,7 @@
     <message>
         <location filename="../downloadthread.cpp" line="828"/>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation>从存储设备读取数据时发生错误。&lt;br&gt;SD 卡可能已损坏。</translation>
+        <translation>读取存储设备时发生错误。&lt;br&gt;SD 卡可能已损坏。</translation>
     </message>
     <message>
         <location filename="../downloadthread.cpp" line="847"/>
@@ -245,7 +245,7 @@
     <message>
         <location filename="../imagewriter.cpp" line="1185"/>
         <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation>您想要通过系统钥匙串预填 WiFi 密码吗？</translation>
+        <translation>您想要通过系统钥匙串访问自动填充 WiFi 密码吗？</translation>
     </message>
 </context>
 <context>
@@ -253,7 +253,7 @@
     <message>
         <location filename="../localfileextractthread.cpp" line="34"/>
         <source>opening image file</source>
-        <translation>打开镜像</translation>
+        <translation>打开镜像文件</translation>
     </message>
     <message>
         <location filename="../localfileextractthread.cpp" line="39"/>
@@ -304,7 +304,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="73"/>
         <source>Options</source>
-        <translation>选项</translation>
+        <translation>可选配置</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="89"/>
@@ -319,7 +319,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="134"/>
         <source>Username:</source>
-        <translation>用户名</translation>
+        <translation>用户名：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="151"/>
@@ -330,12 +330,12 @@
     <message>
         <location filename="../OptionsPopup.qml" line="187"/>
         <source>Configure wireless LAN</source>
-        <translation>配置 WiFi</translation>
+        <translation>配置 WLAN</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="206"/>
         <source>SSID:</source>
-        <translation>WIFI 名（SSID）：</translation>
+        <translation>网络名称：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="239"/>
@@ -345,12 +345,12 @@
     <message>
         <location filename="../OptionsPopup.qml" line="245"/>
         <source>Hidden SSID</source>
-        <translation>隐藏的 WIFI 名（Hidden SSID）</translation>
+        <translation>隐藏的网络</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="251"/>
         <source>Wireless LAN country:</source>
-        <translation>WIFI 国家/地区：</translation>
+        <translation>WLAN 区域：</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="262"/>
@@ -400,7 +400,7 @@
     <message>
         <location filename="../OptionsPopup.qml" line="380"/>
         <source>Eject media when finished</source>
-        <translation>在完成后弹出磁盘</translation>
+        <translation>在完成后卸载磁盘</translation>
     </message>
     <message>
         <location filename="../OptionsPopup.qml" line="384"/>
@@ -441,7 +441,7 @@
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="115"/>
         <source>NO, CLEAR SETTINGS</source>
-        <translation>否，将清空所有设置</translation>
+        <translation>否，并清空所有设置</translation>
     </message>
     <message>
         <location filename="../UseSavedSettingsPopup.qml" line="125"/>
@@ -475,7 +475,7 @@
     <message>
         <location filename="../main.qml" line="143"/>
         <source>Select this button to choose your target Raspberry Pi</source>
-        <translation>选择您的树莓派型号</translation>
+        <translation>点击此处选择您的树莓派型号</translation>
     </message>
     <message>
         <location filename="../main.qml" line="157"/>
@@ -492,7 +492,7 @@
     <message>
         <location filename="../main.qml" line="180"/>
         <source>Select this button to change the operating system</source>
-        <translation>更改操作系统</translation>
+        <translation>点击此处更改操作系统</translation>
     </message>
     <message>
         <location filename="../main.qml" line="194"/>
@@ -519,7 +519,7 @@
     <message>
         <location filename="../main.qml" line="219"/>
         <source>Select this button to change the destination storage device</source>
-        <translation>更改所选存储设备</translation>
+        <translation>点击此处更改所选存储设备</translation>
     </message>
     <message>
         <location filename="../main.qml" line="265"/>
@@ -552,7 +552,7 @@
     <message>
         <location filename="../main.qml" line="298"/>
         <source>Select this button to start writing the image</source>
-        <translation>开始写入</translation>
+        <translation>点击此处开始写入</translation>
     </message>
     <message>
         <location filename="../main.qml" line="320"/>
@@ -587,7 +587,7 @@
     <message>
         <location filename="../main.qml" line="652"/>
         <source>Go back to main menu</source>
-        <translation>回到主页</translation>
+        <translation>回到主菜单</translation>
     </message>
     <message>
         <location filename="../main.qml" line="894"/>
@@ -614,7 +614,7 @@
         <location filename="../main.qml" line="1094"/>
         <location filename="../main.qml" line="1100"/>
         <source>Mounted as %1</source>
-        <translation>挂载为：%1</translation>
+        <translation>已挂载为：%1</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1096"/>
@@ -624,7 +624,7 @@
     <message>
         <location filename="../main.qml" line="1141"/>
         <source>Are you sure you want to quit?</source>
-        <translation>确定要退出吗？</translation>
+        <translation>您确定要退出吗？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1142"/>
@@ -644,7 +644,7 @@
     <message>
         <location filename="../main.qml" line="1176"/>
         <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation>&apos;%1&apos; 上的所有数据都将被删除。&lt;br&gt;是否继续？</translation>
+        <translation>&apos;%1&apos; 上的已有数据都将被删除。&lt;br&gt;是否继续？</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1191"/>
@@ -715,12 +715,12 @@
     <message>
         <location filename="../imagewriter.cpp" line="604"/>
         <source>Select a custom .img from your computer</source>
-        <translation>选择已有 .img 文件</translation>
+        <translation>选择本地已有的 .img 文件</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1712"/>
         <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation>请先连接一个包含镜像的 USB 设备。&lt;br&gt;其镜像必须位于该设备的根文件夹下。</translation>
+        <translation>请先连接一个包含镜像的 USB 设备。&lt;br&gt;其镜像必须位于该设备的根路径下。</translation>
     </message>
     <message>
         <location filename="../main.qml" line="1728"/>

--- a/src/linux/org.raspberrypi.rpi-imager.desktop
+++ b/src/linux/org.raspberrypi.rpi-imager.desktop
@@ -2,7 +2,9 @@
 Type=Application
 Version=1.0
 Name=Imager
+Name[zh_CN]=树莓派启动盘制作工具
 Comment=Raspberry Pi Imager
+Comment[zh_CN]=树莓派启动盘制作工具
 Icon=rpi-imager
 Exec=rpi-imager %F
 Categories=Utility


### PR DESCRIPTION
Update zh-CN (Simplified Chinese) translation.

- The Simplified Chinese translation of Raspberry Pi Imager has been revised to more closely align with the original text.
- Any entries that were not present in the original text have been removed, and any entries that were not translated have been updated.
- The translation has been subjected to rigorous accuracy checks to ensure optimal alignment with the target audience of Raspberry Pi.
- The terminology employed in reference to Apple macOS has been aligned with the Simplified Chinese translations utilized within the macOS system itself.
- Added translation for Linux desktop icon file

Note: I am unfamiliar with the programming environment on macOS and the process of modifying `Info.plist.in`.  **Therefore, I request that someone with the requisite expertise perform these modifications in the future. I am not familiar with Windows at all `rpi-imager.rc` or `rpi-imager.nsi.in`. Sorry.**