### PR TITLE
Fix duplicate string in OS list

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -1619,7 +1619,9 @@ ApplicationWindow {
             var candidate = oslist_parsed[0]
 
             if ("description" in candidate && !("subitems" in candidate)) {
-                candidate["description"] += " (Recommended)"
+                if (!candidate["description"].includes("(Recommended)")) {
+                    candidate["description"] += " (Recommended)"
+                }
             }
         }
 


### PR DESCRIPTION
The "(Recommended)" string can be appended twice when the description already contains (Recommended) as is the case with the Pi OS 64 bit image:
![image](https://github.com/user-attachments/assets/ae64a7b4-b9ba-423f-b760-210f2179e684)

This adds a check to ensure this doesn't happen.
