### PR TITLE
Explicitly add '--tree' to the lsblk to remove partitions from top level output

### DIFF
--- a/src/linux/linuxdrivelist.cpp
+++ b/src/linux/linuxdrivelist.cpp
@@ -52,6 +52,7 @@ namespace Drivelist
             "--bytes",
             "--json",
             "--paths",
+            "--tree",
             "--output", "kname,type,subsystems,ro,rm,hotplug,size,phy-sec,log-sec,label,vendor,model,mountpoint",
             "--exclude", "7"
         };


### PR DESCRIPTION
After trimming the lsblk output by listing only required columns (see [1]), the output includes not only the disk devices, but also their partitions, which significantly clutters the device selection dialog.

This happens becuase the "--output" argument [2] defaults to using "--tree", but only if the column "NAME" is outputed, which in current state doesn't (only "kname" is used). So that all child elements (e.g. partitions) are listed on the same level with disk devices.

Thus ist's proposed to explicitly add "--tree" argument, so that we don't rely on lsblk CLI intricacies.

Fixes #935 

[1] https://github.com/raspberrypi/rpi-imager/commit/baae3c76417cde5c7a38b37400a016f7e7cdb5d1
[2] https://www.mankier.com/8/lsblk#--output