### PR TITLE
Updating the list of Pi models when creating a bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -72,10 +72,11 @@ body:
       label: Which Raspberry Pi Device are you using?
       multiple: false
       options:
-        - Raspberry Pi 5
+        - Raspberry Pi 5, 500, and Compute Modules 5
         - Raspberry Pi 4B, 400, and Compute Modules 4, 4S
         - Raspberry Pi Zero 2 W
         - Raspberry Pi 3B, 3A+, 3B+, and Compute Module 3, 3+
+        - Raspberry Pi 2B
         - Raspberry Pi Zero, Zero W, Zero WH
         - Raspberry Pi A, B, A+, B+, and Compute Module 1
     validations:


### PR DESCRIPTION
I assume that 500, and Compute Modules 5 were unintentionally forgotten.

The Raspberry Pi 2B is of course an old model, but some users (like me) still use it.

I don't remember if there were other variants of the Raspberry Pi 2, please correct me if I missed something.

Off topic, but I wonder if the future Raspberry Pi OS (Debian 13, Trixie) will still support the 32-bit architecture and therefore the Raspberry Pi 2?