### PR TITLE
FIX Set cache in temp folder

### DIFF
--- a/src/cachemanager.cpp
+++ b/src/cachemanager.cpp
@@ -434,7 +434,9 @@ void CacheManager::saveCacheSettings()
 
 QString CacheManager::getDefaultCacheFilePath() const
 {
-    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + 
+    return QStandardPaths::writableLocation(QStandardPaths::TempLocation) + 
+           QDir::separator() + QCoreApplication::applicationName() + 
+           QDir::separator() + "cache" + 
            QDir::separator() + "lastdownload.cache";
 }
 

--- a/src/networkaccessmanagerfactory.cpp
+++ b/src/networkaccessmanagerfactory.cpp
@@ -5,6 +5,7 @@
 
 #include "networkaccessmanagerfactory.h"
 #include "config.h"
+#include <QCoreApplication>
 #include <QNetworkAccessManager>
 #include <QNetworkDiskCache>
 #include <QStandardPaths>
@@ -22,7 +23,13 @@ QNetworkAccessManager *NetworkAccessManagerFactory::create(QObject *parent)
 {
     QNetworkAccessManager *nam = new QNetworkAccessManager(parent);
     auto c = new QNetworkDiskCache(nam);
-    c->setCacheDirectory(QStandardPaths::writableLocation(QStandardPaths::CacheLocation)+QDir::separator()+"oslistcache"+QString::number(_nr++));
+    c->setCacheDirectory(
+        QStandardPaths::writableLocation(QStandardPaths::TempLocation) + 
+        QDir::separator() + QCoreApplication::applicationName() + 
+        QDir::separator() + "cache" + 
+        QDir::separator() + "oslistcache" + 
+        QString::number(_nr++)
+        );
     c->clear();
     nam->setCache(c);
     return nam;


### PR DESCRIPTION
In order to make it easier for users to clean the cache, this PR sets cache in the temp folder.

This fixes issue #209 