### PR TITLE
Update the issue templates for the latest release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -24,7 +24,8 @@ body:
       label: Version
       description: What version of our software are you running?
       options:
-        - 1.8.5 (Default)
+        - 1.9.0 (Default)
+        - 1.8.5
         - 1.8.4
         - 1.8.3
         - 1.8.2

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -47,7 +47,8 @@ body:
       label: Version
       description: What version of our software did you last run?
       options:
-        - 1.8.5 (Default)
+        - 1.9.0 (Default)
+        - 1.8.5
         - 1.8.4
         - 1.8.3
         - 1.8.2


### PR DESCRIPTION
The issue templates had not been adjusted for the latest release, fix this by inserting the correct version into the template. In the future this is a task that should probably be automated.