### PR TITLE
Add openUrl method to ImageWriter for external URL handling

### DIFF
--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -183,6 +183,7 @@ public:
     QString detectPiKeyboard();
     Q_INVOKABLE bool hasMouse();
     Q_INVOKABLE void reboot();
+    Q_INVOKABLE void openUrl(const QUrl &url);
 
 signals:
     /* We are emiting signals with QVariant as parameters because QML likes it that way */

--- a/src/main.qml
+++ b/src/main.qml
@@ -780,7 +780,7 @@ ApplicationWindow {
         title: qsTr("Update available")
         text: qsTr("There is a newer version of Imager available.<br>Would you like to visit the website to download it?")
         onYes: {
-            Qt.openUrlExternally(url)
+            window.imageWriter.openUrl(url)
         }
     }
 


### PR DESCRIPTION
Implemented a new Q_INVOKABLE method in ImageWriter to open URLs using platform-specific commands (xdg-open for Linux, open for macOS, and start for Windows). Added fallback to QDesktopServices if the platform command fails. Updated main.qml to utilize the new method for opening URLs externally.