### PR TITLE
macOS: Programmatically get copyright year.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -611,7 +611,8 @@ elseif(APPLE)
     set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${IMAGER_VERSION_STR}")
     set(MACOSX_BUNDLE_LONG_VERSION_STRING "${IMAGER_VERSION_STR}")
     set(MACOSX_BUNDLE_ICON_FILE "rpi-imager.icns")
-    set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2020-2025 Raspberry Pi Ltd")
+    string(TIMESTAMP CURRENT_YEAR "%Y")
+    set(MACOSX_BUNDLE_COPYRIGHT "Copyright © 2020-${CURRENT_YEAR} Raspberry Pi Ltd")
     
     # Simple macos bundle with minimal Info.plist configuration
     set_target_properties(${PROJECT_NAME} PROPERTIES 


### PR DESCRIPTION
To avoid unnecessary churn as we iterate the application, get this programmatically.