### PR TITLE
Linux/OSX: Fix reversed fsync check

### DIFF
--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -314,7 +314,7 @@ bool DownloadThread::_openAndPrepareDevice()
         if (!_file.seek(knownsize-emptyMB.size())
                 || !_file.write(emptyMB.data(), emptyMB.size())
                 || !_file.flush()
-                || !::fsync(_file.handle()))
+                || ::fsync(_file.handle()))
         {
             emit error(tr("Write error while trying to zero out last part of card.<br>"
                           "Card could be advertising wrong capacity (possible counterfeit)."));


### PR DESCRIPTION
This if() condition checks the result of seek, write, flush and fsync. The first three are methods on QFile, so return a truthy value on success. write() returns number of bytes written while seek() and flush() return bool true on success. Therefore they have to be inverted to detect errors. However, fsync() is a posix system call, so it returns zero (false) on success. Therefore it should not be inverted.

Note that currently this entire code block can never run. knownsize is always zero because QFile.size() currently cannot determine the size of a block device. However, when I asked to confirm this behavior, a Qt maintainer decided to implement it, so there is now a PR. If that is released then this code block will become live and the reversed fsync check will cause a problem.

PR: https://codereview.qt-project.org/c/qt/qtbase/+/581443