### PR TITLE
AppImage: Disable Wayland support

### DIFF
--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -20,5 +20,12 @@ appimage:
     raw_environment:
       QML_SOURCES_PATHS: "\"$PROJECT_ROOT\"/src/qmlcomponents/"
     environment:
-      EXTRA_PLATFORM_PLUGINS: "libqwayland-egl.so;libqwayland-generic.so"
-      EXTRA_QT_PLUGINS: "waylandcompositor"
+      # Disable Wayland back-end until the dependency problem gets resolved.
+      # Essentially, importing libqwayland-generic causes the AppImage dependency walker
+      # to find libwayland-client from the build OS, and include that in the AppImage.
+      # This is deleterious - because the the runtime OS graphics stack also depends on that
+      # library to create native window types. With no strong ABI versioning on that library,
+      # you wind up with exotic symbol resolution failures at runtime.
+      # See-Also: 
+      # EXTRA_PLATFORM_PLUGINS: "libqwayland-egl.so;libqwayland-generic.so"
+      # EXTRA_QT_PLUGINS: "waylandcompositor"


### PR DESCRIPTION
The Wayland composition flags in the Qt AppImage support are not safe to use - they include a system-owned copy of libwayland-client that is cross-called by the system Mesa - outside of the AppImage. Including the system-owned copy from the build host creates an ABI breakage that prevents execution.

This is an unacceptable situation, and until a more precise fix can be provided, disable Wayland client support in Imager.

Fixes #942 