### PR TITLE
Visual Fixes for Embedded Imager

### DIFF
--- a/src/MainPopupBase.qml
+++ b/src/MainPopupBase.qml
@@ -26,8 +26,9 @@ Popup {
     function getNextFocusableElement(startElement) { return startElement }
     function getPreviousFocusableElement(startElement) { return startElement }
 
-    contentItem: Item {
+    contentItem: Rectangle {
         id: content
+        color: Style.listViewRowBackgroundColor
         Keys.onPressed: (event) => {
             if (!event.accepted) {
                 var focusedItem = Window.activeFocusItem

--- a/src/main.qml
+++ b/src/main.qml
@@ -560,6 +560,24 @@ ApplicationWindow {
                             Layout.topMargin: 10
                             Layout.bottomMargin: 10
 
+                            delegate: ItemDelegate {
+                                width: parent.width
+                                height: 30
+
+                                contentItem: Text {
+                                    text: modelData
+                                    font.pixelSize: 16
+                                    verticalAlignment: Text.AlignVCenter
+                                    leftPadding: 10
+                                    color: Style.textDescriptionColor
+                                }
+
+                                background: Rectangle {
+                                    id: bgrect
+                                    color: parent.hovered ? Style.listViewHoverRowBackgroundColor : Style.listViewRowBackgroundColor
+                                }
+                            }
+
                             Keys.onPressed: (event) => {
                                 if (event.key === Qt.Key_Backtab || (event.key === Qt.Key_Tab && event.modifiers & Qt.ShiftModifier)) {
                                     window.getPreviousFocusableElement(languageCombo).forceActiveFocus()
@@ -595,6 +613,23 @@ ApplicationWindow {
                             Layout.bottomMargin: 10
                             Layout.rightMargin: 30
 
+                            delegate: ItemDelegate {
+                                width: parent.width
+                                height: 30
+
+                                contentItem: Text {
+                                    text: modelData
+                                    font.pixelSize: 16
+                                    verticalAlignment: Text.AlignVCenter
+                                    leftPadding: 10
+                                    color: Style.textDescriptionColor
+                                }
+
+                                background: Rectangle {
+                                    id: bgrect
+                                    color: parent.hovered ? Style.listViewHoverRowBackgroundColor : Style.listViewRowBackgroundColor
+                                }
+                            }
                             Keys.onPressed: (event) => {
                                 if (event.key === Qt.Key_Backtab || (event.key === Qt.Key_Tab && event.modifiers & Qt.ShiftModifier)) {
                                     window.getPreviousFocusableElement(keyboardCombo).forceActiveFocus()
@@ -754,6 +789,9 @@ ApplicationWindow {
         minimumWidth: 450
         minimumHeight: 400
 
+        x: window.x + (window.width - width) / 2
+        y: window.y + (window.height - height) / 2
+    
         imageWriter: window.imageWriter
 
         onSaveSettingsSignal: (settings) => {

--- a/src/qmlcomponents/ImButton.qml
+++ b/src/qmlcomponents/ImButton.qml
@@ -5,16 +5,26 @@
 
 import QtQuick 2.9
 import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.2
 
 import RpiImager
 
 Button {
     font.family: Style.fontFamily
     font.capitalization: Font.AllUppercase
-    Material.background: activeFocus ? Style.buttonFocusedBackgroundColor : Style.buttonBackgroundColor
-    Material.foreground: Style.buttonForegroundColor
-    Material.roundedScale: Material.ExtraSmallScale
+
+    background: Rectangle {
+        color: parent.enabled ? (parent.activeFocus ? Style.buttonFocusedBackgroundColor : (parent.hovered ? Style.buttonFocusedBackgroundColor : Style.buttonBackgroundColor)) : Qt.rgba(0, 0, 0, 0.1)
+        radius: 4
+    }
+
+    contentItem: Text {
+        text: parent.text
+        font: parent.font
+        color: parent.enabled ? Style.buttonForegroundColor : Qt.rgba(0, 0, 0, 0.3)
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+    }
+
     activeFocusOnTab: true
     Accessible.onPressAction: clicked()
     Keys.onEnterPressed: clicked()

--- a/src/qmlcomponents/ImButtonRed.qml
+++ b/src/qmlcomponents/ImButtonRed.qml
@@ -2,12 +2,30 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (C) 2022 Raspberry Pi Ltd
  */
-
-import QtQuick.Controls.Material 2.2
+import QtQuick 2.9
+import QtQuick.Controls 2.2
 
 import RpiImager
 
-ImButton {
-    Material.background: activeFocus ? Style.button2FocusedBackgroundColor : Style.mainBackgroundColor
-    Material.foreground: Style.button2ForegroundColor
+Button {
+    font.family: Style.fontFamily
+    font.capitalization: Font.AllUppercase
+
+    background: Rectangle {
+        color: parent.enabled ? (parent.activeFocus ? Style.progressBarBackgroundColor : (parent.hovered ? Style.buttonFocusedBackgroundColor : Style.mainBackgroundColor)) : Qt.rgba(0, 0, 0, 0.1)
+        radius: 4
+    }
+
+    contentItem: Text {
+        text: parent.text
+        font: parent.font
+        color: parent.enabled ? Style.button2ForegroundColor : Qt.rgba(0, 0, 0, 0.3)
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+    }
+
+    activeFocusOnTab: true
+    Accessible.onPressAction: clicked()
+    Keys.onEnterPressed: clicked()
+    Keys.onReturnPressed: clicked()
 }

--- a/src/qmlcomponents/ImPopup.qml
+++ b/src/qmlcomponents/ImPopup.qml
@@ -31,6 +31,11 @@ Popup {
     signal yes()
     signal no()
 
+    background: Rectangle {
+    color: Style.listViewRowBackgroundColor
+    radius: 5
+    }
+
     contentItem: Item {
         focus: true
         Keys.onPressed: (event) => {


### PR DESCRIPTION
Material Theme does not work on embedded mode. Have changed buttons and pop-ups to be drawn without Material. 
Visually the same as the desktop imager (Apart from the main screen button's hover effect does not seem to work - however this is not critical at this stage!)
