### PR TITLE
OptionsPopup: duplication of ssh keys, making the interface unusable …

### DIFF
--- a/src/OptionsPopup.qml
+++ b/src/OptionsPopup.qml
@@ -534,6 +534,8 @@ Window {
         }
         if ('sshAuthorizedKeys' in settings) {
             var possiblePublicKeys = settings.sshAuthorizedKeys.split('\n')
+            // Clear existing keys first to prevent duplication
+            remoteAccessTab.publicKeyModel.clear()
 
             for (const publicKey of possiblePublicKeys) {
                 var pkitem = publicKey.trim()


### PR DESCRIPTION
…after a period of time

This means that every time the dialog opens, it appends the saved keys to whatever keys are already in the model, bloating the whole app.