### PR TITLE
Added .wic as a file format for Yocto builds

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -793,7 +793,7 @@ void ImageWriter::openFileDialog()
 
     QFileDialog *fd = new QFileDialog(nullptr, tr("Select image"),
                                       path,
-                                      "Image files (*.img *.zip *.iso *.gz *.xz *.zst);;All files (*)");
+                                      "Image files (*.img *.zip *.iso *.gz *.xz *.zst *.wic);;All files (*)");
     connect(fd, SIGNAL(fileSelected(QString)), SLOT(onFileSelected(QString)));
 
     if (_engine)
@@ -1028,7 +1028,7 @@ QByteArray ImageWriter::getUsbSourceOSlist()
     QJsonArray oslist;
     QDir dir("/media");
     const QStringList medialist = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
-    QStringList namefilters = {"*.img", "*.zip", "*.gz", "*.xz", "*.zst"};
+    QStringList namefilters = {"*.img", "*.zip", "*.gz", "*.xz", "*.zst", "*.wic"};
 
     for (const QString &devname : medialist)
     {

--- a/src/windows/rpi-imager.nsi.in
+++ b/src/windows/rpi-imager.nsi.in
@@ -771,6 +771,7 @@ WriteRegStr SHCTX "Software\Classes\.zip\OpenWithProgIds" "RPI_IMAGINGUTILITY" "
 WriteRegStr SHCTX "Software\Classes\.gz\OpenWithProgIds" "RPI_IMAGINGUTILITY" ""
 WriteRegStr SHCTX "Software\Classes\.xz\OpenWithProgIds" "RPI_IMAGINGUTILITY" ""
 WriteRegStr SHCTX "Software\Classes\.img\OpenWithProgIds" "RPI_IMAGINGUTILITY" ""
+WriteRegStr SHCTX "Software\Classes\.wic\OpenWithProgIds" "RPI_IMAGINGUTILITY" ""
 WriteRegStr SHCTX "Software\Classes\.zstd\OpenWithProgIds" "RPI_IMAGINGUTILITY" ""
 WriteRegStr SHCTX "Software\Classes\RPI_IMAGINGUTILITY\shell\open" "FriendlyAppName" "Raspberry Pi Imager"
 WriteRegStr SHCTX "Software\Classes\RPI_IMAGINGUTILITY\shell\open\command" "" '"$INSTDIR\rpi-imager.exe" "%1"'
@@ -1715,6 +1716,7 @@ DeleteRegValue SHCTX "Software\Classes\.zip\OpenWithProgIds" "RPI_IMAGINGUTILITY
 DeleteRegValue SHCTX "Software\Classes\.gz\OpenWithProgIds" "RPI_IMAGINGUTILITY"
 DeleteRegValue SHCTX "Software\Classes\.xz\OpenWithProgIds" "RPI_IMAGINGUTILITY"
 DeleteRegValue SHCTX "Software\Classes\.img\OpenWithProgIds" "RPI_IMAGINGUTILITY"
+DeleteRegValue SHCTX "Software\Classes\.wic\OpenWithProgIds" "RPI_IMAGINGUTILITY"
 DeleteRegValue SHCTX "Software\Classes\.zstd\OpenWithProgIds" "RPI_IMAGINGUTILITY"
 DeleteRegKey SHCTX "Software\Classes\RPI_IMAGINGUTILITY"
 


### PR DESCRIPTION
Hi there,

I love using the Raspberry Pi Imager, but I noticed one small detail when using it with Yocto built .wic images. Every time I'm trying to flash a .wic image, I have to change the file extensions to "All Files" which can be a bit cumbersome. Therefore I added the .wic file format to the list of default extensions.

I hope this makes sense and helps folks like me that experiment or work with Yocto.
Please let me know if there are any issues that I might have overlooked.

Kind Regards,
sohnemann