### PR TITLE
(il8n) Added Irish tranlsation

### DIFF
--- a/src/i18n/rpi-imager_ga.ts
+++ b/src/i18n/rpi-imager_ga.ts
@@ -1,0 +1,638 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ga">
+<context>
+    <name>DownloadExtractThread</name>
+    <message>
+        <source>Error extracting archive: %1</source>
+        <translation>Earráid ag baint amach cartlainne: %1</translation>
+    </message>
+    <message>
+        <source>Error mounting FAT32 partition</source>
+        <translation>Earráid ag gléasadh an deighilt FAT32</translation>
+    </message>
+    <message>
+        <source>Operating system did not mount FAT32 partition</source>
+        <translation>Níor fheistiú an córas oibriúcháin an chuid FAT32</translation>
+    </message>
+    <message>
+        <source>Error changing to directory &apos;%1&apos;</source>
+        <translation>Earráid ag athrú go dtí an eolaire &apos;%1&apos;</translation>
+    </message>
+</context>
+<context>
+    <name>DownloadThread</name>
+    <message>
+        <source>unmounting drive</source>
+        <translation>tiomántán a dhíshuiteáil</translation>
+    </message>
+    <message>
+        <source>opening drive</source>
+        <translation>tiomáint oscailte</translation>
+    </message>
+    <message>
+        <source>Error running diskpart: %1</source>
+        <translation>Earráid ag rith diskpart: %1</translation>
+    </message>
+    <message>
+        <source>Error removing existing partitions</source>
+        <translation>Earráid agus críochdheighiltí atá ann cheana á mbaint</translation>
+    </message>
+    <message>
+        <source>Authentication cancelled</source>
+        <translation>Cealaíodh an fíordheimhniú</translation>
+    </message>
+    <message>
+        <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
+        <translation>Earráid ag rith autoopen chun rochtain a fháil ar ghléas diosca &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
+        <translation>Deimhnigh le do thoil an bhfuil cead ag &apos;Raspberry Pi Imager&apos; rochtain a fháil ar &apos;imleabhair inbhainte&apos; i socruithe príobháideachta (faoi &apos;comhaid agus fillteáin&apos; nó tabhair &apos;rochtain iomlán ar dhiosca&apos; dó.</translation>
+    </message>
+    <message>
+        <source>Cannot open storage device &apos;%1&apos;.</source>
+        <translation>Ní féidir gléas stórála &apos;%1&apos; a oscailt.</translation>
+    </message>
+    <message>
+        <source>discarding existing data on drive</source>
+        <translation>sonraí atá ann cheana féin ar thiomántán a scriosadh</translation>
+    </message>
+    <message>
+        <source>zeroing out first and last MB of drive</source>
+        <translation>ag nialadh an chéad MB agus an MB deireanach den tiomántán</translation>
+    </message>
+    <message>
+        <source>Write error while zero&apos;ing out MBR</source>
+        <translation>Earráid scríbhneoireachta agus MBR á nialáil</translation>
+    </message>
+    <message>
+        <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
+        <translation>Earráid scríbhneoireachta agus iarracht á déanamh an chuid dheireanach den chárta a bhaint amach.&lt;br&gt;D’fhéadfadh an cárta a bheith ag fógairt acmhainn mhícheart (góchumtha b’fhéidir).</translation>
+    </message>
+    <message>
+        <source>starting download</source>
+        <translation>ag tosú íoslódáil</translation>
+    </message>
+    <message>
+        <source>Error downloading: %1</source>
+        <translation>Earráid ag íoslódáil: %1</translation>
+    </message>
+    <message>
+        <source>Access denied error while writing file to disk.</source>
+        <translation>Earráid rochtana diúltaithe agus comhad á scríobh chuig diosca.</translation>
+    </message>
+    <message>
+        <source>Controlled Folder Access seems to be enabled. Please add both rpi-imager.exe and fat32format.exe to the list of allowed apps and try again.</source>
+        <translation>Is cosúil go bhfuil Rochtain Rialaithe ar Fhillteáin cumasaithe. Cuir rpi-imager.exe agus fat32format.exe leis an liosta aipeanna ceadaithe agus déan iarracht arís.</translation>
+    </message>
+    <message>
+        <source>Error writing file to disk</source>
+        <translation>Earráid ag scríobh comhaid chuig diosca</translation>
+    </message>
+    <message>
+        <source>Download corrupt. Hash does not match</source>
+        <translation>Íoslódáil truaillithe. Ní hionann an hash</translation>
+    </message>
+    <message>
+        <source>Error writing to storage (while flushing)</source>
+        <translation>Earráid ag scríobh chuig an stóras (agus é ag sruthlú)</translation>
+    </message>
+    <message>
+        <source>Error writing to storage (while fsync)</source>
+        <translation>Earráid ag scríobh chuig stóras (le linn fsync)</translation>
+    </message>
+    <message>
+        <source>Error writing first block (partition table)</source>
+        <translation>Earráid ag scríobh an chéad bhloc (tábla deighilte)</translation>
+    </message>
+    <message>
+        <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
+        <translation>Earráid ag léamh ón stóras.&lt;br&gt;B’fhéidir go bhfuil an cárta SD briste.</translation>
+    </message>
+    <message>
+        <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
+        <translation>Theip ar fhíorú an scríbhneoireachta. Tá ábhar an chárta SD difriúil ón méid a scríobhadh air.</translation>
+    </message>
+    <message>
+        <source>Customizing image</source>
+        <translation>Íomhá á saincheapadh</translation>
+    </message>
+</context>
+<context>
+    <name>DriveFormatThread</name>
+    <message>
+        <source>Error partitioning: %1</source>
+        <translation>Earráid ag deighilt: %1</translation>
+    </message>
+    <message>
+        <source>Error starting fat32format</source>
+        <translation>Earráid ag tosú fat32format</translation>
+    </message>
+    <message>
+        <source>Error running fat32format: %1</source>
+        <translation>Earráid ag rith fat32format: %1</translation>
+    </message>
+    <message>
+        <source>Error determining new drive letter</source>
+        <translation>Earráid ag cinneadh litir tiomána nua</translation>
+    </message>
+    <message>
+        <source>Invalid device: %1</source>
+        <translation>Gléas neamhbhailí: %1</translation>
+    </message>
+    <message>
+        <source>Error formatting (through udisks2)</source>
+        <translation>Earráid ag formáidiú (trí udisks2)</translation>
+    </message>
+    <message>
+        <source>Error starting sfdisk</source>
+        <translation>Earráid ag tosú sfdisk</translation>
+    </message>
+    <message>
+        <source>Partitioning did not create expected FAT partition %1</source>
+        <translation>Níor chruthaigh an deighilt an deighilt FAT a bhíothas ag súil léi %1</translation>
+    </message>
+    <message>
+        <source>Error starting mkfs.fat</source>
+        <translation>Earráid ag tosú mkfs.fat</translation>
+    </message>
+    <message>
+        <source>Error running mkfs.fat: %1</source>
+        <translation>Earráid ag rith mkfs.fat: %1</translation>
+    </message>
+    <message>
+        <source>Formatting not implemented for this platform</source>
+        <translation>Níl an formáidiú curtha i bhfeidhm don ardán seo</translation>
+    </message>
+</context>
+<context>
+    <name>DstPopup</name>
+    <message>
+        <source>Storage</source>
+        <translation>Stóráil</translation>
+    </message>
+    <message>
+        <source>No storage devices found</source>
+        <translation>Níor aimsíodh aon fheistí stórála</translation>
+    </message>
+    <message>
+        <source>Exclude System Drives</source>
+        <translation>Eisiamh Tiomántáin an Chórais</translation>
+    </message>
+    <message>
+        <source>gigabytes</source>
+        <translation>gigibheart</translation>
+    </message>
+    <message>
+        <source>Mounted as %1</source>
+        <translation>Suiteáilte mar %1</translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation>GB</translation>
+    </message>
+    <message>
+        <source>[WRITE PROTECTED]</source>
+        <translation>[COSANT Ó SCRÍOBH]</translation>
+    </message>
+    <message>
+        <source>SYSTEM</source>
+        <translation>CÓRAS</translation>
+    </message>
+    <message>
+        <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
+        <translation>Tá an cárta SD cosanta ó scríobh.&lt;br&gt;Brúigh an lasc glasála ar thaobh clé an chárta suas, agus déan iarracht arís.</translation>
+    </message>
+</context>
+<context>
+    <name>HWListModel</name>
+    <message>
+        <source>CHOOSE DEVICE</source>
+        <translation>ROGHNAIGH GLÉAS</translation>
+    </message>
+</context>
+<context>
+    <name>HwPopup</name>
+    <message>
+        <source>Raspberry Pi Device</source>
+        <translation>Gléas Raspberry Pi</translation>
+    </message>
+</context>
+<context>
+    <name>ImageWriter</name>
+    <message>
+        <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
+        <translation>Níl an cumas stórála mór go leor.&lt;br&gt;Ní mór dó a bheith %1 GB ar a laghad.</translation>
+    </message>
+    <message>
+        <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
+        <translation>Ní íomhá diosca bailí é an comhad ionchuir.&lt;br&gt;Ní iolraí de 512 beart é méid an chomhaid %1 beart.</translation>
+    </message>
+    <message>
+        <source>Downloading and writing image</source>
+        <translation>Íomhá á íoslódáil agus á scríobh</translation>
+    </message>
+    <message>
+        <source>Select image</source>
+        <translation>Roghnaigh íomhá</translation>
+    </message>
+    <message>
+        <source>Error synchronizing time. Trying again in 3 seconds</source>
+        <translation>Earráid ag sioncrónú an ama. Ag iarraidh arís i gceann 3 soicind</translation>
+    </message>
+    <message>
+        <source>STP is enabled on your Ethernet switch. Getting IP will take long time.</source>
+        <translation>Tá STP cumasaithe ar do lasc Ethernet. Tógfaidh sé tamall fada IP a fháil.</translation>
+    </message>
+    <message>
+        <source>Would you like to prefill the wifi password from the system keychain?</source>
+        <translation>Ar mhaith leat an focal faire wifi a réamh-líonadh ón eochairchód córais?</translation>
+    </message>
+</context>
+<context>
+    <name>LocalFileExtractThread</name>
+    <message>
+        <source>opening image file</source>
+        <translation>comhad íomhá á oscailt</translation>
+    </message>
+    <message>
+        <source>Error opening image file</source>
+        <translation>Earráid ag oscailt comhad íomhá</translation>
+    </message>
+</context>
+<context>
+    <name>MsgPopup</name>
+    <message>
+        <source>NO</source>
+        <translation>NÍL</translation>
+    </message>
+    <message>
+        <source>YES</source>
+        <translation>TÁ</translation>
+    </message>
+    <message>
+        <source>CONTINUE</source>
+        <translation>LEAN AR AGHAIDH</translation>
+    </message>
+    <message>
+        <source>QUIT</source>
+        <translation>SCOR</translation>
+    </message>
+</context>
+<context>
+    <name>OSListModel</name>
+    <message>
+        <source>Recommended</source>
+        <translation>Molta</translation>
+    </message>
+</context>
+<context>
+    <name>OSPopup</name>
+    <message>
+        <source>Operating System</source>
+        <translation>Córas Oibriúcháin</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation>Ar ais</translation>
+    </message>
+    <message>
+        <source>Go back to main menu</source>
+        <translation>Téigh ar ais go dtí an príomh-roghchlár</translation>
+    </message>
+    <message>
+        <source>Released: %1</source>
+        <translation>Scaoilte: %1</translation>
+    </message>
+    <message>
+        <source>Cached on your computer</source>
+        <translation>Taisceadh ar do ríomhaire</translation>
+    </message>
+    <message>
+        <source>Local file</source>
+        <translation>Comhad áitiúil</translation>
+    </message>
+    <message>
+        <source>Online - %1 GB download</source>
+        <translation>Ar líne - íoslódáil %1 GB</translation>
+    </message>
+    <message>
+        <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
+        <translation>Ceangail bata USB ina bhfuil íomhánna ar dtús.&lt;br&gt;Ní mór na híomhánna a bheith suite i bhfillteán fréimhe an bhata USB.</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsGeneralTab</name>
+    <message>
+        <source>Set hostname:</source>
+        <translation>Socraigh ainm óstach:</translation>
+    </message>
+    <message>
+        <source>Set username and password</source>
+        <translation>Socraigh ainm úsáideora agus pasfhocal</translation>
+    </message>
+    <message>
+        <source>Username:</source>
+        <translation>Ainm úsáideora:</translation>
+    </message>
+    <message>
+        <source>Password:</source>
+        <translation>Pasfhocal:</translation>
+    </message>
+    <message>
+        <source>Configure wireless LAN</source>
+        <translation>Cumraigh LAN gan sreang</translation>
+    </message>
+    <message>
+        <source>SSID:</source>
+        <translation>SSID:</translation>
+    </message>
+    <message>
+        <source>Show password</source>
+        <translation>Taispeáin an focal faire</translation>
+    </message>
+    <message>
+        <source>Hidden SSID</source>
+        <translation>SSID i bhfolach</translation>
+    </message>
+    <message>
+        <source>Wireless LAN country:</source>
+        <translation>Tír LAN gan sreang:</translation>
+    </message>
+    <message>
+        <source>Set locale settings</source>
+        <translation>Socraigh socruithe logánta</translation>
+    </message>
+    <message>
+        <source>Time zone:</source>
+        <translation>Crios ama:</translation>
+    </message>
+    <message>
+        <source>Keyboard layout:</source>
+        <translation>Leagan amach méarchláir:</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsMiscTab</name>
+    <message>
+        <source>Play sound when finished</source>
+        <translation>Seinn fuaim nuair a bheidh sé críochnaithe</translation>
+    </message>
+    <message>
+        <source>Eject media when finished</source>
+        <translation>Díbirt na meáin nuair a bheidh siad críochnaithe</translation>
+    </message>
+    <message>
+        <source>Enable telemetry</source>
+        <translation>Cumasaigh teileiméadracht</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsPopup</name>
+    <message>
+        <source>OS Customization</source>
+        <translation>Saincheapadh OS</translation>
+    </message>
+    <message>
+        <source>OS customization options</source>
+        <translation>Roghanna saincheaptha OS</translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation>Ginearálta</translation>
+    </message>
+    <message>
+        <source>Services</source>
+        <translation>Seirbhísí</translation>
+    </message>
+    <message>
+        <source>Options</source>
+        <translation>Roghanna</translation>
+    </message>
+    <message>
+        <source>SAVE</source>
+        <translation>SÁBHÁIL</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsServicesTab</name>
+    <message>
+        <source>Enable SSH</source>
+        <translation>Cumasaigh SSH</translation>
+    </message>
+    <message>
+        <source>Use password authentication</source>
+        <translation>Úsáid fíordheimhniú pasfhocail</translation>
+    </message>
+    <message>
+        <source>Allow public-key authentication only</source>
+        <translation>Ceadaigh fíordheimhniú eochrach-poiblí amháin</translation>
+    </message>
+    <message>
+        <source>Set authorized_keys for &apos;%1&apos;:</source>
+        <translation>Socraigh eochracha_údaraithe do &apos;%1&apos;:</translation>
+    </message>
+    <message>
+        <source>Delete Key</source>
+        <translation>Eochair Scriosta</translation>
+    </message>
+    <message>
+        <source>RUN SSH-KEYGEN</source>
+        <translation>Rith SSH-KEYGEN</translation>
+    </message>
+    <message>
+        <source>Add SSH Key</source>
+        <translation>Cuir Eochair SSH leis</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Internal SD card reader</source>
+        <translation>Léitheoir cárta SD inmheánach</translation>
+    </message>
+</context>
+<context>
+    <name>UseSavedSettingsPopup</name>
+    <message>
+        <source>Use OS customization?</source>
+        <translation>Úsáid saincheapadh OS?</translation>
+    </message>
+    <message>
+        <source>Would you like to apply OS customization settings?</source>
+        <translation>Ar mhaith leat socruithe saincheaptha OS a chur i bhfeidhm?</translation>
+    </message>
+    <message>
+        <source>NO</source>
+        <translation>NÍL</translation>
+    </message>
+    <message>
+        <source>NO, CLEAR SETTINGS</source>
+        <translation>NÍL, GLAN NA SOCRAITHE</translation>
+    </message>
+    <message>
+        <source>YES</source>
+        <translation>TÁ</translation>
+    </message>
+    <message>
+        <source>EDIT SETTINGS</source>
+        <translation>Socruithe a Chur in Eagar</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>Raspberry Pi Imager v%1</source>
+        <translation>Íomháitheoir Raspberry Pi leagan v%1</translation>
+    </message>
+    <message>
+        <source>Raspberry Pi Device</source>
+        <translation>Gléas Raspberry Pi</translation>
+    </message>
+    <message>
+        <source>Select this button to choose your target Raspberry Pi</source>
+        <translation>Roghnaigh an cnaipe seo chun do Raspberry Pi sprice a roghnú</translation>
+    </message>
+    <message>
+        <source>Operating System</source>
+        <translation>Córas Oibriúcháin</translation>
+    </message>
+    <message>
+        <source>CHOOSE OS</source>
+        <translation>ROGHNAIGH OS</translation>
+    </message>
+    <message>
+        <source>Select this button to change the operating system</source>
+        <translation>Roghnaigh an cnaipe seo chun an córas oibriúcháin a athrú</translation>
+    </message>
+    <message>
+        <source>Storage</source>
+        <translation>Stóráil</translation>
+    </message>
+    <message>
+        <source>Network not ready yet</source>
+        <translation>Níl an líonra réidh fós</translation>
+    </message>
+    <message>
+        <source>CHOOSE STORAGE</source>
+        <translation>ROGHNAIGH STÓRÁIL</translation>
+    </message>
+    <message>
+        <source>Select this button to change the destination storage device</source>
+        <translation>Roghnaigh an cnaipe seo chun an gléas stórála ceann scríbe a athrú</translation>
+    </message>
+    <message>
+        <source>CANCEL WRITE</source>
+        <translation>CEALAIGH SCRÍOBH</translation>
+    </message>
+    <message>
+        <source>Cancelling...</source>
+        <translation>Ag cealú...</translation>
+    </message>
+    <message>
+        <source>CANCEL VERIFY</source>
+        <translation>CEALAIGH FÍORÚ</translation>
+    </message>
+    <message>
+        <source>Finalizing...</source>
+        <translation>Ag críochnú...</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation>Ar Aghaidh</translation>
+    </message>
+    <message>
+        <source>Select this button to start writing the image</source>
+        <translation>Roghnaigh an cnaipe seo chun tús a chur le scríobh na híomhá</translation>
+    </message>
+    <message>
+        <source>Using custom repository: %1</source>
+        <translation>Ag baint úsáide as stórlann saincheaptha: %1</translation>
+    </message>
+    <message>
+        <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
+        <translation>Nascleanúint méarchláir: &lt;tab&gt; nascleanúint go dtí an chéad chnaipe eile &lt;space&gt; brúigh an cnaipe/roghnaigh mír &lt;saighead suas/síos&gt; téigh suas/síos sna liostaí</translation>
+    </message>
+    <message>
+        <source>Language: </source>
+        <translation>Teanga: </translation>
+    </message>
+    <message>
+        <source>Keyboard: </source>
+        <translation>Méarchlár: </translation>
+    </message>
+    <message>
+        <source>Are you sure you want to quit?</source>
+        <translation>An bhfuil tú cinnte gur mian leat éirí as?</translation>
+    </message>
+    <message>
+        <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
+        <translation>Tá Raspberry Pi Imager fós gnóthach.&lt;br&gt;An bhfuil tú cinnte gur mhaith leat scor?</translation>
+    </message>
+    <message>
+        <source>Warning</source>
+        <translation>Rabhadh</translation>
+    </message>
+    <message>
+        <source>Preparing to write...</source>
+        <translation>Ag ullmhú le scríobh...</translation>
+    </message>
+    <message>
+        <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
+        <translation>Scriosfar na sonraí go léir atá ann cheana féin ar &apos;%1&apos;.&lt;br&gt;An bhfuil tú cinnte gur mian leat leanúint ar aghaidh?</translation>
+    </message>
+    <message>
+        <source>Update available</source>
+        <translation>Nuashonrú ar fáil</translation>
+    </message>
+    <message>
+        <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
+        <translation>Tá leagan níos nuaí de Imager ar fáil.&lt;br&gt;Ar mhaith leat cuairt a thabhairt ar an suíomh Gréasáin chun é a íoslódáil?</translation>
+    </message>
+    <message>
+        <source>Writing... %1%</source>
+        <translation>Scríbhneoireacht... %1%</translation>
+    </message>
+    <message>
+        <source>Verifying... %1%</source>
+        <translation>Ag fíorú... %1%</translation>
+    </message>
+    <message>
+        <source>Preparing to write... (%1)</source>
+        <translation>Ag ullmhú le scríobh... (%1)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Earráid</translation>
+    </message>
+    <message>
+        <source>Write Successful</source>
+        <translation>Scríobh go Rathúil</translation>
+    </message>
+    <message>
+        <source>Erase</source>
+        <translation>Scrios</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
+        <translation>Scriosadh &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Is féidir leat an cárta SD a bhaint as an léitheoir anois</translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
+        <translation>Scríobhadh &lt;b&gt;%1&lt;/b&gt; chuig &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;Is féidir leat an cárta SD a bhaint as an léitheoir anois</translation>
+    </message>
+    <message>
+        <source>Format card as FAT32</source>
+        <translation>Formáidigh cárta mar FAT32</translation>
+    </message>
+    <message>
+        <source>Use custom</source>
+        <translation>Úsáid saincheaptha</translation>
+    </message>
+    <message>
+        <source>Select a custom .img from your computer</source>
+        <translation>Roghnaigh .img saincheaptha ó do ríomhaire</translation>
+    </message>
+</context>
+</TS>

--- a/src/i18n/translations.qrc
+++ b/src/i18n/translations.qrc
@@ -5,6 +5,7 @@
         <file>rpi-imager_en.qm</file>
         <file>rpi-imager_es.qm</file>
         <file>rpi-imager_fr.qm</file>
+        <file>rpi-imager_ga.qm</file>
         <file>rpi-imager_he.qm</file>
         <file>rpi-imager_it.qm</file>
         <file>rpi-imager_ja.qm</file>


### PR DESCRIPTION
Hi,

This commit introduces initial translations for the Raspberry Pi Imager application in Irish (language code ga). The translations are based on the English rpi-imager_en.ts file.

Key changes:

*   Added `rpi-imager_ga.ts` file.
*   Updated `translations.qrc` to include the 'ga' language code.

Points to note:
*   Language code for Irish is:- ga
*   Official name for language is Irish (English) or Gaeilge (Native)

