### PR TITLE
Filter system drives by user choice

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,6 @@
 cmake_minimum_required(VERSION 3.15)
 OPTION (ENABLE_CHECK_VERSION "Check for version updates" ON)
 OPTION (ENABLE_TELEMETRY "Enable sending telemetry" ON)
-OPTION (DRIVELIST_FILTER_SYSTEM_DRIVES "Filter System drives from displayed drives" ON)
 
 set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "Which macOS architectures to build for")
 
@@ -306,13 +305,6 @@ if(ENABLE_CHECK_VERSION)
     add_definitions(-DCHECK_VERSION_DEFAULT=true)
 else()
     add_definitions(-DCHECK_VERSION_DEFAULT=false)
-endif()
-
-if(DRIVELIST_FILTER_SYSTEM_DRIVES)
-   # Hide system drives from list
-   add_definitions(-DDRIVELIST_FILTER_SYSTEM_DRIVES=true)
-else()
-   add_definitions(-DDRIVELIST_FILTER_SYSTEM_DRIVES=false)
 endif()
 
 # Because dependencies are typically not available by default on Windows, build bundled code

--- a/src/drivelistitem.cpp
+++ b/src/drivelistitem.cpp
@@ -5,8 +5,8 @@
 
 #include "drivelistitem.h"
 
-DriveListItem::DriveListItem(QString device, QString description, quint64 size, bool isUsb, bool isScsi, bool readOnly, QStringList mountpoints, QObject *parent)
-    : QObject(parent), _device(device), _description(description), _mountpoints(mountpoints), _size(size), _isUsb(isUsb), _isScsi(isScsi), _isReadOnly(readOnly)
+DriveListItem::DriveListItem(QString device, QString description, quint64 size, bool isUsb, bool isScsi, bool readOnly, bool isSystem, QStringList mountpoints, QObject *parent)
+    : QObject(parent), _device(device), _description(description), _mountpoints(mountpoints), _size(size), _isUsb(isUsb), _isScsi(isScsi), _isReadOnly(readOnly), _isSystem(isSystem)
 {
 
 }

--- a/src/drivelistitem.h
+++ b/src/drivelistitem.h
@@ -13,7 +13,7 @@ class DriveListItem : public QObject
 {
     Q_OBJECT
 public:
-    explicit DriveListItem(QString device, QString description, quint64 size, bool isUsb = false, bool isScsi = false, bool readOnly = false, QStringList mountpoints = QStringList(), QObject *parent = nullptr);
+    explicit DriveListItem(QString device, QString description, quint64 size, bool isUsb = false, bool isScsi = false, bool readOnly = false, bool isSystem = false, QStringList mountpoints = QStringList(), QObject *parent = nullptr);
 
     Q_PROPERTY(QString device MEMBER _device CONSTANT)
     Q_PROPERTY(QString description MEMBER _description CONSTANT)
@@ -22,6 +22,7 @@ public:
     Q_PROPERTY(bool isUsb MEMBER _isUsb CONSTANT)
     Q_PROPERTY(bool isScsi MEMBER _isScsi CONSTANT)
     Q_PROPERTY(bool isReadOnly MEMBER _isReadOnly CONSTANT)
+    Q_PROPERTY(bool isSystem MEMBER _isSystem CONSTANT)
     Q_INVOKABLE int sizeInGb();
 
 signals:
@@ -36,6 +37,7 @@ protected:
     bool _isUsb;
     bool _isScsi;
     bool _isReadOnly;
+    bool _isSystem;
 };
 
 #endif // DRIVELISTITEM_H

--- a/src/drivelistmodel.cpp
+++ b/src/drivelistmodel.cpp
@@ -19,6 +19,7 @@ DriveListModel::DriveListModel(QObject *parent)
         {isUsbRole, "isUsb"},
         {isScsiRole, "isScsi"},
         {isReadOnlyRole, "isReadOnly"},
+        {isSystemRole, "isSystem"},
         {mountpointsRole, "mountpoints"}
     };
 
@@ -52,7 +53,6 @@ QVariant DriveListModel::data(const QModelIndex &index, int role) const
 void DriveListModel::processDriveList(std::vector<Drivelist::DeviceDescriptor> l)
 {
     bool changes = false;
-    bool filterSystemDrives = DRIVELIST_FILTER_SYSTEM_DRIVES;
     QSet<QString> drivesInNewList;
 
     for (auto &i: l)
@@ -64,11 +64,6 @@ void DriveListModel::processDriveList(std::vector<Drivelist::DeviceDescriptor> l
             mountpoints.append(QString::fromStdString(s));
         }
 
-        if (filterSystemDrives)
-        {
-            if (i.isSystem)
-                continue;
-        }
         // Should already be caught by isSystem variable, but just in case...
         if (mountpoints.contains("/") || mountpoints.contains("C://"))
             continue;
@@ -96,7 +91,7 @@ void DriveListModel::processDriveList(std::vector<Drivelist::DeviceDescriptor> l
                 changes = true;
             }
 
-            _drivelist[deviceNamePlusSize] = new DriveListItem(QString::fromStdString(i.device), QString::fromStdString(i.description), i.size, i.isUSB, i.isSCSI, i.isReadOnly, mountpoints, this);
+            _drivelist[deviceNamePlusSize] = new DriveListItem(QString::fromStdString(i.device), QString::fromStdString(i.description), i.size, i.isUSB, i.isSCSI, i.isReadOnly, i.isSystem, mountpoints, this);
         }
     }
 

--- a/src/drivelistmodel.h
+++ b/src/drivelistmodel.h
@@ -24,7 +24,7 @@ public:
     void stopPolling();
 
     enum driveListRoles {
-        deviceRole = Qt::UserRole + 1, descriptionRole, sizeRole, isUsbRole, isScsiRole, isReadOnlyRole, mountpointsRole
+        deviceRole = Qt::UserRole + 1, descriptionRole, sizeRole, isUsbRole, isScsiRole, isReadOnlyRole, isSystemRole, mountpointsRole
     };
 
 public slots:

--- a/src/main.qml
+++ b/src/main.qml
@@ -1099,7 +1099,6 @@ ApplicationWindow {
                             Layout.fillWidth: true
                             font.family: roboto.name
                             font.pointSize: 16
-                            color: (isReadOnly || unselectable) ? "grey" : "";
                             color: !dstitem.unselectable ? "" : "grey";
                             text: {
                                 var sizeStr = (size/1000000000).toFixed(1)+ " " + qsTr("GB");
@@ -1114,7 +1113,6 @@ ApplicationWindow {
                             Layout.fillWidth: true
                             font.family: roboto.name
                             font.pointSize: 12
-                            color: "grey"
                             color: !dstitem.unselectable ? "" : "grey";
                             text: {
                                 var txt= qsTr("Mounted as %1").arg(mountpoints.join(", "));
@@ -1141,10 +1139,8 @@ ApplicationWindow {
 
             MouseArea {
                 anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
                 cursorShape: !dstitem.unselectable ? Qt.PointingHandCursor : Qt.ForbiddenCursor
                 hoverEnabled: true
-                enabled: filterSystemDrives.checked
                 enabled: !dstitem.unselectable
 
                 onEntered: {

--- a/src/main.qml
+++ b/src/main.qml
@@ -1045,6 +1045,7 @@ ApplicationWindow {
         id: dstdelegate
 
         Item {
+            id: dstitem
             anchors.left: parent.left
             anchors.right: parent.right
             Layout.topMargin: 1
@@ -1059,6 +1060,7 @@ ApplicationWindow {
             property string description: model.description
             property string device: model.device
             property string size: model.size
+            property bool unselectable: (isSystem && filterSystemDrives.checked) || isReadOnly
 
             Rectangle {
                 id: dstbgrect
@@ -1069,7 +1071,6 @@ ApplicationWindow {
 
                 color: mouseOver ? "#f5f5f5" : "#ffffff"
                 property bool mouseOver: false
-                property bool unselectable: isSystem && filterSystemDrives.checked
 
                 RowLayout {
                     anchors.fill: parent
@@ -1099,6 +1100,7 @@ ApplicationWindow {
                             font.family: roboto.name
                             font.pointSize: 16
                             color: (isReadOnly || unselectable) ? "grey" : "";
+                            color: !dstitem.unselectable ? "" : "grey";
                             text: {
                                 var sizeStr = (size/1000000000).toFixed(1)+ " " + qsTr("GB");
                                 return description + " - " + sizeStr;
@@ -1113,6 +1115,7 @@ ApplicationWindow {
                             font.family: roboto.name
                             font.pointSize: 12
                             color: "grey"
+                            color: !dstitem.unselectable ? "" : "grey";
                             text: {
                                 var txt= qsTr("Mounted as %1").arg(mountpoints.join(", "));
                                 if (isReadOnly) {
@@ -1139,8 +1142,10 @@ ApplicationWindow {
             MouseArea {
                 anchors.fill: parent
                 cursorShape: Qt.PointingHandCursor
+                cursorShape: !dstitem.unselectable ? Qt.PointingHandCursor : Qt.ForbiddenCursor
                 hoverEnabled: true
                 enabled: filterSystemDrives.checked
+                enabled: !dstitem.unselectable
 
                 onEntered: {
                     dstbgrect.mouseOver = true

--- a/src/main.qml
+++ b/src/main.qml
@@ -991,7 +991,7 @@ ApplicationWindow {
             anchors.top: dstpopup_title_separator.bottom
             anchors.left: parent.left
             anchors.right: parent.right
-            anchors.bottom: parent.bottom
+            anchors.bottom: filterRow.top
             boundsBehavior: Flickable.StopAtBounds
             highlight: Rectangle { color: "lightsteelblue"; radius: 5 }
             clip: true
@@ -1023,6 +1023,22 @@ ApplicationWindow {
             Keys.onEnterPressed: Keys.onSpacePressed(event)
             Keys.onReturnPressed: Keys.onSpacePressed(event)
         }
+        RowLayout {
+            id: filterRow
+            anchors {
+                bottom: parent.bottom
+                right: parent.right
+                left: parent.left
+            }
+            Item {
+                Layout.fillWidth: true
+            }
+            ImCheckBox {
+                id: filterSystemDrives
+                checked: true
+                text: qsTr("Exclude System Drives")
+            }
+        }
     }
 
     Component {
@@ -1053,6 +1069,7 @@ ApplicationWindow {
 
                 color: mouseOver ? "#f5f5f5" : "#ffffff"
                 property bool mouseOver: false
+                property bool unselectable: isSystem && filterSystemDrives.checked
 
                 RowLayout {
                     anchors.fill: parent
@@ -1081,7 +1098,7 @@ ApplicationWindow {
                             Layout.fillWidth: true
                             font.family: roboto.name
                             font.pointSize: 16
-                            color: isReadOnly ? "grey" : "";
+                            color: (isReadOnly || unselectable) ? "grey" : "";
                             text: {
                                 var sizeStr = (size/1000000000).toFixed(1)+ " " + qsTr("GB");
                                 return description + " - " + sizeStr;
@@ -1099,7 +1116,9 @@ ApplicationWindow {
                             text: {
                                 var txt= qsTr("Mounted as %1").arg(mountpoints.join(", "));
                                 if (isReadOnly) {
-                                    txt += " " + qsTr("[WRITE PROTECTED]")
+                                    txt += " " + qsTr("[WRITE PROTECTED]");
+                                } else if (isSystem) {
+                                    text += " [" + qsTr("SYSTEM") + "]";
                                 }
                                 return txt;
                             }
@@ -1121,6 +1140,7 @@ ApplicationWindow {
                 anchors.fill: parent
                 cursorShape: Qt.PointingHandCursor
                 hoverEnabled: true
+                enabled: filterSystemDrives.checked
 
                 onEntered: {
                     dstbgrect.mouseOver = true


### PR DESCRIPTION
Rather than using a compile-time variable to determine when to filter system drives, introduce a UI item to allow users to dynamically grey-enable system drives.

This change carries the risk that users might decide to destroy their PC's hard drive. The mitigation has been to retain the behaviour of filtering by default - this change only moves the point of choice on filtering to the UI.

This change will be most beneficial in the Network Installer, where attached NVMe or USB drives may incorrectly be flagged as 'system' drives.