### PR TITLE
Fix GitHub Actions and add Fedora workflow

### DIFF
--- a/.github/workflows/build-fedora.yml
+++ b/.github/workflows/build-fedora.yml
@@ -1,0 +1,48 @@
+name: Build Fedora
+
+on:
+  push:
+    branches: [ "qml" ]
+  pull_request:
+    branches: [ "qml" ]
+
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    name: Fedora ${{ matrix.fedora_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora_version: [ '40', '41', '42' ]
+    container: fedora:${{ matrix.fedora_version }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # After Fedora 40 the containers no longer have 'lsblk'
+    - name: Ensure lsblk installed
+      run : sudo dnf install -y util-linux
+
+    - name: Install dependencies
+      # On Fedora, rather than use install-qt-action, install the Qt6 packages from Fedora
+      run: sudo dnf install -y gnutls-devel qt6-qtbase-devel qt6-qtsvg-devel qt6-qtquick3d-devel qt6-qttools-devel qt6-qtquickcontrols2-devel libcurl-devel libarchive-devel libzstd-devel zlib-devel lzma-sdk-devel libdrm-devel
+
+    - name: Configure CMake
+      run: |
+        cmake --version
+        cmake -S src/ -B build/ -Wdev -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: CMake Build ${{env.BUILD_TYPE}}
+      run: cmake --build build --target all --config ${{env.BUILD_TYPE}} -- -j4
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: rpi-imager-fedora-${{ matrix.fedora_version }}.zip
+        if-no-files-found: 'error'
+        path: |
+          build/rpi-imager
+          build/*.qm

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,28 +7,52 @@ on:
     branches: [ "qml" ]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
   build:
-    runs-on: macos-latest
-
-    defaults:
-      run:
-        working-directory: src
+    # macos-latest is currently macos-14-arm64
+    name: macOS ${{ matrix.os_version }}
+    runs-on: macos-${{ matrix.os_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os_version: '12', arch: 'x86_64' } # macos-12 can only target x86_64
+          - { os_version: '13', arch: 'x86_64' } # macos-13 can do a universal build targeting x86_64 and/or arm64
+          - { os_version: '14', arch: 'arm64' }  # macos-14 is an m1 cpu and can only target arm64
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.7.*'
+        host: 'mac'
+        target: 'desktop'
+        arch: 'clang_64'
+        tools: 'tools_qtcreator tools_cmake'
 
+    - name: Configure Qt6_ROOT
+      # The CMakeLists file requires Qt6_ROOT to be set for Mac builds to find macdeployqt
+      run: echo "Qt6_ROOT=$QT_ROOT_DIR" >> $GITHUB_ENV
+  
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: |
+        cmake --version
+        cmake -S src/ -B ${{github.workspace}}/build -Wdev -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_OSX_ARCHITECTURES=${{matrix.arch}}
 
-    - name: Build
+    - name: CMake Build ${{env.BUILD_TYPE}}
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build . --config ${{env.BUILD_TYPE}}
+      working-directory: ${{github.workspace}}/build
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: rpi-imager-osx-${{ matrix.os_version }}.zip
+        if-no-files-found: 'error'
+        path: |
+          build/*.dmg

--- a/.github/workflows/build-ubuntu-deb.yml
+++ b/.github/workflows/build-ubuntu-deb.yml
@@ -6,17 +6,62 @@ on:
   pull_request:
     branches: [ "qml" ]
 
+env:
+  BUILD_TYPE: Release
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Ubuntu ${{ matrix.ubuntu_version }}
+    runs-on: ubuntu-${{ matrix.ubuntu_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_version: [ '20.04', '22.04', 'latest' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt install -y --no-install-recommends build-essential devscripts debhelper cmake git libarchive-dev libcurl4-gnutls-dev
-           qtbase5-dev qtbase5-dev-tools qtdeclarative5-dev libqt5svg5-dev qttools5-dev libgnutls28-dev
-           qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-templates2 qml-module-qtquick-window2 qml-module-qtgraphicaleffects
+      run: |
+        sudo apt update -y
+        sudo apt install -y --no-install-recommends devscripts debhelper cmake libarchive-dev libcurl4-gnutls-dev libgnutls28-dev
 
-    - name: Build
-      run: debuild -uc -us
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.7.*'
+        host: 'linux'
+        target: 'desktop'
+        arch: 'linux_gcc_64'
+        tools: 'tools_qtcreator tools_cmake'
+
+    - name: Configure Qt6_ROOT
+      # The Qt6_ROOT variable can be set based on the install-qt-action
+      run: echo "Qt6_ROOT=$QT_ROOT_DIR" >> $GITHUB_ENV
+
+# No longer need qt libs from Ubuntu Repo but if we did QT6 will be:
+# qt6-base-dev qt6-base-dev-tools qt6-declarative-dev libqt6svg6-dev qt6-tools-dev linguist-qt6 qml6-module-qtquick qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtquick-templates qml6-module-qtquick-window
+
+    - name: Cmake Build
+      run: |
+        cmake --version
+        cmake -S src/ -B build/ -Wdev -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: CMake Build ${{env.BUILD_TYPE}}
+      run: cmake --build build --target all --config ${{env.BUILD_TYPE}} -- -j4
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: rpi-imager-ubuntu-${{ matrix.ubuntu_version }}.zip
+        if-no-files-found: 'error'
+        path: |
+          build/rpi-imager
+          build/*.qm
+
+#    - name: Configure LD_LIBRARY_PATH
+#      run: |
+#        echo "LD_LIBRARY_PATH=$QT_ROOT_DIR/lib" >> $GITHUB_ENV
+#
+#    - name: build Debian package
+#      run: |
+#        debuild -uc -us

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
            qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-layouts qml-module-qtquick-templates2 qml-module-qtquick-window2 qml-module-qtgraphicaleffects
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2020-2024 Raspberry Pi Ltd
 
-cmake_minimum_required(VERSION 3.15)
+# To build for Apple platforms you need to set cmake_minimum_required() to 3.21.1 or newer
+# see: https://doc.qt.io/qt-6/macos-deployment.html#using-cmake
+cmake_minimum_required(VERSION 3.21.1)
+
 OPTION (ENABLE_CHECK_VERSION "Check for version updates" ON)
 OPTION (ENABLE_TELEMETRY "Enable sending telemetry" ON)
 OPTION (DRIVELIST_FILTER_SYSTEM_DRIVES "Filter System drives from displayed drives" ON)
@@ -418,13 +421,17 @@ elseif(APPLE)
     set(EXTRALIBS ${EXTRALIBS} ${CoreFoundation} ${DiskArbitration} ${Security} ${Cocoa} ${IOKit} ${SystemConfiguration} iconv)
     set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE YES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/mac/Info.plist.in)
 
+    message(STATUS "Looking for macdeployqt")
     find_program(MACDEPLOYQT "macdeployqt" PATHS "${Qt6_ROOT}/bin")
     if (NOT MACDEPLOYQT_EXECUTABLE)
         message(FATAL_ERROR "Unable to locate macdeployqt")
+    else()
+        message(STATUS "Found macdeployqt in ${Qt6_ROOT}/bin")
     endif()
 
     if(IMAGER_SIGNED_APP)
         if(IMAGER_SIGNING_IDENTITY)
+            message(STATUS "Signing identity found")
             # Create the .app, leveraging macdeployqt's knowledge of Qt libraries and configuration files
             add_custom_command(TARGET ${PROJECT_NAME}
                 POST_BUILD
@@ -438,11 +445,13 @@ elseif(APPLE)
                 COMMAND codesign -f --deep --digest-algorithm=sha1,sha256 -o runtime --timestamp -s "${IMAGER_SIGNING_IDENTITY}" "${CMAKE_BINARY_DIR}/Raspberry\ Pi\ Imager.app")
 
             # Create the .dmg for distribution
+            message(STATUS "Creating .dmg file...")
             add_custom_command(TARGET ${PROJECT_NAME}
                 POST_BUILD
                 COMMAND hdiutil create -volname "Raspberry Pi Imager" -srcfolder "${CMAKE_BINARY_DIR}/Raspberry\ Pi\ Imager.app" -ov -format UDBZ "${CMAKE_BINARY_DIR}/Raspberry\ Pi\ Imager.dmg")
 
             # Sign the .dmg for distribution, but do not initialise notarisation
+            message(STATUS "Signing .dmg file...")
             add_custom_command(TARGET ${PROJECT_NAME}
                 POST_BUILD
                 COMMAND codesign -f --digest-algorithm=sha1,sha256 -o runtime --timestamp -s "${IMAGER_SIGNING_IDENTITY}" "${CMAKE_BINARY_DIR}/Raspberry\ Pi\ Imager.dmg")
@@ -465,9 +474,18 @@ elseif(APPLE)
         endif(IMAGER_SIGNING_IDENTITY)
     else()
         # Unsigned application
+        message(STATUS "App will be unsigned")
         add_custom_command(TARGET ${PROJECT_NAME}
             POST_BUILD
-            COMMAND "${MACDEPLOYQT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/Raspberry\ Pi\ Imager.app" -qmldir="${CMAKE_CURRENT_SOURCE_DIR}" -always-overwrite -no-strip -dmg)
+            COMMAND "${MACDEPLOYQT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app" -qmldir="${CMAKE_CURRENT_SOURCE_DIR}" -always-overwrite -no-strip -dmg)
+        # Rename .app file
+        add_custom_command(TARGET ${PROJECT_NAME}
+            POST_BUILD
+            COMMAND mv "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app" "${CMAKE_BINARY_DIR}/Raspberry\ Pi\ Imager.app")
+        message(STATUS "Creating .dmg file...")
+        add_custom_command(TARGET ${PROJECT_NAME}
+            POST_BUILD
+            COMMAND hdiutil create -volname "Raspberry Pi Imager" -srcfolder "${CMAKE_BINARY_DIR}/Raspberry\ Pi\ Imager.app" -ov -format UDBZ "${CMAKE_BINARY_DIR}/Raspberry\ Pi\ Imager.dmg")
     endif(IMAGER_SIGNED_APP)
 
     add_custom_command(TARGET ${PROJECT_NAME}


### PR DESCRIPTION
While in the process of creating a GitHub workflow for Fedora builds I found that there were problems with the current workflows and the CMakeLists file. I've fixed the problems so that all builds now pass and also, by using a build matrix, the builds are run on multiple versions of the operating systems. They also make build artifacts available in a zip file:

![image](https://github.com/user-attachments/assets/2feb4a96-db64-4aa8-bf65-abaa95d885d8)

Adding Windows builds would be a good addition