### PR TITLE
Fix numerous file leaks, bad queing behaviours.

### DIFF
--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -53,8 +53,9 @@ DownloadThread::~DownloadThread()
 {
     _cancelled = true;
     wait();
-    if (_file.isOpen())
-        _file.close();
+    
+    // Use _closeFiles() to ensure all file handles are properly closed
+    _closeFiles();
 
     if (_firstBlock)
         qFreeAligned(_firstBlock);

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -237,6 +237,21 @@ ImageWriter::ImageWriter(QObject *parent)
 
 ImageWriter::~ImageWriter()
 {
+    // Ensure any running thread is properly cleaned up
+    if (_thread) {
+        if (_thread->isRunning()) {
+            qDebug() << "Cancelling running thread in ImageWriter destructor";
+            _thread->cancelDownload();
+            if (!_thread->wait(10000)) {
+                qDebug() << "Thread did not finish within 10 seconds, terminating it";
+                _thread->terminate();
+                _thread->wait(2000);
+            }
+        }
+        delete _thread;
+        _thread = nullptr;
+    }
+    
     if (_trans)
     {
         QCoreApplication::removeTranslator(_trans);

--- a/src/localfileextractthread.cpp
+++ b/src/localfileextractthread.cpp
@@ -17,6 +17,13 @@ LocalFileExtractThread::LocalFileExtractThread(const QByteArray &url, const QByt
 LocalFileExtractThread::~LocalFileExtractThread()
 {
     _cancelled = true;
+    
+    // Ensure input file is always closed to prevent file handle leaks
+    if (_inputfile.isOpen()) {
+        _inputfile.close();
+        qDebug() << "Closed input file in LocalFileExtractThread destructor";
+    }
+    
     wait();
     qFreeAligned(_inputBuf);
 }


### PR DESCRIPTION
- Missing libarchive close calls
- Missing filesystem sync operations
- libarchive handle leaks in exceptional paths
- LocalFileExtractThread didn't close the input file
- DownloadThread cachefile handles leaking
- ImageWriter destructor failed to clean up _thread