### PR TITLE
fix typo in debug output for firstrun.sh

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -1227,7 +1227,7 @@ void ImageWriter::setImageCustomization(const QByteArray &config, const QByteArr
 
     qDebug() << "Custom config.txt entries:" << config;
     qDebug() << "Custom cmdline.txt entries:" << cmdline;
-    qDebug() << "Custom firstuse.sh:" << firstrun;
+    qDebug() << "Custom firstrun.sh:" << firstrun;
     qDebug() << "Cloudinit:" << cloudinit;
 }
 


### PR DESCRIPTION
The debug output refers to it as "firstuse.sh" instead of "firstrun.sh" like everywhere else. I could not find any other references to this string, so I am assuming its a mistake.