### PR TITLE
cmake: Build Windows binary unsigned by default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ set(Qt6_ROOT "/opt/Qt/6.7.2/gcc_arm64" CACHE PATH "Your Qt6 root path")
 
 if (WIN32)
     set(MINGW64_ROOT "" CACHE PATH "Your MinGW64 root path, likely provided by QtCreator")
+    set(IMAGER_SIGNED_APP OFF CACHE BOOL "Sign Imager and its installer as part of the build. Requires a valid Code Signing certificate.")
 endif()
 
 if (APPLE)
@@ -328,6 +329,7 @@ if (WIN32)
         POST_BUILD
         COMMAND ${CMAKE_STRIP} "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.exe")
 
+    if (IMAGER_SIGNED_APP)
     # Borrowed from the 'mstdlib' project: Code signing
     # First, determine our build architecture
     if (CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -375,6 +377,8 @@ if (WIN32)
     add_custom_command(TARGET ${PROJECT_NAME}
         POST_BUILD
         COMMAND "${SIGNTOOL}" sign /tr http://timestamp.digicert.com /td sha256 /fd sha256 /a "${CMAKE_BINARY_DIR}/dependencies/fat32format/fat32format.exe")
+
+    endif(IMAGER_SIGNED_APP)
 
     # Windeploy
     find_program(WINDEPLOYQT "windeployqt.exe" PATHS "${Qt6_ROOT}/bin")


### PR DESCRIPTION
Use the IMAGER_SIGNED_APP flag we use on macOS to control Windows signing, too.

This means that Windows developer builds can be made without access to the signing key, and without manually hacking the root CMakeLists