### PR TITLE
Fix GPT signature test

### DIFF
--- a/src/devicewrapper.cpp
+++ b/src/devicewrapper.cpp
@@ -166,7 +166,7 @@ DeviceWrapperFatPartition *DeviceWrapper::fatPartition(int nr)
     struct gpt_partition gptpart;
     pread((char *) &gpt, sizeof(gpt), 512);
 
-    if (!strcmp("EFI PART", gpt.Signature) && gpt.MyLBA == 1)
+    if (!strncmp("EFI PART", gpt.Signature, 8) && gpt.MyLBA == 1)
     {
         qDebug() << "Using GPT partition table";
         if (nr > gpt.NumberOfPartitionEntries)


### PR DESCRIPTION
gpt.Signature is not a null-terminated string, but an 8-byte character array. Using `strcmp` will not provide a valid result. Use `strncmp` over the first 8 bytes instead.