### PR TITLE
Fixup SSH configuration handling in OptionsPopup

### DIFF
--- a/src/OptionsServicesTab.qml
+++ b/src/OptionsServicesTab.qml
@@ -28,6 +28,12 @@ OptionsTabBase {
     required property TextField fieldUserName
     required property TextField fieldUserPassword
 
+    // ButtonGroup to ensure SSH authentication radio buttons are mutually exclusive
+    ButtonGroup {
+        id: sshAuthButtonGroup
+        buttons: [radioPasswordAuthentication, radioPubKeyAuthentication]
+    }
+
     // Unified SSH key validation function
     function isValidSSHKey(keyText) {
         if (!keyText || keyText.trim().length === 0) return true // Empty is valid


### PR DESCRIPTION
- Added logic to append 'PasswordAuthentication yes' to sshd_config for enabling SSH.
- Implemented mutual exclusivity for SSH authentication methods (password and key) in the UI.
- Updated SSH settings handling to prioritize key authentication when both methods are present.
- Introduced a ButtonGroup for SSH authentication radio buttons to ensure proper selection behavior.