### PR TITLE
embedded: Use blconfig alias to find bootloader config

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -102,7 +102,7 @@ ImageWriter::ImageWriter(QObject *parent)
                     "-maxdepth",
                     "3",
                     "-samefile",
-                    nvmem_blconfig_path
+                    "/sys/firmware/devicetree/base" + nvmem_blconfig_path
                 };
                 QProcess *findProcess = new QProcess(this);
                 connect(findProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),


### PR DESCRIPTION
Use the blconfig alias to find the correct nvmem device to read the bootloader configuration, the practical effect being that IMAGER_REPO_URL should work on Raspberry Pi 5.

Fixes #894 