### PR TITLE
make NSIS(windows installer) use the "all users" shell folder - fix app shortcut for all users

### DIFF
--- a/src/windows/rpi-imager.nsi.in
+++ b/src/windows/rpi-imager.nsi.in
@@ -11,7 +11,7 @@
 !define COPYRIGHT "Raspberry Pi Ltd"
 !define DESCRIPTION "Raspberry Pi Imager"
 !define MAIN_APP_EXE "rpi-imager.exe"
-!define INSTALL_TYPE "SetShellVarContext current"
+!define INSTALL_TYPE "SetShellVarContext all"
 !define REG_ROOT "HKCU"
 !define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${MAIN_APP_EXE}"
 !define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"


### PR DESCRIPTION
- make NSIS(windows installer) use the "all users" shell folder
  - that makes the shortcut be created for all users instead of only the admin user that installed the application