### PR TITLE
README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Building Raspberry Pi Imager on macOS is best done with Visual Studio Code (or a
   - `-DIMAGER_NOTARIZE_KEYCHAIN_PROFILE=notarytool-password` - specify the name of the keychain item containing your Apple ID credentials for notarizing.
 - In the CMake plugin tab, ensure you have selected the `MinSizeRel` variant if you intend to distribute to others.
 - In the CMake plugin tab, select the 'rpi_imager' target, and build it
-- Your resultant DMG will be located at `$WORKSPACE\build\Raspberry Pi Imager-$VERSION.dmg`
+- Your resultant DMG will be located at `$WORKSPACE/build/Raspberry Pi Imager-$VERSION.dmg`
 
 ### Linux embedded (netboot) build
 


### PR DESCRIPTION
macOS uses forward-slashes in paths (like Linux), not backward-slashes (like Windows)