### PR TITLE
Add back native file-ops errors

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,23 @@
+BasedOnStyle: LLVM   # or Google, Mozilla, WebKit, etc. (choose one as baseline)
+IndentWidth: 4       # optional, just an example
+
+BraceWrapping:
+  AfterFunction: false
+  AfterNamespace: false
+  AfterClass: false
+  AfterControlStatement: false
+  AfterStruct: false
+  AfterEnum: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeElse: false
+  BeforeCatch: false
+  BeforeLambdaBody: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: None
+AllowShortCaseLabelsOnASingleLine: false
+AlignTrailingComments: false

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -821,7 +821,7 @@ void DownloadThread::_onWriteError()
         _onDownloadError(tr("I/O device error - The storage device may have been disconnected or is malfunctioning."));
         return;
     case rpi_imager::DetailedError::kBusy:
-        _onDownloadError(tr("The device is busy. Close apps that might use it and try again."));
+        _onDownloadError(tr("The storage device is busy. Close any apps that might be using it and try again."));
         return;
     case rpi_imager::DetailedError::kAccessDenied:
         // Windows handled above; other platforms fall through to coarse

--- a/src/file_operations.h
+++ b/src/file_operations.h
@@ -24,13 +24,6 @@ enum class FileError {
     kLockError,
     kSyncError,
     kFlushError,
-
-    kNoSpace,
-    kWriteProtected,
-    kBadSector,
-    kCrcError,
-    kInvalidParameter,
-    kIoDevice
 };
 
 enum class DetailedError {

--- a/src/file_operations.h
+++ b/src/file_operations.h
@@ -14,61 +14,89 @@ namespace rpi_imager {
 
 // Error types for file operations
 enum class FileError {
-  kSuccess,
-  kOpenError,
-  kWriteError,
-  kReadError,
-  kSeekError,
-  kSizeError,
-  kCloseError,
-  kLockError,
-  kSyncError,
-  kFlushError
+    kSuccess,
+    kOpenError,
+    kWriteError,
+    kReadError,
+    kSeekError,
+    kSizeError,
+    kCloseError,
+    kLockError,
+    kSyncError,
+    kFlushError,
+
+    kNoSpace,
+    kWriteProtected,
+    kBadSector,
+    kCrcError,
+    kInvalidParameter,
+    kIoDevice
+};
+
+enum class DetailedError {
+    kNoDetails = 0,     // platform didn’t provide details
+    kNoSpace,           // ENOSPC / ERROR_DISK_FULL
+    kWriteProtected,    // EROFS / ERROR_WRITE_PROTECT
+    kBadSector,         // low-level media error (e.g., ERROR_SECTOR_NOT_FOUND)
+    kCrcError,          // CRC / data integrity error
+    kInvalidParameter,  // EINVAL / ERROR_INVALID_PARAMETER
+    kIoDevice,          // EIO / ERROR_IO_DEVICE
+    kAccessDenied,      // EPERM/EACCES / ERROR_ACCESS_DENIED
+    kBusy,              // EBUSY (device in use)
+};
+
+struct ErrorInfo {
+    FileError coarse = FileError::kSuccess;
+    DetailedError detailed = DetailedError::kNoDetails;
+    int os_code = 0;                // errno or GetLastError()
 };
 
 // Abstract interface for platform-specific file operations
 class FileOperations {
- public:
-  virtual ~FileOperations() = default;
+public:
+    virtual ~FileOperations() = default;
 
-  // Open a file or device for read/write access
-  virtual FileError OpenDevice(const std::string& path) = 0;
-  
-  // Open/create a file for testing purposes
-  virtual FileError CreateTestFile(const std::string& path, std::uint64_t size) = 0;
-  
-  // Write data at a specific offset
-  virtual FileError WriteAtOffset(
+    // Open a file or device for read/write access
+    virtual FileError OpenDevice(const std::string& path) = 0;
+
+    // Open/create a file for testing purposes
+    virtual FileError CreateTestFile(const std::string& path, std::uint64_t size) = 0;
+
+    // Write data at a specific offset
+    virtual FileError WriteAtOffset(
       std::uint64_t offset,
       const std::uint8_t* data,
       std::size_t size) = 0;
-  
-  // Get the size of the opened device/file
-  virtual FileError GetSize(std::uint64_t& size) = 0;
-  
-  // Close the current file/device
-  virtual FileError Close() = 0;
-  
-  // Check if a file/device is currently open
-  virtual bool IsOpen() const = 0;
 
-  // Streaming I/O operations (for sequential writing like image downloads)
-  virtual FileError WriteSequential(const std::uint8_t* data, std::size_t size) = 0;
-  virtual FileError ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) = 0;
-  
-  // File positioning for streaming operations
-  virtual FileError Seek(std::uint64_t position) = 0;
-  virtual std::uint64_t Tell() const = 0;
-  
-  // Force filesystem sync (for page cache management)
-  virtual FileError ForceSync() = 0;
-  virtual FileError Flush() = 0;
-  
-  // Get platform-specific file handle (for compatibility with existing code)
-  virtual int GetHandle() const = 0;
+    // Get the size of the opened device/file
+    virtual FileError GetSize(std::uint64_t& size) = 0;
 
-  // Factory method to create platform-specific implementation
-  static std::unique_ptr<FileOperations> Create();
+    // Close the current file/device
+    virtual FileError Close() = 0;
+
+    // Check if a file/device is currently open
+    virtual bool IsOpen() const = 0;
+
+    // Streaming I/O operations (for sequential writing like image downloads)
+    virtual FileError WriteSequential(const std::uint8_t* data, std::size_t size) = 0;
+    virtual FileError ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) = 0;
+
+    // File positioning for streaming operations
+    virtual FileError Seek(std::uint64_t position) = 0;
+    virtual std::uint64_t Tell() const = 0;
+
+    // Force filesystem sync (for page cache management)
+    virtual FileError ForceSync() = 0;
+    virtual FileError Flush() = 0;
+
+    // Get platform-specific file handle (for compatibility with existing code)
+    virtual int GetHandle() const = 0;
+
+    // Query native error
+    virtual ErrorInfo LastError() const = 0;
+
+    // Factory method to create platform-specific implementation
+    static std::unique_ptr<FileOperations> Create();
 };
 
 } // namespace rpi_imager

--- a/src/linux/file_operations_linux.cpp
+++ b/src/linux/file_operations_linux.cpp
@@ -5,297 +5,255 @@
 
 #include "file_operations_linux.h"
 
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/stat.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
-namespace rpi_imager
-{
+namespace rpi_imager {
 
-    LinuxFileOperations::LinuxFileOperations() : fd_(-1) {}
+LinuxFileOperations::LinuxFileOperations() : fd_(-1) {
+}
 
-    LinuxFileOperations::~LinuxFileOperations()
-    {
+LinuxFileOperations::~LinuxFileOperations() {
+    Close();
+}
+
+// Map a few common errno values to cross-platform details
+DetailedError LinuxFileOperations::MapErrnoDetail(int e) {
+    switch (e) {
+    case ENOSPC:
+        return DetailedError::kNoSpace;             // no space left
+    case EROFS:
+        return DetailedError::kWriteProtected;      // read-only FS
+    case EBUSY:
+        return DetailedError::kBusy;                // device/file busy
+    case EACCES:
+    case EPERM:
+        return DetailedError::kAccessDenied;        // permissions
+    case EINVAL:
+        return DetailedError::kInvalidParameter;    // bad arg/offset
+    case EIO:
+    case ENXIO:
+        return DetailedError::kIoDevice;            // I/O error
+    default:
+        return DetailedError::kNoDetails;
+    }
+}
+
+FileError LinuxFileOperations::OpenDevice(const std::string &path) {
+    return OpenInternal(path.c_str(), O_RDWR | O_SYNC);
+}
+
+FileError LinuxFileOperations::CreateTestFile(const std::string &path,
+                                              std::uint64_t size) {
+    // First create/truncate the file
+    FileError result = OpenInternal(path.c_str(), O_CREAT | O_RDWR | O_TRUNC,
+                                    S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    if (result != FileError::kSuccess) {
+        return result;
+    }
+
+    // Set the file size
+    if (ftruncate(fd_, static_cast<off_t>(size)) != 0) {
+        SetLastErrFromErrno(FileError::kSizeError);
         Close();
+        return FileError::kSizeError;
     }
 
-    // Map a few common errno values to cross-platform details
-    DetailedError LinuxFileOperations::MapErrnoDetail(int e) {
-        switch (e) {
-        case ENOSPC:  return DetailedError::kNoSpace;          // no space left
-        case EROFS:   return DetailedError::kWriteProtected;    // read-only FS
-        case EBUSY:   return DetailedError::kBusy;              // device/file busy
-        case EACCES:
-        case EPERM:   return DetailedError::kAccessDenied;      // permissions
-        case EINVAL:  return DetailedError::kInvalidParameter;  // bad arg/offset
-        case EIO:
-        case ENXIO:   return DetailedError::kIoDevice;          // I/O error
-        default:      return DetailedError::kNoDetails;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError LinuxFileOperations::WriteAtOffset(std::uint64_t offset,
+                                             const std::uint8_t *data,
+                                             std::size_t size) {
+
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    // Helpers to record/clear error state
-    #define SET_LAST_ERR_FROM_ERRNO(_coarse_) do { \
-        int _e = errno; \
-        last_error_ = { (_coarse_), MapErrnoDetail(_e), _e}; \
-    } while(0)
-
-    #define SET_LAST_ERR(_coarse_, _detail_) do { \
-        last_error_ = { (_coarse_), (_detail_), 0 }; \
-    } while(0)
-
-    #define CLEAR_LAST_ERR() do { last_error_ = {}; } while(0)
-
-    FileError LinuxFileOperations::OpenDevice(const std::string &path)
-    {
-        return OpenInternal(path.c_str(), O_RDWR | O_SYNC);
+    if (lseek(fd_, static_cast<off_t>(offset), SEEK_SET) == -1) {
+        SetLastErrFromErrno(FileError::kSeekError);
+        return FileError::kSeekError;
     }
 
-    FileError LinuxFileOperations::CreateTestFile(const std::string &path, std::uint64_t size)
-    {
-        // First create/truncate the file
-        FileError result = OpenInternal(path.c_str(),
-                                        O_CREAT | O_RDWR | O_TRUNC,
-                                        S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-        if (result != FileError::kSuccess)
-        {
-            return result;
+    std::size_t bytes_written = 0;
+    while (bytes_written < size) {
+        ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
+        if (result <= 0) {
+            SetLastErrFromErrno(FileError::kWriteError);
+            return FileError::kWriteError;
         }
-
-        // Set the file size
-        if (ftruncate(fd_, static_cast<off_t>(size)) != 0)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSizeError);
-            Close();
-            return FileError::kSizeError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+        bytes_written += static_cast<std::size_t>(result);
     }
 
-    FileError LinuxFileOperations::WriteAtOffset(
-        std::uint64_t offset,
-        const std::uint8_t *data,
-        std::size_t size)
-    {
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
+FileError LinuxFileOperations::GetSize(std::uint64_t &size) {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
+    }
+
+    struct stat st;
+    if (fstat(fd_, &st) != 0) {
+        SetLastErrFromErrno(FileError::kSizeError);
+        return FileError::kSizeError;
+    }
+
+    size = static_cast<std::uint64_t>(st.st_size);
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError LinuxFileOperations::Close() {
+    if (fd_ >= 0) {
+        if (close(fd_) != 0) {
+            fd_ = -1;
+            SetLastErrFromErrno(FileError::kCloseError);
+            return FileError::kCloseError;
         }
+        fd_ = -1;
+    }
+    current_path_.clear();
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        if (lseek(fd_, static_cast<off_t>(offset), SEEK_SET) == -1)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSeekError);
-            return FileError::kSeekError;
-        }
+bool LinuxFileOperations::IsOpen() const {
+    return fd_ >= 0;
+}
 
-        std::size_t bytes_written = 0;
-        while (bytes_written < size)
-        {
-            ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
-            if (result <= 0)
-            {
-                SET_LAST_ERR_FROM_ERRNO(FileError::kWriteError);
+FileError LinuxFileOperations::OpenInternal(const char *path, int flags,
+                                            mode_t mode) {
+    // Close any existing file
+    Close();
+
+    fd_ = open(path, flags, mode);
+    if (fd_ < 0) {
+        SetLastErrFromErrno(FileError::kOpenError);
+        return FileError::kOpenError;
+    }
+
+    current_path_ = path;
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+// Streaming I/O operations
+FileError LinuxFileOperations::WriteSequential(const std::uint8_t *data,
+                                               std::size_t size) {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
+    }
+
+    std::size_t bytes_written = 0;
+    while (bytes_written < size) {
+        ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
+        if (result <= 0) {
+            if (result == 0 || errno != EINTR) {
+                SetLastErrFromErrno(FileError::kWriteError);
                 return FileError::kWriteError;
             }
-            bytes_written += static_cast<std::size_t>(result);
+            // EINTR - retry the write
+            continue;
         }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+        bytes_written += static_cast<std::size_t>(result);
     }
 
-    FileError LinuxFileOperations::GetSize(std::uint64_t &size)
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        struct stat st;
-        if (fstat(fd_, &st) != 0)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSizeError);
-            return FileError::kSizeError;
-        }
-
-        size = static_cast<std::uint64_t>(st.st_size);
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+FileError LinuxFileOperations::ReadSequential(std::uint8_t *data,
+                                              std::size_t size,
+                                              std::size_t &bytes_read) {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    FileError LinuxFileOperations::Close()
-    {
-        if (fd_ >= 0)
-        {
-            if (close(fd_) != 0)
-            {
-                fd_ = -1;
-                SET_LAST_ERR_FROM_ERRNO(FileError::kCloseError);
-                return FileError::kCloseError;
-            }
-            fd_ = -1;
-        }
-        current_path_.clear();
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    ssize_t result = read(fd_, data, size);
+    if (result < 0) {
+        bytes_read = 0;
+        SetLastErrFromErrno(FileError::kReadError);
+        return FileError::kReadError;
     }
 
-    bool LinuxFileOperations::IsOpen() const
-    {
-        return fd_ >= 0;
+    bytes_read = static_cast<std::size_t>(result);
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError LinuxFileOperations::Seek(std::uint64_t position) {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    FileError LinuxFileOperations::OpenInternal(const char *path, int flags, mode_t mode)
-    {
-        // Close any existing file
-        Close();
-
-        fd_ = open(path, flags, mode);
-        if (fd_ < 0)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
-
-        current_path_ = path;
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    if (lseek(fd_, static_cast<off_t>(position), SEEK_SET) == -1) {
+        SetLastErrFromErrno(FileError::kSeekError);
+        return FileError::kSeekError;
     }
 
-    // Streaming I/O operations
-    FileError LinuxFileOperations::WriteSequential(const std::uint8_t *data, std::size_t size)
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        std::size_t bytes_written = 0;
-        while (bytes_written < size)
-        {
-            ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
-            if (result <= 0)
-            {
-                if (result == 0 || errno != EINTR)
-                {
-                    SET_LAST_ERR_FROM_ERRNO(FileError::kWriteError);
-                    return FileError::kWriteError;
-                }
-                // EINTR - retry the write
-                continue;
-            }
-            bytes_written += static_cast<std::size_t>(result);
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+std::uint64_t LinuxFileOperations::Tell() const {
+    if (!IsOpen()) {
+        return 0;
     }
 
-    FileError LinuxFileOperations::ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read)
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
+    off_t pos = lseek(fd_, 0, SEEK_CUR);
+    return (pos == -1) ? 0 : static_cast<std::uint64_t>(pos);
+}
 
-        ssize_t result = read(fd_, data, size);
-        if (result < 0)
-        {
-            bytes_read = 0;
-            SET_LAST_ERR_FROM_ERRNO(FileError::kReadError);
-            return FileError::kReadError;
-        }
-
-        bytes_read = static_cast<std::size_t>(result);
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+FileError LinuxFileOperations::ForceSync() {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    FileError LinuxFileOperations::Seek(std::uint64_t position)
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
-
-        if (lseek(fd_, static_cast<off_t>(position), SEEK_SET) == -1)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSeekError);
-            return FileError::kSeekError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    // Force filesystem sync using fsync - same logic as LinuxFile::forceSync()
+    if (::fsync(fd_) != 0) {
+        SetLastErrFromErrno(FileError::kSyncError);
+        return FileError::kSyncError;
     }
 
-    std::uint64_t LinuxFileOperations::Tell() const
-    {
-        if (!IsOpen())
-        {
-            return 0;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        off_t pos = lseek(fd_, 0, SEEK_CUR);
-        return (pos == -1) ? 0 : static_cast<std::uint64_t>(pos);
+FileError LinuxFileOperations::Flush() {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    FileError LinuxFileOperations::ForceSync()
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
-
-        // Force filesystem sync using fsync - same logic as LinuxFile::forceSync()
-        if (::fsync(fd_) != 0)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSyncError);
-            return FileError::kSyncError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    // On Linux, fsync handles both buffer flush and disk sync
+    // For streaming operations, we can use fdatasync for better performance
+    if (::fdatasync(fd_) != 0) {
+        SetLastErrFromErrno(FileError::kFlushError);
+        return FileError::kFlushError;
     }
 
-    FileError LinuxFileOperations::Flush()
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        // On Linux, fsync handles both buffer flush and disk sync
-        // For streaming operations, we can use fdatasync for better performance
-        if (::fdatasync(fd_) != 0)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kFlushError);
-            return FileError::kFlushError;
-        }
+int LinuxFileOperations::GetHandle() const {
+    return fd_;
+}
 
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
-    }
-
-    int LinuxFileOperations::GetHandle() const
-    {
-        return fd_;
-    }
-
-    // Platform-specific factory function implementation
-    std::unique_ptr<FileOperations> CreatePlatformFileOperations()
-    {
-        return std::make_unique<LinuxFileOperations>();
-    }
+// Platform-specific factory function implementation
+std::unique_ptr<FileOperations> CreatePlatformFileOperations() {
+    return std::make_unique<LinuxFileOperations>();
+}
 
 } // namespace rpi_imager

--- a/src/linux/file_operations_linux.cpp
+++ b/src/linux/file_operations_linux.cpp
@@ -10,196 +10,292 @@
 #include <sys/stat.h>
 #include <errno.h>
 
-namespace rpi_imager {
+namespace rpi_imager
+{
 
-LinuxFileOperations::LinuxFileOperations() : fd_(-1) {}
+    LinuxFileOperations::LinuxFileOperations() : fd_(-1) {}
 
-LinuxFileOperations::~LinuxFileOperations() {
-  Close();
-}
-
-FileError LinuxFileOperations::OpenDevice(const std::string& path) {
-  return OpenInternal(path.c_str(), O_RDWR | O_SYNC);
-}
-
-FileError LinuxFileOperations::CreateTestFile(const std::string& path, std::uint64_t size) {
-  // First create/truncate the file
-  FileError result = OpenInternal(path.c_str(), 
-                                  O_CREAT | O_RDWR | O_TRUNC, 
-                                  S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-  if (result != FileError::kSuccess) {
-    return result;
-  }
-
-  // Set the file size
-  if (ftruncate(fd_, static_cast<off_t>(size)) != 0) {
-    Close();
-    return FileError::kSizeError;
-  }
-
-  return FileError::kSuccess;
-}
-
-FileError LinuxFileOperations::WriteAtOffset(
-    std::uint64_t offset,
-    const std::uint8_t* data,
-    std::size_t size) {
-  
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
-
-  if (lseek(fd_, static_cast<off_t>(offset), SEEK_SET) == -1) {
-    return FileError::kSeekError;
-  }
-
-  std::size_t bytes_written = 0;
-  while (bytes_written < size) {
-    ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
-    if (result <= 0) {
-      return FileError::kWriteError;
+    LinuxFileOperations::~LinuxFileOperations()
+    {
+        Close();
     }
-    bytes_written += static_cast<std::size_t>(result);
-  }
 
-  return FileError::kSuccess;
-}
-
-FileError LinuxFileOperations::GetSize(std::uint64_t& size) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
-
-  struct stat st;
-  if (fstat(fd_, &st) != 0) {
-    return FileError::kSizeError;
-  }
-
-  size = static_cast<std::uint64_t>(st.st_size);
-  return FileError::kSuccess;
-}
-
-FileError LinuxFileOperations::Close() {
-  if (fd_ >= 0) {
-    if (close(fd_) != 0) {
-      fd_ = -1;
-      return FileError::kCloseError;
+    // Map a few common errno values to cross-platform details
+    DetailedError LinuxFileOperations::MapErrnoDetail(int e) {
+        switch (e) {
+        case ENOSPC:  return DetailedError::kNoSpace;          // no space left
+        case EROFS:   return DetailedError::kWriteProtected;    // read-only FS
+        case EBUSY:   return DetailedError::kBusy;              // device/file busy
+        case EACCES:
+        case EPERM:   return DetailedError::kAccessDenied;      // permissions
+        case EINVAL:  return DetailedError::kInvalidParameter;  // bad arg/offset
+        case EIO:
+        case ENXIO:   return DetailedError::kIoDevice;          // I/O error
+        default:      return DetailedError::kNoDetails;
+        }
     }
-    fd_ = -1;
-  }
-  current_path_.clear();
-  return FileError::kSuccess;
-}
 
-bool LinuxFileOperations::IsOpen() const {
-  return fd_ >= 0;
-}
+    // Helpers to record/clear error state
+    #define SET_LAST_ERR_FROM_ERRNO(_coarse_) do { \
+        int _e = errno; \
+        last_error_ = { (_coarse_), MapErrnoDetail(_e), _e}; \
+    } while(0)
 
-FileError LinuxFileOperations::OpenInternal(const char* path, int flags, mode_t mode) {
-  // Close any existing file
-  Close();
+    #define SET_LAST_ERR(_coarse_, _detail_) do { \
+        last_error_ = { (_coarse_), (_detail_), 0 }; \
+    } while(0)
 
-  fd_ = open(path, flags, mode);
-  if (fd_ < 0) {
-    return FileError::kOpenError;
-  }
+    #define CLEAR_LAST_ERR() do { last_error_ = {}; } while(0)
 
-  current_path_ = path;
-  return FileError::kSuccess;
-}
-
-// Streaming I/O operations
-FileError LinuxFileOperations::WriteSequential(const std::uint8_t* data, std::size_t size) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
-
-  std::size_t bytes_written = 0;
-  while (bytes_written < size) {
-    ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
-    if (result <= 0) {
-      if (result == 0 || errno != EINTR) {
-        return FileError::kWriteError;
-      }
-      // EINTR - retry the write
-      continue;
+    FileError LinuxFileOperations::OpenDevice(const std::string &path)
+    {
+        return OpenInternal(path.c_str(), O_RDWR | O_SYNC);
     }
-    bytes_written += static_cast<std::size_t>(result);
-  }
 
-  return FileError::kSuccess;
-}
+    FileError LinuxFileOperations::CreateTestFile(const std::string &path, std::uint64_t size)
+    {
+        // First create/truncate the file
+        FileError result = OpenInternal(path.c_str(),
+                                        O_CREAT | O_RDWR | O_TRUNC,
+                                        S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        if (result != FileError::kSuccess)
+        {
+            return result;
+        }
 
-FileError LinuxFileOperations::ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        // Set the file size
+        if (ftruncate(fd_, static_cast<off_t>(size)) != 0)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSizeError);
+            Close();
+            return FileError::kSizeError;
+        }
 
-  ssize_t result = read(fd_, data, size);
-  if (result < 0) {
-    bytes_read = 0;
-    return FileError::kReadError;
-  }
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-  bytes_read = static_cast<std::size_t>(result);
-  return FileError::kSuccess;
-}
+    FileError LinuxFileOperations::WriteAtOffset(
+        std::uint64_t offset,
+        const std::uint8_t *data,
+        std::size_t size)
+    {
 
-FileError LinuxFileOperations::Seek(std::uint64_t position) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
 
-  if (lseek(fd_, static_cast<off_t>(position), SEEK_SET) == -1) {
-    return FileError::kSeekError;
-  }
+        if (lseek(fd_, static_cast<off_t>(offset), SEEK_SET) == -1)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSeekError);
+            return FileError::kSeekError;
+        }
 
-  return FileError::kSuccess;
-}
+        std::size_t bytes_written = 0;
+        while (bytes_written < size)
+        {
+            ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
+            if (result <= 0)
+            {
+                SET_LAST_ERR_FROM_ERRNO(FileError::kWriteError);
+                return FileError::kWriteError;
+            }
+            bytes_written += static_cast<std::size_t>(result);
+        }
 
-std::uint64_t LinuxFileOperations::Tell() const {
-  if (!IsOpen()) {
-    return 0;
-  }
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-  off_t pos = lseek(fd_, 0, SEEK_CUR);
-  return (pos == -1) ? 0 : static_cast<std::uint64_t>(pos);
-}
+    FileError LinuxFileOperations::GetSize(std::uint64_t &size)
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
 
-FileError LinuxFileOperations::ForceSync() {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        struct stat st;
+        if (fstat(fd_, &st) != 0)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSizeError);
+            return FileError::kSizeError;
+        }
 
-  // Force filesystem sync using fsync - same logic as LinuxFile::forceSync()
-  if (::fsync(fd_) != 0) {
-    return FileError::kSyncError;
-  }
+        size = static_cast<std::uint64_t>(st.st_size);
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-  return FileError::kSuccess;
-}
+    FileError LinuxFileOperations::Close()
+    {
+        if (fd_ >= 0)
+        {
+            if (close(fd_) != 0)
+            {
+                fd_ = -1;
+                SET_LAST_ERR_FROM_ERRNO(FileError::kCloseError);
+                return FileError::kCloseError;
+            }
+            fd_ = -1;
+        }
+        current_path_.clear();
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-FileError LinuxFileOperations::Flush() {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+    bool LinuxFileOperations::IsOpen() const
+    {
+        return fd_ >= 0;
+    }
 
-  // On Linux, fsync handles both buffer flush and disk sync
-  // For streaming operations, we can use fdatasync for better performance
-  if (::fdatasync(fd_) != 0) {
-    return FileError::kFlushError;
-  }
+    FileError LinuxFileOperations::OpenInternal(const char *path, int flags, mode_t mode)
+    {
+        // Close any existing file
+        Close();
 
-  return FileError::kSuccess;
-}
+        fd_ = open(path, flags, mode);
+        if (fd_ < 0)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
 
-int LinuxFileOperations::GetHandle() const {
-  return fd_;
-}
+        current_path_ = path;
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-// Platform-specific factory function implementation
-std::unique_ptr<FileOperations> CreatePlatformFileOperations() {
-  return std::make_unique<LinuxFileOperations>();
-}
+    // Streaming I/O operations
+    FileError LinuxFileOperations::WriteSequential(const std::uint8_t *data, std::size_t size)
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
 
-} // namespace rpi_imager 
+        std::size_t bytes_written = 0;
+        while (bytes_written < size)
+        {
+            ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
+            if (result <= 0)
+            {
+                if (result == 0 || errno != EINTR)
+                {
+                    SET_LAST_ERR_FROM_ERRNO(FileError::kWriteError);
+                    return FileError::kWriteError;
+                }
+                // EINTR - retry the write
+                continue;
+            }
+            bytes_written += static_cast<std::size_t>(result);
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    FileError LinuxFileOperations::ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read)
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
+
+        ssize_t result = read(fd_, data, size);
+        if (result < 0)
+        {
+            bytes_read = 0;
+            SET_LAST_ERR_FROM_ERRNO(FileError::kReadError);
+            return FileError::kReadError;
+        }
+
+        bytes_read = static_cast<std::size_t>(result);
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    FileError LinuxFileOperations::Seek(std::uint64_t position)
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
+
+        if (lseek(fd_, static_cast<off_t>(position), SEEK_SET) == -1)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSeekError);
+            return FileError::kSeekError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    std::uint64_t LinuxFileOperations::Tell() const
+    {
+        if (!IsOpen())
+        {
+            return 0;
+        }
+
+        off_t pos = lseek(fd_, 0, SEEK_CUR);
+        return (pos == -1) ? 0 : static_cast<std::uint64_t>(pos);
+    }
+
+    FileError LinuxFileOperations::ForceSync()
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
+
+        // Force filesystem sync using fsync - same logic as LinuxFile::forceSync()
+        if (::fsync(fd_) != 0)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSyncError);
+            return FileError::kSyncError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    FileError LinuxFileOperations::Flush()
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
+
+        // On Linux, fsync handles both buffer flush and disk sync
+        // For streaming operations, we can use fdatasync for better performance
+        if (::fdatasync(fd_) != 0)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kFlushError);
+            return FileError::kFlushError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    int LinuxFileOperations::GetHandle() const
+    {
+        return fd_;
+    }
+
+    // Platform-specific factory function implementation
+    std::unique_ptr<FileOperations> CreatePlatformFileOperations()
+    {
+        return std::make_unique<LinuxFileOperations>();
+    }
+
+} // namespace rpi_imager

--- a/src/linux/file_operations_linux.h
+++ b/src/linux/file_operations_linux.h
@@ -8,52 +8,59 @@
 
 #include "../file_operations.h"
 
-namespace rpi_imager {
+namespace rpi_imager
+{
 
-// Linux implementation using POSIX file operations
-class LinuxFileOperations : public FileOperations {
- public:
-  LinuxFileOperations();
-  ~LinuxFileOperations() override;
+    // Linux implementation using POSIX file operations
+    class LinuxFileOperations : public FileOperations
+    {
+    public:
+        LinuxFileOperations();
+        ~LinuxFileOperations() override;
 
-  // Non-copyable, movable
-  LinuxFileOperations(const LinuxFileOperations&) = delete;
-  LinuxFileOperations& operator=(const LinuxFileOperations&) = delete;
-  LinuxFileOperations(LinuxFileOperations&&) = default;
-  LinuxFileOperations& operator=(LinuxFileOperations&&) = default;
+        // Non-copyable, movable
+        LinuxFileOperations(const LinuxFileOperations &) = delete;
+        LinuxFileOperations &operator=(const LinuxFileOperations &) = delete;
+        LinuxFileOperations(LinuxFileOperations &&) = default;
+        LinuxFileOperations &operator=(LinuxFileOperations &&) = default;
 
-  FileError OpenDevice(const std::string& path) override;
-  FileError CreateTestFile(const std::string& path, std::uint64_t size) override;
-  FileError WriteAtOffset(
-      std::uint64_t offset,
-      const std::uint8_t* data,
-      std::size_t size) override;
-  FileError GetSize(std::uint64_t& size) override;
-  FileError Close() override;
-  bool IsOpen() const override;
+        FileError OpenDevice(const std::string &path) override;
+        FileError CreateTestFile(const std::string &path, std::uint64_t size) override;
+        FileError WriteAtOffset(
+            std::uint64_t offset,
+            const std::uint8_t *data,
+            std::size_t size) override;
+        FileError GetSize(std::uint64_t &size) override;
+        FileError Close() override;
+        bool IsOpen() const override;
 
-  // Streaming I/O operations
-  FileError WriteSequential(const std::uint8_t* data, std::size_t size) override;
-  FileError ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) override;
-  
-  // File positioning
-  FileError Seek(std::uint64_t position) override;
-  std::uint64_t Tell() const override;
-  
-  // Sync operations
-  FileError ForceSync() override;
-  FileError Flush() override;
-  
-  // Handle access
-  int GetHandle() const override;
+        // Streaming I/O operations
+        FileError WriteSequential(const std::uint8_t *data, std::size_t size) override;
+        FileError ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read) override;
 
- private:
-  int fd_;
-  std::string current_path_;
-  
-  FileError OpenInternal(const char* path, int flags, mode_t mode = 0);
-};
+        // File positioning
+        FileError Seek(std::uint64_t position) override;
+        std::uint64_t Tell() const override;
+
+        // Sync operations
+        FileError ForceSync() override;
+        FileError Flush() override;
+
+        // Handle access
+        int GetHandle() const override;
+
+        ErrorInfo LastError() const override { return last_error_; }
+
+    private:
+        int fd_;
+        std::string current_path_;
+
+        ErrorInfo last_error_{};
+        static DetailedError MapErrnoDetail(int e);
+
+        FileError OpenInternal(const char *path, int flags, mode_t mode = 0);
+    };
 
 } // namespace rpi_imager
 
-#endif // FILE_OPERATIONS_LINUX_H_ 
+#endif // FILE_OPERATIONS_LINUX_H_

--- a/src/linux/file_operations_linux.h
+++ b/src/linux/file_operations_linux.h
@@ -8,58 +8,72 @@
 
 #include "../file_operations.h"
 
-namespace rpi_imager
-{
+namespace rpi_imager {
 
-    // Linux implementation using POSIX file operations
-    class LinuxFileOperations : public FileOperations
-    {
-    public:
-        LinuxFileOperations();
-        ~LinuxFileOperations() override;
+// Linux implementation using POSIX file operations
+class LinuxFileOperations : public FileOperations {
+  public:
+    LinuxFileOperations();
+    ~LinuxFileOperations() override;
 
-        // Non-copyable, movable
-        LinuxFileOperations(const LinuxFileOperations &) = delete;
-        LinuxFileOperations &operator=(const LinuxFileOperations &) = delete;
-        LinuxFileOperations(LinuxFileOperations &&) = default;
-        LinuxFileOperations &operator=(LinuxFileOperations &&) = default;
+    // Non-copyable, movable
+    LinuxFileOperations(const LinuxFileOperations &) = delete;
+    LinuxFileOperations &operator=(const LinuxFileOperations &) = delete;
+    LinuxFileOperations(LinuxFileOperations &&) = default;
+    LinuxFileOperations &operator=(LinuxFileOperations &&) = default;
 
-        FileError OpenDevice(const std::string &path) override;
-        FileError CreateTestFile(const std::string &path, std::uint64_t size) override;
-        FileError WriteAtOffset(
-            std::uint64_t offset,
-            const std::uint8_t *data,
-            std::size_t size) override;
-        FileError GetSize(std::uint64_t &size) override;
-        FileError Close() override;
-        bool IsOpen() const override;
+    FileError OpenDevice(const std::string &path) override;
+    FileError CreateTestFile(const std::string &path,
+                             std::uint64_t size) override;
+    FileError WriteAtOffset(std::uint64_t offset, const std::uint8_t *data,
+                            std::size_t size) override;
+    FileError GetSize(std::uint64_t &size) override;
+    FileError Close() override;
+    bool IsOpen() const override;
 
-        // Streaming I/O operations
-        FileError WriteSequential(const std::uint8_t *data, std::size_t size) override;
-        FileError ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read) override;
+    // Streaming I/O operations
+    FileError WriteSequential(const std::uint8_t *data,
+                              std::size_t size) override;
+    FileError ReadSequential(std::uint8_t *data, std::size_t size,
+                             std::size_t &bytes_read) override;
 
-        // File positioning
-        FileError Seek(std::uint64_t position) override;
-        std::uint64_t Tell() const override;
+    // File positioning
+    FileError Seek(std::uint64_t position) override;
+    std::uint64_t Tell() const override;
 
-        // Sync operations
-        FileError ForceSync() override;
-        FileError Flush() override;
+    // Sync operations
+    FileError ForceSync() override;
+    FileError Flush() override;
 
-        // Handle access
-        int GetHandle() const override;
+    // Handle access
+    int GetHandle() const override;
 
-        ErrorInfo LastError() const override { return last_error_; }
+    ErrorInfo LastError() const override {
+        return last_error_;
+    }
 
-    private:
-        int fd_;
-        std::string current_path_;
+  private:
+    int fd_;
+    std::string current_path_;
 
-        ErrorInfo last_error_{};
-        static DetailedError MapErrnoDetail(int e);
+    ErrorInfo last_error_{};
+    static DetailedError MapErrnoDetail(int e);
 
-        FileError OpenInternal(const char *path, int flags, mode_t mode = 0);
-    };
+    FileError OpenInternal(const char *path, int flags, mode_t mode = 0);
+
+    inline void SetLastErrFromErrno(FileError coarse) noexcept {
+        const int e = errno;
+        last_error_ = {coarse, MapErrnoDetail(e), e};
+    }
+
+    inline void SetLastErr(FileError coarse, DetailedError detail) noexcept {
+        last_error_ = {coarse, detail, 0};
+    }
+
+    inline void ClearLastErr() noexcept {
+        last_error_ = {};
+    }
+};
 
 } // namespace rpi_imager
 

--- a/src/mac/file_operations_macos.cpp
+++ b/src/mac/file_operations_macos.cpp
@@ -6,362 +6,322 @@
 #include "file_operations_macos.h"
 #include "macfile.h"
 
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <errno.h>
-#include <iostream>
 #include <QDebug>
+#include <errno.h>
+#include <fcntl.h>
+#include <iostream>
+#include <sys/stat.h>
+#include <unistd.h>
 
-namespace rpi_imager
-{
+namespace rpi_imager {
 
-    MacOSFileOperations::MacOSFileOperations() : fd_(-1) {}
+MacOSFileOperations::MacOSFileOperations() : fd_(-1) {
+}
 
-    MacOSFileOperations::~MacOSFileOperations()
-    {
-        Close();
+MacOSFileOperations::~MacOSFileOperations() {
+    Close();
+}
+
+// Map a few common errno values to cross-platform details
+DetailedError MacOSFileOperations::MapErrnoDetail(int e) {
+    switch (e) {
+    case ENOSPC:
+        return DetailedError::kNoSpace; // no space left
+    case EROFS:
+        return DetailedError::kWriteProtected; // read-only FS
+    case EBUSY:
+        return DetailedError::kBusy; // device/file busy
+    case EACCES:
+    case EPERM:
+        return DetailedError::kAccessDenied; // permissions
+    case EINVAL:
+        return DetailedError::kInvalidParameter; // bad arg/offset
+    case EIO:
+    case ENXIO:
+        return DetailedError::kIoDevice; // I/O error
+    default:
+        return DetailedError::kNoDetails;
     }
+}
 
-    // Map a few common errno values to cross-platform details
-    DetailedError MacOSFileOperations::MapErrnoDetail(int e) {
-        switch (e) {
-        case ENOSPC:  return DetailedError::kNoSpace;          // no space left
-        case EROFS:   return DetailedError::kWriteProtected;    // read-only FS
-        case EBUSY:   return DetailedError::kBusy;              // device/file busy
-        case EACCES:
-        case EPERM:   return DetailedError::kAccessDenied;      // permissions
-        case EINVAL:  return DetailedError::kInvalidParameter;  // bad arg/offset
-        case EIO:
-        case ENXIO:   return DetailedError::kIoDevice;          // I/O error
-        default:      return DetailedError::kNoDetails;
-        }
-    }
+FileError MacOSFileOperations::OpenDevice(const std::string &path) {
+    std::cout << "Opening macOS device: " << path << std::endl;
 
-    // Helpers to record/clear error state
-    #define SET_LAST_ERR_FROM_ERRNO(_coarse_) do { \
-        int _e = errno; \
-            last_error_ = { (_coarse_), MapErrnoDetail(_e), _e}; \
-        } while(0)
+    // For raw device access on macOS, we need to use the authorization
+    // mechanism Similar to how MacFile::authOpen() works
+    if (path.find("/dev/") == 0) {
+        std::cout << "Device path detected, using macOS authorization..."
+                  << std::endl;
 
-    #define SET_LAST_ERR(_coarse_, _detail_) do { \
-            last_error_ = { (_coarse_), (_detail_), 0 }; \
-        } while(0)
+        // Create a MacFile instance to handle authorization
+        MacFile macfile;
+        QByteArray devicePath = QByteArray::fromStdString(path);
 
-    #define CLEAR_LAST_ERR() do { last_error_ = {}; } while(0)
-
-    FileError MacOSFileOperations::OpenDevice(const std::string &path)
-    {
-        std::cout << "Opening macOS device: " << path << std::endl;
-
-        // For raw device access on macOS, we need to use the authorization mechanism
-        // Similar to how MacFile::authOpen() works
-        if (path.find("/dev/") == 0)
-        {
-            std::cout << "Device path detected, using macOS authorization..." << std::endl;
-
-            // Create a MacFile instance to handle authorization
-            MacFile macfile;
-            QByteArray devicePath = QByteArray::fromStdString(path);
-
-            auto authResult = macfile.authOpen(devicePath);
-            if (authResult == MacFile::authOpenCancelled)
-            {
-                std::cout << "Authorization cancelled by user" << std::endl;
-                SET_LAST_ERR(FileError::kOpenError, DetailedError::kAccessDenied);
-                return FileError::kOpenError;
-            }
-            else if (authResult == MacFile::authOpenError)
-            {
-                std::cout << "Authorization failed" << std::endl;
-                SET_LAST_ERR(FileError::kOpenError, DetailedError::kNoDetails);
-                return FileError::kOpenError;
-            }
-
-            // Get the file descriptor from the authorized MacFile
-            fd_ = macfile.handle();
-            if (fd_ < 0)
-            {
-                SET_LAST_ERR_FROM_ERRNO(FileError::kOpenError);
-                std::cout << "Failed to get file descriptor from MacFile" << std::endl;
-                return FileError::kOpenError;
-            }
-
-            // Duplicate the file descriptor so we can manage it independently
-            int duplicated_fd = dup(fd_);
-            if (duplicated_fd < 0)
-            {
-                SET_LAST_ERR_FROM_ERRNO(FileError::kOpenError);
-                std::cout << "Failed to duplicate file descriptor" << std::endl;
-                return FileError::kOpenError;
-            }
-
-            // Close the MacFile (this will close the original fd)
-            macfile.close();
-
-            // Use our duplicated fd
-            fd_ = duplicated_fd;
-            current_path_ = path;
-
-            std::cout << "Successfully opened device with authorization, fd=" << fd_ << std::endl;
-            CLEAR_LAST_ERR();
-            return FileError::kSuccess;
-        }
-
-        // For regular files, use standard POSIX open
-        return OpenInternal(path.c_str(), O_RDWR | O_SYNC);
-    }
-
-    FileError MacOSFileOperations::CreateTestFile(const std::string &path, std::uint64_t size)
-    {
-        // First create/truncate the file
-        FileError result = OpenInternal(path.c_str(),
-                                        O_CREAT | O_RDWR | O_TRUNC,
-                                        S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-        if (result != FileError::kSuccess)
-        {
-            // last error is alread set by OpenInternal
-            return result;
-        }
-
-        // Set the file size
-        if (ftruncate(fd_, static_cast<off_t>(size)) != 0)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSizeError);
-            Close();
-            return FileError::kSizeError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
-    }
-
-    FileError MacOSFileOperations::WriteAtOffset(
-        std::uint64_t offset,
-        const std::uint8_t *data,
-        std::size_t size)
-    {
-
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            std::cout << "WriteAtOffset: Device not open" << std::endl;
+        auto authResult = macfile.authOpen(devicePath);
+        if (authResult == MacFile::authOpenCancelled) {
+            std::cout << "Authorization cancelled by user" << std::endl;
+            SetLastErr(FileError::kOpenError, DetailedError::kAccessDenied);
+            return FileError::kOpenError;
+        } else if (authResult == MacFile::authOpenError) {
+            std::cout << "Authorization failed" << std::endl;
+            SetLastErr(FileError::kOpenError, DetailedError::kNoDetails);
             return FileError::kOpenError;
         }
 
-        if (lseek(fd_, static_cast<off_t>(offset), SEEK_SET) == -1)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSeekError);
-            std::cout << "WriteAtOffset: lseek failed, offset=" << offset << ", errno=" << errno << std::endl;
-            return FileError::kSeekError;
+        // Get the file descriptor from the authorized MacFile
+        fd_ = macfile.handle();
+        if (fd_ < 0) {
+            SetLastErrFromErrno(FileError::kOpenError);
+            std::cout << "Failed to get file descriptor from MacFile"
+                      << std::endl;
+            return FileError::kOpenError;
         }
 
-        std::size_t bytes_written = 0;
-        while (bytes_written < size)
-        {
-            ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
-            if (result <= 0)
-            {
-                SET_LAST_ERR_FROM_ERRNO(FileError::kWriteError);
-                std::cout << "WriteAtOffset: write failed, bytes_written=" << bytes_written << ", errno=" << errno << std::endl;
+        // Duplicate the file descriptor so we can manage it independently
+        int duplicated_fd = dup(fd_);
+        if (duplicated_fd < 0) {
+            SetLastErrFromErrno(FileError::kOpenError);
+            std::cout << "Failed to duplicate file descriptor" << std::endl;
+            return FileError::kOpenError;
+        }
+
+        // Close the MacFile (this will close the original fd)
+        macfile.close();
+
+        // Use our duplicated fd
+        fd_ = duplicated_fd;
+        current_path_ = path;
+
+        std::cout << "Successfully opened device with authorization, fd=" << fd_
+                  << std::endl;
+        ClearLastErr();
+        return FileError::kSuccess;
+    }
+
+    // For regular files, use standard POSIX open
+    return OpenInternal(path.c_str(), O_RDWR | O_SYNC);
+}
+
+FileError MacOSFileOperations::CreateTestFile(const std::string &path,
+                                              std::uint64_t size) {
+    // First create/truncate the file
+    FileError result = OpenInternal(path.c_str(), O_CREAT | O_RDWR | O_TRUNC,
+                                    S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    if (result != FileError::kSuccess) {
+        // last error is alread set by OpenInternal
+        return result;
+    }
+
+    // Set the file size
+    if (ftruncate(fd_, static_cast<off_t>(size)) != 0) {
+        SetLastErrFromErrno(FileError::kSizeError);
+        Close();
+        return FileError::kSizeError;
+    }
+
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError MacOSFileOperations::WriteAtOffset(std::uint64_t offset,
+                                             const std::uint8_t *data,
+                                             std::size_t size) {
+
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        std::cout << "WriteAtOffset: Device not open" << std::endl;
+        return FileError::kOpenError;
+    }
+
+    if (lseek(fd_, static_cast<off_t>(offset), SEEK_SET) == -1) {
+        SetLastErrFromErrno(FileError::kSeekError);
+        std::cout << "WriteAtOffset: lseek failed, offset=" << offset
+                  << ", errno=" << errno << std::endl;
+        return FileError::kSeekError;
+    }
+
+    std::size_t bytes_written = 0;
+    while (bytes_written < size) {
+        ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
+        if (result <= 0) {
+            SetLastErrFromErrno(FileError::kWriteError);
+            std::cout << "WriteAtOffset: write failed, bytes_written="
+                      << bytes_written << ", errno=" << errno << std::endl;
+            return FileError::kWriteError;
+        }
+        bytes_written += static_cast<std::size_t>(result);
+    }
+
+    std::cout << "WriteAtOffset: Successfully wrote " << bytes_written
+              << " bytes at offset " << offset << std::endl;
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError MacOSFileOperations::GetSize(std::uint64_t &size) {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
+    }
+
+    struct stat st;
+    if (fstat(fd_, &st) != 0) {
+        SetLastErr(FileError::kSizeError, DetailedError::kNoDetails);
+        return FileError::kSizeError;
+    }
+
+    size = static_cast<std::uint64_t>(st.st_size);
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError MacOSFileOperations::Close() {
+    if (fd_ >= 0) {
+        if (close(fd_) != 0) {
+            fd_ = -1;
+            SetLastErrFromErrno(FileError::kCloseError);
+            return FileError::kCloseError;
+        }
+        fd_ = -1;
+    }
+    current_path_.clear();
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+bool MacOSFileOperations::IsOpen() const {
+    return fd_ >= 0;
+}
+
+FileError MacOSFileOperations::OpenInternal(const char *path, int flags,
+                                            mode_t mode) {
+    // Close any existing file
+    Close();
+
+    fd_ = open(path, flags, mode);
+    if (fd_ < 0) {
+        SetLastErr(FileError::kOpenError, DetailedError::kNoDetails);
+        std::cout << "OpenInternal: Failed to open " << path
+                  << ", errno=" << errno << std::endl;
+        return FileError::kOpenError;
+    }
+
+    current_path_ = path;
+    std::cout << "OpenInternal: Successfully opened " << path << ", fd=" << fd_
+              << std::endl;
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+// Streaming I/O operations
+FileError MacOSFileOperations::WriteSequential(const std::uint8_t *data,
+                                               std::size_t size) {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
+    }
+
+    std::size_t bytes_written = 0;
+    while (bytes_written < size) {
+        ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
+        if (result <= 0) {
+            if (result == 0 || errno != EINTR) {
+                SetLastErrFromErrno(FileError::kWriteError);
                 return FileError::kWriteError;
             }
-            bytes_written += static_cast<std::size_t>(result);
+            // EINTR - retry the write
+            continue;
         }
-
-        std::cout << "WriteAtOffset: Successfully wrote " << bytes_written << " bytes at offset " << offset << std::endl;
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+        bytes_written += static_cast<std::size_t>(result);
     }
 
-    FileError MacOSFileOperations::GetSize(std::uint64_t &size)
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        struct stat st;
-        if (fstat(fd_, &st) != 0)
-        {
-            SET_LAST_ERR(FileError::kSizeError, DetailedError::kNoDetails);
-            return FileError::kSizeError;
-        }
-
-        size = static_cast<std::uint64_t>(st.st_size);
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+FileError MacOSFileOperations::ReadSequential(std::uint8_t *data,
+                                              std::size_t size,
+                                              std::size_t &bytes_read) {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    FileError MacOSFileOperations::Close()
-    {
-        if (fd_ >= 0)
-        {
-            if (close(fd_) != 0)
-            {
-                fd_ = -1;
-                SET_LAST_ERR_FROM_ERRNO(FileError::kCloseError);
-                return FileError::kCloseError;
-            }
-            fd_ = -1;
-        }
-        current_path_.clear();
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    ssize_t result = read(fd_, data, size);
+    if (result < 0) {
+        bytes_read = 0;
+        SetLastErrFromErrno(FileError::kReadError);
+        return FileError::kReadError;
     }
 
-    bool MacOSFileOperations::IsOpen() const
-    {
-        return fd_ >= 0;
+    bytes_read = static_cast<std::size_t>(result);
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError MacOSFileOperations::Seek(std::uint64_t position) {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    FileError MacOSFileOperations::OpenInternal(const char *path, int flags, mode_t mode)
-    {
-        // Close any existing file
-        Close();
-
-        fd_ = open(path, flags, mode);
-        if (fd_ < 0)
-        {
-            SET_LAST_ERR(FileError::kOpenError, DetailedError::kNoDetails);
-            std::cout << "OpenInternal: Failed to open " << path << ", errno=" << errno << std::endl;
-            return FileError::kOpenError;
-        }
-
-        current_path_ = path;
-        std::cout << "OpenInternal: Successfully opened " << path << ", fd=" << fd_ << std::endl;
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    if (lseek(fd_, static_cast<off_t>(position), SEEK_SET) == -1) {
+        SetLastErrFromErrno(FileError::kSeekError);
+        return FileError::kSeekError;
     }
 
-    // Streaming I/O operations
-    FileError MacOSFileOperations::WriteSequential(const std::uint8_t *data, std::size_t size)
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        std::size_t bytes_written = 0;
-        while (bytes_written < size)
-        {
-            ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
-            if (result <= 0)
-            {
-                if (result == 0 || errno != EINTR)
-                {
-                    SET_LAST_ERR_FROM_ERRNO(FileError::kWriteError);
-                    return FileError::kWriteError;
-                }
-                // EINTR - retry the write
-                continue;
-            }
-            bytes_written += static_cast<std::size_t>(result);
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+std::uint64_t MacOSFileOperations::Tell() const {
+    if (!IsOpen()) {
+        return 0;
     }
 
-    FileError MacOSFileOperations::ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read)
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
+    off_t pos = lseek(fd_, 0, SEEK_CUR);
+    return (pos == -1) ? 0 : static_cast<std::uint64_t>(pos);
+}
 
-        ssize_t result = read(fd_, data, size);
-        if (result < 0)
-        {
-            bytes_read = 0;
-            SET_LAST_ERR_FROM_ERRNO(FileError::kReadError);
-            return FileError::kReadError;
-        }
-
-        bytes_read = static_cast<std::size_t>(result);
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+FileError MacOSFileOperations::ForceSync() {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    FileError MacOSFileOperations::Seek(std::uint64_t position)
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
-
-        if (lseek(fd_, static_cast<off_t>(position), SEEK_SET) == -1)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSeekError);
-            return FileError::kSeekError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    // Force filesystem sync using fsync - same logic as MacFile::forceSync()
+    if (::fsync(fd_) != 0) {
+        SetLastErrFromErrno(FileError::kSyncError);
+        return FileError::kSyncError;
     }
 
-    std::uint64_t MacOSFileOperations::Tell() const
-    {
-        if (!IsOpen())
-        {
-            return 0;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        off_t pos = lseek(fd_, 0, SEEK_CUR);
-        return (pos == -1) ? 0 : static_cast<std::uint64_t>(pos);
+FileError MacOSFileOperations::Flush() {
+    if (!IsOpen()) {
+        last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+        return FileError::kOpenError;
     }
 
-    FileError MacOSFileOperations::ForceSync()
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
-
-        // Force filesystem sync using fsync - same logic as MacFile::forceSync()
-        if (::fsync(fd_) != 0)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kSyncError);
-            return FileError::kSyncError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    // On macOS, use fsync for both flush and sync operations
+    if (::fsync(fd_) != 0) {
+        SetLastErrFromErrno(FileError::kFlushError);
+        return FileError::kFlushError;
     }
 
-    FileError MacOSFileOperations::Flush()
-    {
-        if (!IsOpen())
-        {
-            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        // On macOS, use fsync for both flush and sync operations
-        if (::fsync(fd_) != 0)
-        {
-            SET_LAST_ERR_FROM_ERRNO(FileError::kFlushError);
-            return FileError::kFlushError;
-        }
+int MacOSFileOperations::GetHandle() const {
+    return fd_;
+}
 
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
-    }
-
-    int MacOSFileOperations::GetHandle() const
-    {
-        return fd_;
-    }
-
-    // Platform-specific factory function implementation
-    std::unique_ptr<FileOperations> CreatePlatformFileOperations()
-    {
-        return std::make_unique<MacOSFileOperations>();
-    }
+// Platform-specific factory function implementation
+std::unique_ptr<FileOperations> CreatePlatformFileOperations() {
+    return std::make_unique<MacOSFileOperations>();
+}
 
 } // namespace rpi_imager

--- a/src/mac/file_operations_macos.cpp
+++ b/src/mac/file_operations_macos.cpp
@@ -13,247 +13,355 @@
 #include <iostream>
 #include <QDebug>
 
-namespace rpi_imager {
+namespace rpi_imager
+{
 
-MacOSFileOperations::MacOSFileOperations() : fd_(-1) {}
+    MacOSFileOperations::MacOSFileOperations() : fd_(-1) {}
 
-MacOSFileOperations::~MacOSFileOperations() {
-  Close();
-}
-
-FileError MacOSFileOperations::OpenDevice(const std::string& path) {
-  std::cout << "Opening macOS device: " << path << std::endl;
-  
-  // For raw device access on macOS, we need to use the authorization mechanism
-  // Similar to how MacFile::authOpen() works
-  if (path.find("/dev/") == 0) {
-    std::cout << "Device path detected, using macOS authorization..." << std::endl;
-    
-    // Create a MacFile instance to handle authorization
-    MacFile macfile;
-    QByteArray devicePath = QByteArray::fromStdString(path);
-    
-    auto authResult = macfile.authOpen(devicePath);
-    if (authResult == MacFile::authOpenCancelled) {
-      std::cout << "Authorization cancelled by user" << std::endl;
-      return FileError::kOpenError;
-    } else if (authResult == MacFile::authOpenError) {
-      std::cout << "Authorization failed" << std::endl;
-      return FileError::kOpenError;
+    MacOSFileOperations::~MacOSFileOperations()
+    {
+        Close();
     }
-    
-    // Get the file descriptor from the authorized MacFile
-    fd_ = macfile.handle();
-    if (fd_ < 0) {
-      std::cout << "Failed to get file descriptor from MacFile" << std::endl;
-      return FileError::kOpenError;
+
+    // Map a few common errno values to cross-platform details
+    DetailedError MacOSFileOperations::MapErrnoDetail(int e) {
+        switch (e) {
+        case ENOSPC:  return DetailedError::kNoSpace;          // no space left
+        case EROFS:   return DetailedError::kWriteProtected;    // read-only FS
+        case EBUSY:   return DetailedError::kBusy;              // device/file busy
+        case EACCES:
+        case EPERM:   return DetailedError::kAccessDenied;      // permissions
+        case EINVAL:  return DetailedError::kInvalidParameter;  // bad arg/offset
+        case EIO:
+        case ENXIO:   return DetailedError::kIoDevice;          // I/O error
+        default:      return DetailedError::kNoDetails;
+        }
     }
-    
-    // Duplicate the file descriptor so we can manage it independently
-    int duplicated_fd = dup(fd_);
-    if (duplicated_fd < 0) {
-      std::cout << "Failed to duplicate file descriptor" << std::endl;
-      return FileError::kOpenError;
+
+    // Helpers to record/clear error state
+    #define SET_LAST_ERR_FROM_ERRNO(_coarse_) do { \
+        int _e = errno; \
+            last_error_ = { (_coarse_), MapErrnoDetail(_e), _e}; \
+        } while(0)
+
+    #define SET_LAST_ERR(_coarse_, _detail_) do { \
+            last_error_ = { (_coarse_), (_detail_), 0 }; \
+        } while(0)
+
+    #define CLEAR_LAST_ERR() do { last_error_ = {}; } while(0)
+
+    FileError MacOSFileOperations::OpenDevice(const std::string &path)
+    {
+        std::cout << "Opening macOS device: " << path << std::endl;
+
+        // For raw device access on macOS, we need to use the authorization mechanism
+        // Similar to how MacFile::authOpen() works
+        if (path.find("/dev/") == 0)
+        {
+            std::cout << "Device path detected, using macOS authorization..." << std::endl;
+
+            // Create a MacFile instance to handle authorization
+            MacFile macfile;
+            QByteArray devicePath = QByteArray::fromStdString(path);
+
+            auto authResult = macfile.authOpen(devicePath);
+            if (authResult == MacFile::authOpenCancelled)
+            {
+                std::cout << "Authorization cancelled by user" << std::endl;
+                SET_LAST_ERR(FileError::kOpenError, DetailedError::kAccessDenied);
+                return FileError::kOpenError;
+            }
+            else if (authResult == MacFile::authOpenError)
+            {
+                std::cout << "Authorization failed" << std::endl;
+                SET_LAST_ERR(FileError::kOpenError, DetailedError::kNoDetails);
+                return FileError::kOpenError;
+            }
+
+            // Get the file descriptor from the authorized MacFile
+            fd_ = macfile.handle();
+            if (fd_ < 0)
+            {
+                SET_LAST_ERR_FROM_ERRNO(FileError::kOpenError);
+                std::cout << "Failed to get file descriptor from MacFile" << std::endl;
+                return FileError::kOpenError;
+            }
+
+            // Duplicate the file descriptor so we can manage it independently
+            int duplicated_fd = dup(fd_);
+            if (duplicated_fd < 0)
+            {
+                SET_LAST_ERR_FROM_ERRNO(FileError::kOpenError);
+                std::cout << "Failed to duplicate file descriptor" << std::endl;
+                return FileError::kOpenError;
+            }
+
+            // Close the MacFile (this will close the original fd)
+            macfile.close();
+
+            // Use our duplicated fd
+            fd_ = duplicated_fd;
+            current_path_ = path;
+
+            std::cout << "Successfully opened device with authorization, fd=" << fd_ << std::endl;
+            CLEAR_LAST_ERR();
+            return FileError::kSuccess;
+        }
+
+        // For regular files, use standard POSIX open
+        return OpenInternal(path.c_str(), O_RDWR | O_SYNC);
     }
-    
-    // Close the MacFile (this will close the original fd)
-    macfile.close();
-    
-    // Use our duplicated fd
-    fd_ = duplicated_fd;
-    current_path_ = path;
-    
-    std::cout << "Successfully opened device with authorization, fd=" << fd_ << std::endl;
-    return FileError::kSuccess;
-  }
-  
-  // For regular files, use standard POSIX open
-  return OpenInternal(path.c_str(), O_RDWR | O_SYNC);
-}
 
-FileError MacOSFileOperations::CreateTestFile(const std::string& path, std::uint64_t size) {
-  // First create/truncate the file
-  FileError result = OpenInternal(path.c_str(), 
-                                  O_CREAT | O_RDWR | O_TRUNC, 
-                                  S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-  if (result != FileError::kSuccess) {
-    return result;
-  }
+    FileError MacOSFileOperations::CreateTestFile(const std::string &path, std::uint64_t size)
+    {
+        // First create/truncate the file
+        FileError result = OpenInternal(path.c_str(),
+                                        O_CREAT | O_RDWR | O_TRUNC,
+                                        S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        if (result != FileError::kSuccess)
+        {
+            // last error is alread set by OpenInternal
+            return result;
+        }
 
-  // Set the file size
-  if (ftruncate(fd_, static_cast<off_t>(size)) != 0) {
-    Close();
-    return FileError::kSizeError;
-  }
+        // Set the file size
+        if (ftruncate(fd_, static_cast<off_t>(size)) != 0)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSizeError);
+            Close();
+            return FileError::kSizeError;
+        }
 
-  return FileError::kSuccess;
-}
-
-FileError MacOSFileOperations::WriteAtOffset(
-    std::uint64_t offset,
-    const std::uint8_t* data,
-    std::size_t size) {
-  
-  if (!IsOpen()) {
-    std::cout << "WriteAtOffset: Device not open" << std::endl;
-    return FileError::kOpenError;
-  }
-
-  if (lseek(fd_, static_cast<off_t>(offset), SEEK_SET) == -1) {
-    std::cout << "WriteAtOffset: lseek failed, offset=" << offset << ", errno=" << errno << std::endl;
-    return FileError::kSeekError;
-  }
-
-  std::size_t bytes_written = 0;
-  while (bytes_written < size) {
-    ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
-    if (result <= 0) {
-      std::cout << "WriteAtOffset: write failed, bytes_written=" << bytes_written << ", errno=" << errno << std::endl;
-      return FileError::kWriteError;
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
     }
-    bytes_written += static_cast<std::size_t>(result);
-  }
 
-  std::cout << "WriteAtOffset: Successfully wrote " << bytes_written << " bytes at offset " << offset << std::endl;
-  return FileError::kSuccess;
-}
+    FileError MacOSFileOperations::WriteAtOffset(
+        std::uint64_t offset,
+        const std::uint8_t *data,
+        std::size_t size)
+    {
 
-FileError MacOSFileOperations::GetSize(std::uint64_t& size) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            std::cout << "WriteAtOffset: Device not open" << std::endl;
+            return FileError::kOpenError;
+        }
 
-  struct stat st;
-  if (fstat(fd_, &st) != 0) {
-    return FileError::kSizeError;
-  }
+        if (lseek(fd_, static_cast<off_t>(offset), SEEK_SET) == -1)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSeekError);
+            std::cout << "WriteAtOffset: lseek failed, offset=" << offset << ", errno=" << errno << std::endl;
+            return FileError::kSeekError;
+        }
 
-  size = static_cast<std::uint64_t>(st.st_size);
-  return FileError::kSuccess;
-}
+        std::size_t bytes_written = 0;
+        while (bytes_written < size)
+        {
+            ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
+            if (result <= 0)
+            {
+                SET_LAST_ERR_FROM_ERRNO(FileError::kWriteError);
+                std::cout << "WriteAtOffset: write failed, bytes_written=" << bytes_written << ", errno=" << errno << std::endl;
+                return FileError::kWriteError;
+            }
+            bytes_written += static_cast<std::size_t>(result);
+        }
 
-FileError MacOSFileOperations::Close() {
-  if (fd_ >= 0) {
-    if (close(fd_) != 0) {
-      fd_ = -1;
-      return FileError::kCloseError;
+        std::cout << "WriteAtOffset: Successfully wrote " << bytes_written << " bytes at offset " << offset << std::endl;
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
     }
-    fd_ = -1;
-  }
-  current_path_.clear();
-  return FileError::kSuccess;
-}
 
-bool MacOSFileOperations::IsOpen() const {
-  return fd_ >= 0;
-}
+    FileError MacOSFileOperations::GetSize(std::uint64_t &size)
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
 
-FileError MacOSFileOperations::OpenInternal(const char* path, int flags, mode_t mode) {
-  // Close any existing file
-  Close();
+        struct stat st;
+        if (fstat(fd_, &st) != 0)
+        {
+            SET_LAST_ERR(FileError::kSizeError, DetailedError::kNoDetails);
+            return FileError::kSizeError;
+        }
 
-  fd_ = open(path, flags, mode);
-  if (fd_ < 0) {
-    std::cout << "OpenInternal: Failed to open " << path << ", errno=" << errno << std::endl;
-    return FileError::kOpenError;
-  }
-
-  current_path_ = path;
-  std::cout << "OpenInternal: Successfully opened " << path << ", fd=" << fd_ << std::endl;
-  return FileError::kSuccess;
-}
-
-// Streaming I/O operations
-FileError MacOSFileOperations::WriteSequential(const std::uint8_t* data, std::size_t size) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
-
-  std::size_t bytes_written = 0;
-  while (bytes_written < size) {
-    ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
-    if (result <= 0) {
-      if (result == 0 || errno != EINTR) {
-        return FileError::kWriteError;
-      }
-      // EINTR - retry the write
-      continue;
+        size = static_cast<std::uint64_t>(st.st_size);
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
     }
-    bytes_written += static_cast<std::size_t>(result);
-  }
 
-  return FileError::kSuccess;
-}
+    FileError MacOSFileOperations::Close()
+    {
+        if (fd_ >= 0)
+        {
+            if (close(fd_) != 0)
+            {
+                fd_ = -1;
+                SET_LAST_ERR_FROM_ERRNO(FileError::kCloseError);
+                return FileError::kCloseError;
+            }
+            fd_ = -1;
+        }
+        current_path_.clear();
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-FileError MacOSFileOperations::ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+    bool MacOSFileOperations::IsOpen() const
+    {
+        return fd_ >= 0;
+    }
 
-  ssize_t result = read(fd_, data, size);
-  if (result < 0) {
-    bytes_read = 0;
-    return FileError::kReadError;
-  }
+    FileError MacOSFileOperations::OpenInternal(const char *path, int flags, mode_t mode)
+    {
+        // Close any existing file
+        Close();
 
-  bytes_read = static_cast<std::size_t>(result);
-  return FileError::kSuccess;
-}
+        fd_ = open(path, flags, mode);
+        if (fd_ < 0)
+        {
+            SET_LAST_ERR(FileError::kOpenError, DetailedError::kNoDetails);
+            std::cout << "OpenInternal: Failed to open " << path << ", errno=" << errno << std::endl;
+            return FileError::kOpenError;
+        }
 
-FileError MacOSFileOperations::Seek(std::uint64_t position) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        current_path_ = path;
+        std::cout << "OpenInternal: Successfully opened " << path << ", fd=" << fd_ << std::endl;
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-  if (lseek(fd_, static_cast<off_t>(position), SEEK_SET) == -1) {
-    return FileError::kSeekError;
-  }
+    // Streaming I/O operations
+    FileError MacOSFileOperations::WriteSequential(const std::uint8_t *data, std::size_t size)
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
 
-  return FileError::kSuccess;
-}
+        std::size_t bytes_written = 0;
+        while (bytes_written < size)
+        {
+            ssize_t result = write(fd_, data + bytes_written, size - bytes_written);
+            if (result <= 0)
+            {
+                if (result == 0 || errno != EINTR)
+                {
+                    SET_LAST_ERR_FROM_ERRNO(FileError::kWriteError);
+                    return FileError::kWriteError;
+                }
+                // EINTR - retry the write
+                continue;
+            }
+            bytes_written += static_cast<std::size_t>(result);
+        }
 
-std::uint64_t MacOSFileOperations::Tell() const {
-  if (!IsOpen()) {
-    return 0;
-  }
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-  off_t pos = lseek(fd_, 0, SEEK_CUR);
-  return (pos == -1) ? 0 : static_cast<std::uint64_t>(pos);
-}
+    FileError MacOSFileOperations::ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read)
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
 
-FileError MacOSFileOperations::ForceSync() {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        ssize_t result = read(fd_, data, size);
+        if (result < 0)
+        {
+            bytes_read = 0;
+            SET_LAST_ERR_FROM_ERRNO(FileError::kReadError);
+            return FileError::kReadError;
+        }
 
-  // Force filesystem sync using fsync - same logic as MacFile::forceSync()
-  if (::fsync(fd_) != 0) {
-    return FileError::kSyncError;
-  }
+        bytes_read = static_cast<std::size_t>(result);
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-  return FileError::kSuccess;
-}
+    FileError MacOSFileOperations::Seek(std::uint64_t position)
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
 
-FileError MacOSFileOperations::Flush() {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        if (lseek(fd_, static_cast<off_t>(position), SEEK_SET) == -1)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSeekError);
+            return FileError::kSeekError;
+        }
 
-  // On macOS, use fsync for both flush and sync operations
-  if (::fsync(fd_) != 0) {
-    return FileError::kFlushError;
-  }
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-  return FileError::kSuccess;
-}
+    std::uint64_t MacOSFileOperations::Tell() const
+    {
+        if (!IsOpen())
+        {
+            return 0;
+        }
 
-int MacOSFileOperations::GetHandle() const {
-  return fd_;
-}
+        off_t pos = lseek(fd_, 0, SEEK_CUR);
+        return (pos == -1) ? 0 : static_cast<std::uint64_t>(pos);
+    }
 
-// Platform-specific factory function implementation
-std::unique_ptr<FileOperations> CreatePlatformFileOperations() {
-  return std::make_unique<MacOSFileOperations>();
-}
+    FileError MacOSFileOperations::ForceSync()
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
 
-} // namespace rpi_imager 
+        // Force filesystem sync using fsync - same logic as MacFile::forceSync()
+        if (::fsync(fd_) != 0)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kSyncError);
+            return FileError::kSyncError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    FileError MacOSFileOperations::Flush()
+    {
+        if (!IsOpen())
+        {
+            last_error_ = {FileError::kOpenError, DetailedError::kNoDetails, 0};
+            return FileError::kOpenError;
+        }
+
+        // On macOS, use fsync for both flush and sync operations
+        if (::fsync(fd_) != 0)
+        {
+            SET_LAST_ERR_FROM_ERRNO(FileError::kFlushError);
+            return FileError::kFlushError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    int MacOSFileOperations::GetHandle() const
+    {
+        return fd_;
+    }
+
+    // Platform-specific factory function implementation
+    std::unique_ptr<FileOperations> CreatePlatformFileOperations()
+    {
+        return std::make_unique<MacOSFileOperations>();
+    }
+
+} // namespace rpi_imager

--- a/src/mac/file_operations_macos.h
+++ b/src/mac/file_operations_macos.h
@@ -8,52 +8,59 @@
 
 #include "../file_operations.h"
 
-namespace rpi_imager {
+namespace rpi_imager
+{
 
-// macOS implementation using POSIX file operations (similar to Linux)
-class MacOSFileOperations : public FileOperations {
- public:
-  MacOSFileOperations();
-  ~MacOSFileOperations() override;
+    // macOS implementation using POSIX file operations (similar to Linux)
+    class MacOSFileOperations : public FileOperations
+    {
+    public:
+        MacOSFileOperations();
+        ~MacOSFileOperations() override;
 
-  // Non-copyable, movable
-  MacOSFileOperations(const MacOSFileOperations&) = delete;
-  MacOSFileOperations& operator=(const MacOSFileOperations&) = delete;
-  MacOSFileOperations(MacOSFileOperations&&) = default;
-  MacOSFileOperations& operator=(MacOSFileOperations&&) = default;
+        // Non-copyable, movable
+        MacOSFileOperations(const MacOSFileOperations &) = delete;
+        MacOSFileOperations &operator=(const MacOSFileOperations &) = delete;
+        MacOSFileOperations(MacOSFileOperations &&) = default;
+        MacOSFileOperations &operator=(MacOSFileOperations &&) = default;
 
-  FileError OpenDevice(const std::string& path) override;
-  FileError CreateTestFile(const std::string& path, std::uint64_t size) override;
-  FileError WriteAtOffset(
-      std::uint64_t offset,
-      const std::uint8_t* data,
-      std::size_t size) override;
-  FileError GetSize(std::uint64_t& size) override;
-  FileError Close() override;
-  bool IsOpen() const override;
+        FileError OpenDevice(const std::string &path) override;
+        FileError CreateTestFile(const std::string &path, std::uint64_t size) override;
+        FileError WriteAtOffset(
+            std::uint64_t offset,
+            const std::uint8_t *data,
+            std::size_t size) override;
+        FileError GetSize(std::uint64_t &size) override;
+        FileError Close() override;
+        bool IsOpen() const override;
 
-  // Streaming I/O operations
-  FileError WriteSequential(const std::uint8_t* data, std::size_t size) override;
-  FileError ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) override;
-  
-  // File positioning
-  FileError Seek(std::uint64_t position) override;
-  std::uint64_t Tell() const override;
-  
-  // Sync operations
-  FileError ForceSync() override;
-  FileError Flush() override;
-  
-  // Handle access
-  int GetHandle() const override;
+        // Streaming I/O operations
+        FileError WriteSequential(const std::uint8_t *data, std::size_t size) override;
+        FileError ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read) override;
 
- private:
-  int fd_;
-  std::string current_path_;
-  
-  FileError OpenInternal(const char* path, int flags, mode_t mode = 0);
-};
+        // File positioning
+        FileError Seek(std::uint64_t position) override;
+        std::uint64_t Tell() const override;
+
+        // Sync operations
+        FileError ForceSync() override;
+        FileError Flush() override;
+
+        // Handle access
+        int GetHandle() const override;
+
+        ErrorInfo LastError() const override { return last_error_; }
+
+    private:
+        int fd_;
+        std::string current_path_;
+
+        ErrorInfo last_error_{};
+        static DetailedError MapErrnoDetail(int e);
+
+        FileError OpenInternal(const char *path, int flags, mode_t mode = 0);
+    };
 
 } // namespace rpi_imager
 
-#endif // FILE_OPERATIONS_MACOS_H_ 
+#endif // FILE_OPERATIONS_MACOS_H_

--- a/src/mac/file_operations_macos.h
+++ b/src/mac/file_operations_macos.h
@@ -8,58 +8,72 @@
 
 #include "../file_operations.h"
 
-namespace rpi_imager
-{
+namespace rpi_imager {
 
-    // macOS implementation using POSIX file operations (similar to Linux)
-    class MacOSFileOperations : public FileOperations
-    {
-    public:
-        MacOSFileOperations();
-        ~MacOSFileOperations() override;
+// macOS implementation using POSIX file operations (similar to Linux)
+class MacOSFileOperations : public FileOperations {
+  public:
+    MacOSFileOperations();
+    ~MacOSFileOperations() override;
 
-        // Non-copyable, movable
-        MacOSFileOperations(const MacOSFileOperations &) = delete;
-        MacOSFileOperations &operator=(const MacOSFileOperations &) = delete;
-        MacOSFileOperations(MacOSFileOperations &&) = default;
-        MacOSFileOperations &operator=(MacOSFileOperations &&) = default;
+    // Non-copyable, movable
+    MacOSFileOperations(const MacOSFileOperations &) = delete;
+    MacOSFileOperations &operator=(const MacOSFileOperations &) = delete;
+    MacOSFileOperations(MacOSFileOperations &&) = default;
+    MacOSFileOperations &operator=(MacOSFileOperations &&) = default;
 
-        FileError OpenDevice(const std::string &path) override;
-        FileError CreateTestFile(const std::string &path, std::uint64_t size) override;
-        FileError WriteAtOffset(
-            std::uint64_t offset,
-            const std::uint8_t *data,
-            std::size_t size) override;
-        FileError GetSize(std::uint64_t &size) override;
-        FileError Close() override;
-        bool IsOpen() const override;
+    FileError OpenDevice(const std::string &path) override;
+    FileError CreateTestFile(const std::string &path,
+                             std::uint64_t size) override;
+    FileError WriteAtOffset(std::uint64_t offset, const std::uint8_t *data,
+                            std::size_t size) override;
+    FileError GetSize(std::uint64_t &size) override;
+    FileError Close() override;
+    bool IsOpen() const override;
 
-        // Streaming I/O operations
-        FileError WriteSequential(const std::uint8_t *data, std::size_t size) override;
-        FileError ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read) override;
+    // Streaming I/O operations
+    FileError WriteSequential(const std::uint8_t *data,
+                              std::size_t size) override;
+    FileError ReadSequential(std::uint8_t *data, std::size_t size,
+                             std::size_t &bytes_read) override;
 
-        // File positioning
-        FileError Seek(std::uint64_t position) override;
-        std::uint64_t Tell() const override;
+    // File positioning
+    FileError Seek(std::uint64_t position) override;
+    std::uint64_t Tell() const override;
 
-        // Sync operations
-        FileError ForceSync() override;
-        FileError Flush() override;
+    // Sync operations
+    FileError ForceSync() override;
+    FileError Flush() override;
 
-        // Handle access
-        int GetHandle() const override;
+    // Handle access
+    int GetHandle() const override;
 
-        ErrorInfo LastError() const override { return last_error_; }
+    ErrorInfo LastError() const override {
+        return last_error_;
+    }
 
-    private:
-        int fd_;
-        std::string current_path_;
+  private:
+    int fd_;
+    std::string current_path_;
 
-        ErrorInfo last_error_{};
-        static DetailedError MapErrnoDetail(int e);
+    ErrorInfo last_error_{};
+    static DetailedError MapErrnoDetail(int e);
 
-        FileError OpenInternal(const char *path, int flags, mode_t mode = 0);
-    };
+    FileError OpenInternal(const char *path, int flags, mode_t mode = 0);
+
+    inline void SetLastErrFromErrno(FileError coarse) noexcept {
+        const int e = errno;
+        last_error_ = {coarse, MapErrnoDetail(e), e};
+    }
+
+    inline void SetLastErr(FileError coarse, DetailedError detail) noexcept {
+        last_error_ = {coarse, detail, 0};
+    }
+
+    inline void ClearLastErr() noexcept {
+        last_error_ = {};
+    }
+};
 
 } // namespace rpi_imager
 

--- a/src/windows/file_operations_windows.cpp
+++ b/src/windows/file_operations_windows.cpp
@@ -8,393 +8,542 @@
 #include <winioctl.h>
 #include <iostream>
 
-namespace rpi_imager {
+namespace rpi_imager
+{
 
-WindowsFileOperations::WindowsFileOperations() : handle_(INVALID_HANDLE_VALUE) {}
+    WindowsFileOperations::WindowsFileOperations() : handle_(INVALID_HANDLE_VALUE) {}
 
-WindowsFileOperations::~WindowsFileOperations() {
-  Close();
-}
-
-FileError WindowsFileOperations::OpenDevice(const std::string& path) {
-  // Windows device paths like \\.\PHYSICALDRIVE0
-  std::cout << "Opening Windows device: " << path << std::endl;
-  
-  // Check if this is a physical drive
-  bool isPhysicalDrive = (path.find("\\\\.\\PHYSICALDRIVE") == 0);
-  
-  if (isPhysicalDrive) {
-    std::cout << "Detected physical drive, ensuring no volumes are mounted" << std::endl;
-    
-    // For physical drives, we need to ensure no volumes are mounted
-    // This is handled by the calling code in downloadthread.cpp
-    // but we can add additional safety here
-  }
-  
-  FileError result = OpenInternal(path, 
-                                  GENERIC_READ | GENERIC_WRITE,
-                                  OPEN_EXISTING);
-  if (result != FileError::kSuccess) {
-    std::cout << "Failed to open device: " << path << std::endl;
-    return result;
-  }
-
-  // Enable extended DASD I/O for raw disk access
-  DWORD bytes_returned;
-  if (!DeviceIoControl(handle_, FSCTL_ALLOW_EXTENDED_DASD_IO, 
-                       nullptr, 0, nullptr, 0, &bytes_returned, nullptr)) {
-    // This may fail on some systems, but we can continue
-    std::cout << "Warning: FSCTL_ALLOW_EXTENDED_DASD_IO failed, continuing anyway" << std::endl;
-  }
-
-  // Only try to lock volume if this is not a physical drive
-  if (!isPhysicalDrive) {
-    FileError lock_result = LockVolume();
-    if (lock_result != FileError::kSuccess) {
-      std::cout << "Warning: Failed to lock volume, continuing anyway" << std::endl;
+    WindowsFileOperations::~WindowsFileOperations()
+    {
+        Close();
     }
-  } else {
-    std::cout << "Skipping volume lock for physical drive" << std::endl;
-  }
-  
-  std::cout << "Successfully opened device: " << path << std::endl;
-  return FileError::kSuccess;
-}
 
-FileError WindowsFileOperations::CreateTestFile(const std::string& path, std::uint64_t size) {
-  // For test files, create a regular file
-  FileError result = OpenInternal(path,
-                                  GENERIC_READ | GENERIC_WRITE,
-                                  CREATE_ALWAYS);
-  if (result != FileError::kSuccess) {
-    return result;
-  }
-
-  // Set file size using SetFilePointer and SetEndOfFile
-  LARGE_INTEGER file_size;
-  file_size.QuadPart = static_cast<LONGLONG>(size);
-  
-  if (!SetFilePointerEx(handle_, file_size, nullptr, FILE_BEGIN)) {
-    Close();
-    return FileError::kSeekError;
-  }
-
-  if (!SetEndOfFile(handle_)) {
-    Close();
-    return FileError::kSizeError;
-  }
-
-  return FileError::kSuccess;
-}
-
-FileError WindowsFileOperations::WriteAtOffset(
-    std::uint64_t offset,
-    const std::uint8_t* data,
-    std::size_t size) {
-  
-  if (!IsOpen()) {
-    std::cout << "WriteAtOffset: Device not open" << std::endl;
-    return FileError::kOpenError;
-  }
-
-  // Set file pointer to the desired offset
-  LARGE_INTEGER offset_large;
-  offset_large.QuadPart = static_cast<LONGLONG>(offset);
-  
-  if (!SetFilePointerEx(handle_, offset_large, nullptr, FILE_BEGIN)) {
-    DWORD error = GetLastError();
-    std::cout << "WriteAtOffset: SetFilePointerEx failed, offset=" << offset << ", error=" << error << std::endl;
-    return FileError::kSeekError;
-  }
-
-  // Write data in chunks with retry logic
-  std::size_t bytes_written = 0;
-  int retry_count = 0;
-  const int max_retries = 3;
-  
-  while (bytes_written < size) {
-    DWORD chunk_size = static_cast<DWORD>(std::min(size - bytes_written, 
-                                                   static_cast<std::size_t>(MAXDWORD)));
-    DWORD written = 0;
-    
-    if (!WriteFile(handle_, data + bytes_written, chunk_size, &written, nullptr)) {
-      DWORD error = GetLastError();
-      std::cout << "WriteAtOffset: WriteFile failed, offset=" << offset + bytes_written 
-                << ", chunk_size=" << chunk_size << ", error=" << error << std::endl;
-      
-      // Handle specific Windows errors
-      if (error == ERROR_ACCESS_DENIED) {
-        std::cout << "WriteAtOffset: Access denied - volume may be locked or protected" << std::endl;
-        return FileError::kWriteError;
-      } else if (error == ERROR_DISK_FULL) {
-        std::cout << "WriteAtOffset: Disk full" << std::endl;
-        return FileError::kWriteError;
-      } else if (error == ERROR_WRITE_PROTECT) {
-        std::cout << "WriteAtOffset: Write protected" << std::endl;
-        return FileError::kWriteError;
-      } else if (error == ERROR_SECTOR_NOT_FOUND || error == ERROR_CRC) {
-        std::cout << "WriteAtOffset: Media error detected" << std::endl;
-        return FileError::kWriteError;
-      }
-      
-      // For other errors, try to retry
-      if (retry_count < max_retries) {
-        retry_count++;
-        std::cout << "WriteAtOffset: Retrying write operation, attempt " << retry_count << std::endl;
-        
-        // Wait a bit before retry
-        Sleep(100 * retry_count);
-        
-        // Reset file pointer
-        if (!SetFilePointerEx(handle_, offset_large, nullptr, FILE_BEGIN)) {
-          std::cout << "WriteAtOffset: Failed to reset file pointer for retry" << std::endl;
-          return FileError::kSeekError;
+    DetailedError WindowsFileOperations::MapWinDetail(DWORD e)
+    {
+        switch (e)
+        {
+        case ERROR_DISK_FULL:
+            return DetailedError::kNoSpace;
+        case ERROR_WRITE_PROTECT:
+            return DetailedError::kWriteProtected;
+        case ERROR_SECTOR_NOT_FOUND:
+            return DetailedError::kBadSector;
+        case ERROR_CRC:
+            return DetailedError::kCrcError;
+        case ERROR_INVALID_PARAMETER:
+            return DetailedError::kInvalidParameter;
+        case ERROR_IO_DEVICE:
+            return DetailedError::kIoDevice;
+        case ERROR_ACCESS_DENIED:
+            return DetailedError::kAccessDenied;
+        case ERROR_BUSY:
+            return DetailedError::kBusy;
+        default:
+            return DetailedError::kNoDetails;
         }
-        
-        continue;
-      }
-      
-      return FileError::kWriteError;
     }
-    
-    if (written == 0) {
-      std::cout << "WriteAtOffset: WriteFile returned 0 bytes written" << std::endl;
-      
-      if (retry_count < max_retries) {
-        retry_count++;
-        std::cout << "WriteAtOffset: Retrying write operation, attempt " << retry_count << std::endl;
-        Sleep(100 * retry_count);
-        continue;
-      }
-      
-      return FileError::kWriteError;
+
+    // convenience macro to set detailed error
+    #define SET_LAST_ERR(coarseCode)                                     \
+        do                                                               \
+        {                                                                \
+            DWORD _e = GetLastError();                                   \
+            last_error_ = {(coarseCode), MapWinDetail(_e), (int)_e}; \
+        } while (0)
+
+    // and a way to clear it on success
+    #define CLEAR_LAST_ERR()  \
+        do                    \
+        {                     \
+            last_error_ = {}; \
+        } while (0)
+
+    FileError WindowsFileOperations::OpenDevice(const std::string &path)
+    {
+        // Windows device paths like \\.\PHYSICALDRIVE0
+        std::cout << "Opening Windows device: " << path << std::endl;
+
+        // Check if this is a physical drive
+        bool isPhysicalDrive = (path.find("\\\\.\\PHYSICALDRIVE") == 0);
+
+        if (isPhysicalDrive)
+        {
+            std::cout << "Detected physical drive, ensuring no volumes are mounted" << std::endl;
+
+            // For physical drives, we need to ensure no volumes are mounted
+            // This is handled by the calling code in downloadthread.cpp
+            // but we can add additional safety here
+        }
+
+        FileError result = OpenInternal(path,
+                                        GENERIC_READ | GENERIC_WRITE,
+                                        OPEN_EXISTING);
+        if (result != FileError::kSuccess)
+        {
+            std::cout << "Failed to open device: " << path << std::endl;
+            // OpenInternal already sets last error
+            return result;
+        }
+
+        // Enable extended DASD I/O for raw disk access
+        DWORD bytes_returned;
+        if (!DeviceIoControl(handle_, FSCTL_ALLOW_EXTENDED_DASD_IO,
+                             nullptr, 0, nullptr, 0, &bytes_returned, nullptr))
+        {
+            // This may fail on some systems, but we can continue
+            std::cout << "Warning: FSCTL_ALLOW_EXTENDED_DASD_IO failed, continuing anyway" << std::endl;
+        }
+
+        // Only try to lock volume if this is not a physical drive
+        if (!isPhysicalDrive)
+        {
+            FileError lock_result = LockVolume();
+            if (lock_result != FileError::kSuccess)
+            {
+                std::cout << "Warning: Failed to lock volume, continuing anyway" << std::endl;
+            }
+        }
+        else
+        {
+            std::cout << "Skipping volume lock for physical drive" << std::endl;
+        }
+
+        std::cout << "Successfully opened device: " << path << std::endl;
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
     }
-    
-    bytes_written += written;
-    retry_count = 0; // Reset retry count on successful write
-  }
 
-  // Flush to ensure data is written
-  if (!FlushFileBuffers(handle_)) {
-    DWORD error = GetLastError();
-    std::cout << "WriteAtOffset: FlushFileBuffers failed, error=" << error << std::endl;
-    // Continue anyway, as this is not always critical
-  }
-  
-  return FileError::kSuccess;
-}
+    FileError WindowsFileOperations::CreateTestFile(const std::string &path, std::uint64_t size)
+    {
+        // For test files, create a regular file
+        FileError result = OpenInternal(path,
+                                        GENERIC_READ | GENERIC_WRITE,
+                                        CREATE_ALWAYS);
+        if (result != FileError::kSuccess)
+        {
+            SET_LAST_ERR(result);
+            return result;
+        }
 
-FileError WindowsFileOperations::GetSize(std::uint64_t& size) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        // Set file size using SetFilePointer and SetEndOfFile
+        LARGE_INTEGER file_size;
+        file_size.QuadPart = static_cast<LONGLONG>(size);
 
-  LARGE_INTEGER file_size;
-  if (!GetFileSizeEx(handle_, &file_size)) {
-    // For devices, try to get geometry information
-    DISK_GEOMETRY geometry;
-    DWORD bytes_returned;
-    
-    if (DeviceIoControl(handle_, IOCTL_DISK_GET_DRIVE_GEOMETRY,
-                        nullptr, 0, &geometry, sizeof(geometry),
-                        &bytes_returned, nullptr)) {
-      
-      size = static_cast<std::uint64_t>(geometry.Cylinders.QuadPart) *
-             geometry.TracksPerCylinder *
-             geometry.SectorsPerTrack *
-             geometry.BytesPerSector;
-      return FileError::kSuccess;
+        if (!SetFilePointerEx(handle_, file_size, nullptr, FILE_BEGIN))
+        {
+            Close();
+            SET_LAST_ERR(FileError::kSeekError);
+            return FileError::kSeekError;
+        }
+
+        if (!SetEndOfFile(handle_))
+        {
+            Close();
+            SET_LAST_ERR(FileError::kSizeError);
+            return FileError::kSizeError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
     }
-    
-    return FileError::kSizeError;
-  }
 
-  size = static_cast<std::uint64_t>(file_size.QuadPart);
-  return FileError::kSuccess;
-}
-
-FileError WindowsFileOperations::Close() {
-  if (handle_ != INVALID_HANDLE_VALUE) {
-    // Only unlock volume if this is not a physical drive
-    bool isPhysicalDrive = (current_path_.find("\\\\.\\PHYSICALDRIVE") == 0);
-    if (!isPhysicalDrive) {
-      UnlockVolume(); // Unlock if it was locked
+    static bool IsTransientWinWriteError(DWORD e) {
+        switch (e) {
+        case ERROR_NOT_READY:        // device temporarily not ready
+        case ERROR_BUSY:             // sharing/busy state that may clear
+        case ERROR_SEM_TIMEOUT:      // timeouts can succeed on retry
+        case ERROR_OPERATION_ABORTED:// sporadic USB hiccups
+            return true;
+        default:
+            return false;
+        }
     }
-    
-    if (!CloseHandle(handle_)) {
-      handle_ = INVALID_HANDLE_VALUE;
-      return FileError::kCloseError;
+
+    #define SET_LAST_ERR_FROM_WIN32(coarse, winerr) \
+        do { last_error_ = { (coarse), MapWinDetail((winerr)), (int)(winerr) }; } while (0)
+
+    FileError WindowsFileOperations::WriteAtOffset(
+        std::uint64_t offset,
+        const std::uint8_t *data,
+        std::size_t size)
+    {
+
+        if (!IsOpen())
+        {
+            std::cout << "WriteAtOffset: Device not open" << std::endl;
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
+
+        // Set file pointer to the desired offset
+        LARGE_INTEGER offset_large;
+        offset_large.QuadPart = static_cast<LONGLONG>(offset);
+
+        if (!SetFilePointerEx(handle_, offset_large, nullptr, FILE_BEGIN))
+        {
+            DWORD error = GetLastError();
+            std::cout << "WriteAtOffset: SetFilePointerEx failed, offset=" << offset << ", error=" << error << std::endl;
+            SET_LAST_ERR(FileError::kSeekError);
+            return FileError::kSeekError;
+        }
+
+        // Write data in chunks with retry logic
+        std::size_t bytes_written = 0;
+        int retry_count = 0;
+        const int max_retries = 3;
+
+        while (bytes_written < size)
+        {
+            DWORD chunk_size = static_cast<DWORD>(std::min(size - bytes_written,
+                                                           static_cast<std::size_t>(MAXDWORD)));
+            DWORD written = 0;
+
+            if (!WriteFile(handle_, data + bytes_written, chunk_size, &written, nullptr))
+            {
+                DWORD error = GetLastError();
+                std::cout << "WriteAtOffset: WriteFile failed, offset=" << offset + bytes_written
+                          << ", chunk_size=" << chunk_size << ", error=" << error << std::endl;
+
+                SET_LAST_ERR_FROM_WIN32(FileError::kWriteError, error);
+
+                // Retry only for transient errors
+                if (retry_count < max_retries && IsTransientWinWriteError(error))
+                {
+                    retry_count++;
+                    std::cout << "WriteAtOffset: Retrying write operation, attempt " << retry_count << std::endl;
+
+                    // Wait a bit before retry
+                    Sleep(100 * retry_count);
+
+                    // Reset file pointer
+                    if (!SetFilePointerEx(handle_, offset_large, nullptr, FILE_BEGIN))
+                    {
+                        std::cout << "WriteAtOffset: Failed to reset file pointer for retry" << std::endl;
+                        SET_LAST_ERR(FileError::kSeekError);
+                        return FileError::kSeekError;
+                    }
+
+                    continue;
+                }
+
+                return FileError::kWriteError;
+            }
+
+            if (written == 0)
+            {
+                std::cout << "WriteAtOffset: WriteFile returned 0 bytes written" << std::endl;
+
+                if (retry_count < max_retries)
+                {
+                    retry_count++;
+                    std::cout << "WriteAtOffset: Retrying write operation, attempt " << retry_count << std::endl;
+                    Sleep(100 * retry_count);
+                    LARGE_INTEGER cur;
+                    // start the retry at the correct offset to not risk duplication or corruption
+                    cur.QuadPart = static_cast<LONGLONG>(offset + bytes_written);
+                    if (!SetFilePointerEx(handle_, cur, nullptr, FILE_BEGIN)) {
+                        SET_LAST_ERR(FileError::kSeekError);
+                        return FileError::kSeekError;
+                    }
+                    continue;
+                }
+
+                // No progress after retries -> fail generically.
+                last_error_ = { FileError::kWriteError, DetailedError::kNoDetails, 0 };
+                return FileError::kWriteError;
+            }
+
+            bytes_written += written;
+            retry_count = 0; // Reset retry count on successful write
+        }
+
+        // Flush to ensure data is written
+        if (!FlushFileBuffers(handle_))
+        {
+            DWORD error = GetLastError();
+            std::cout << "WriteAtOffset: FlushFileBuffers failed, error=" << error << std::endl;
+            // Continue anyway, as this is not always critical
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
     }
-    handle_ = INVALID_HANDLE_VALUE;
-  }
-  current_path_.clear();
-  return FileError::kSuccess;
-}
 
-bool WindowsFileOperations::IsOpen() const {
-  return handle_ != INVALID_HANDLE_VALUE;
-}
+    FileError WindowsFileOperations::GetSize(std::uint64_t &size)
+    {
+        if (!IsOpen())
+        {
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
 
-FileError WindowsFileOperations::LockVolume() {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+        LARGE_INTEGER file_size;
+        if (!GetFileSizeEx(handle_, &file_size))
+        {
+            // For devices, try to get geometry information
+            DISK_GEOMETRY geometry;
+            DWORD bytes_returned;
 
-  DWORD bytes_returned;
-  if (!DeviceIoControl(handle_, FSCTL_LOCK_VOLUME,
-                       nullptr, 0, nullptr, 0, &bytes_returned, nullptr)) {
-    // Lock may fail for files (not devices), which is okay
-    DWORD error = GetLastError();
-    if (error != ERROR_INVALID_FUNCTION) {
-      return FileError::kLockError;
+            if (DeviceIoControl(handle_, IOCTL_DISK_GET_DRIVE_GEOMETRY,
+                                nullptr, 0, &geometry, sizeof(geometry),
+                                &bytes_returned, nullptr))
+            {
+
+                size = static_cast<std::uint64_t>(geometry.Cylinders.QuadPart) *
+                       geometry.TracksPerCylinder *
+                       geometry.SectorsPerTrack *
+                       geometry.BytesPerSector;
+                CLEAR_LAST_ERR();
+                return FileError::kSuccess;
+            }
+
+            SET_LAST_ERR(FileError::kSizeError);
+            return FileError::kSizeError;
+        }
+
+        size = static_cast<std::uint64_t>(file_size.QuadPart);
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
     }
-  }
 
-  return FileError::kSuccess;
-}
+    FileError WindowsFileOperations::Close()
+    {
+        if (handle_ != INVALID_HANDLE_VALUE)
+        {
+            // Only unlock volume if this is not a physical drive
+            bool isPhysicalDrive = (current_path_.find("\\\\.\\PHYSICALDRIVE") == 0);
+            if (!isPhysicalDrive)
+            {
+                UnlockVolume(); // Unlock if it was locked
+            }
 
-FileError WindowsFileOperations::UnlockVolume() {
-  if (!IsOpen()) {
-    return FileError::kSuccess; // Already closed
-  }
-
-  DWORD bytes_returned;
-  DeviceIoControl(handle_, FSCTL_UNLOCK_VOLUME,
-                  nullptr, 0, nullptr, 0, &bytes_returned, nullptr);
-  // Ignore errors here as we're likely closing anyway
-  
-  return FileError::kSuccess;
-}
-
-FileError WindowsFileOperations::OpenInternal(const std::string& path, DWORD access, DWORD creation) {
-  // Close any existing handle
-  Close();
-
-  handle_ = CreateFileA(path.c_str(),
-                        access,
-                        FILE_SHARE_READ | FILE_SHARE_WRITE,
-                        nullptr,
-                        creation,
-                        FILE_ATTRIBUTE_NORMAL, // Removed FILE_FLAG_NO_BUFFERING to fix alignment issues
-                        nullptr);
-
-  if (handle_ == INVALID_HANDLE_VALUE) {
-    return FileError::kOpenError;
-  }
-
-  current_path_ = path;
-  return FileError::kSuccess;
-}
-
-// Streaming I/O operations
-FileError WindowsFileOperations::WriteSequential(const std::uint8_t* data, std::size_t size) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
-
-  DWORD bytes_written = 0;
-  DWORD total_written = 0;
-  
-  while (total_written < size) {
-    BOOL result = WriteFile(handle_, 
-                           data + total_written, 
-                           static_cast<DWORD>(size - total_written), 
-                           &bytes_written, 
-                           nullptr);
-    
-    if (!result) {
-      return FileError::kWriteError;
+            if (!CloseHandle(handle_))
+            {
+                handle_ = INVALID_HANDLE_VALUE;
+                SET_LAST_ERR(FileError::kCloseError);
+                return FileError::kCloseError;
+            }
+            handle_ = INVALID_HANDLE_VALUE;
+        }
+        current_path_.clear();
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
     }
-    
-    total_written += bytes_written;
-  }
 
-  return FileError::kSuccess;
-}
+    bool WindowsFileOperations::IsOpen() const
+    {
+        return handle_ != INVALID_HANDLE_VALUE;
+    }
 
-FileError WindowsFileOperations::ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+    FileError WindowsFileOperations::LockVolume()
+    {
+        if (!IsOpen())
+        {
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
 
-  DWORD win_bytes_read = 0;
-  BOOL result = ReadFile(handle_, data, static_cast<DWORD>(size), &win_bytes_read, nullptr);
-  
-  if (!result) {
-    bytes_read = 0;
-    return FileError::kReadError;
-  }
+        DWORD bytes_returned;
+        if (!DeviceIoControl(handle_, FSCTL_LOCK_VOLUME,
+                             nullptr, 0, nullptr, 0, &bytes_returned, nullptr))
+        {
+            // Lock may fail for files (not devices), which is okay
+            DWORD error = GetLastError();
+            if (error != ERROR_INVALID_FUNCTION)
+            {
+                SET_LAST_ERR(FileError::kLockError);
+                return FileError::kLockError;
+            }
+        }
 
-  bytes_read = static_cast<std::size_t>(win_bytes_read);
-  return FileError::kSuccess;
-}
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-FileError WindowsFileOperations::Seek(std::uint64_t position) {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+    FileError WindowsFileOperations::UnlockVolume()
+    {
+        if (IsOpen())
+        {
+            DWORD bytes_returned;
+            DeviceIoControl(handle_, FSCTL_UNLOCK_VOLUME,
+                            nullptr, 0, nullptr, 0, &bytes_returned, nullptr);
+        }
 
-  LARGE_INTEGER pos;
-  pos.QuadPart = static_cast<LONGLONG>(position);
-  
-  LARGE_INTEGER new_pos;
-  if (!SetFilePointerEx(handle_, pos, &new_pos, FILE_BEGIN)) {
-    return FileError::kSeekError;
-  }
+        // Already closed or
+        // Ignore errors here as we're likely closing anyway
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-  return FileError::kSuccess;
-}
+    FileError WindowsFileOperations::OpenInternal(const std::string &path, DWORD access, DWORD creation)
+    {
+        // Close any existing handle
+        Close();
 
-std::uint64_t WindowsFileOperations::Tell() const {
-  if (!IsOpen()) {
-    return 0;
-  }
+        handle_ = CreateFileA(path.c_str(),
+                              access,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE,
+                              nullptr,
+                              creation,
+                              FILE_ATTRIBUTE_NORMAL, // Removed FILE_FLAG_NO_BUFFERING to fix alignment issues
+                              nullptr);
 
-  LARGE_INTEGER zero = {};
-  LARGE_INTEGER current_pos;
-  
-  if (!SetFilePointerEx(handle_, zero, &current_pos, FILE_CURRENT)) {
-    return 0;
-  }
+        if (handle_ == INVALID_HANDLE_VALUE)
+        {
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
 
-  return static_cast<std::uint64_t>(current_pos.QuadPart);
-}
+        current_path_ = path;
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-FileError WindowsFileOperations::ForceSync() {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+    // Streaming I/O operations
+    FileError WindowsFileOperations::WriteSequential(const std::uint8_t *data, std::size_t size)
+    {
+        if (!IsOpen())
+        {
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
 
-  // Force filesystem sync using FlushFileBuffers - same logic as WinFile::forceSync()
-  if (!FlushFileBuffers(handle_)) {
-    return FileError::kSyncError;
-  }
+        DWORD bytes_written = 0;
+        DWORD total_written = 0;
 
-  return FileError::kSuccess;
-}
+        while (total_written < size)
+        {
+            BOOL result = WriteFile(handle_,
+                                    data + total_written,
+                                    static_cast<DWORD>(size - total_written),
+                                    &bytes_written,
+                                    nullptr);
 
-FileError WindowsFileOperations::Flush() {
-  if (!IsOpen()) {
-    return FileError::kOpenError;
-  }
+            if (!result)
+            {
+                SET_LAST_ERR(FileError::kWriteError);
+                return FileError::kWriteError;
+            }
 
-  // On Windows, FlushFileBuffers handles both buffer flush and disk sync
-  if (!FlushFileBuffers(handle_)) {
-    return FileError::kFlushError;
-  }
+            total_written += bytes_written;
+        }
 
-  return FileError::kSuccess;
-}
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
 
-int WindowsFileOperations::GetHandle() const {
-  // Note: This is a compatibility method. Windows HANDLE cannot be safely cast to int.
-  // For proper Windows code, use the handle_ member directly or add a GetWindowsHandle() method.
-  return static_cast<int>(reinterpret_cast<intptr_t>(handle_));
-}
+    FileError WindowsFileOperations::ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read)
+    {
+        if (!IsOpen())
+        {
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
 
-// Platform-specific factory function implementation
-std::unique_ptr<FileOperations> CreatePlatformFileOperations() {
-  return std::make_unique<WindowsFileOperations>();
-}
+        DWORD win_bytes_read = 0;
+        BOOL result = ReadFile(handle_, data, static_cast<DWORD>(size), &win_bytes_read, nullptr);
 
-} // namespace rpi_imager 
+        if (!result)
+        {
+            bytes_read = 0;
+            SET_LAST_ERR(FileError::kReadError);
+            return FileError::kReadError;
+        }
+
+        bytes_read = static_cast<std::size_t>(win_bytes_read);
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    FileError WindowsFileOperations::Seek(std::uint64_t position)
+    {
+        if (!IsOpen())
+        {
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
+
+        LARGE_INTEGER pos;
+        pos.QuadPart = static_cast<LONGLONG>(position);
+
+        LARGE_INTEGER new_pos;
+        if (!SetFilePointerEx(handle_, pos, &new_pos, FILE_BEGIN))
+        {
+            SET_LAST_ERR(FileError::kSeekError);
+            return FileError::kSeekError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    std::uint64_t WindowsFileOperations::Tell() const
+    {
+        if (!IsOpen())
+        {
+            return 0;
+        }
+
+        LARGE_INTEGER zero = {};
+        LARGE_INTEGER current_pos;
+
+        if (!SetFilePointerEx(handle_, zero, &current_pos, FILE_CURRENT))
+        {
+            return 0;
+        }
+
+        return static_cast<std::uint64_t>(current_pos.QuadPart);
+    }
+
+    FileError WindowsFileOperations::ForceSync()
+    {
+        if (!IsOpen())
+        {
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
+
+        // Force filesystem sync using FlushFileBuffers - same logic as WinFile::forceSync()
+        if (!FlushFileBuffers(handle_))
+        {
+            SET_LAST_ERR(FileError::kSyncError);
+            return FileError::kSyncError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    FileError WindowsFileOperations::Flush()
+    {
+        if (!IsOpen())
+        {
+            SET_LAST_ERR(FileError::kOpenError);
+            return FileError::kOpenError;
+        }
+
+        // On Windows, FlushFileBuffers handles both buffer flush and disk sync
+        if (!FlushFileBuffers(handle_))
+        {
+            SET_LAST_ERR(FileError::kFlushError);
+            return FileError::kFlushError;
+        }
+
+        CLEAR_LAST_ERR();
+        return FileError::kSuccess;
+    }
+
+    int WindowsFileOperations::GetHandle() const
+    {
+        // Note: This is a compatibility method. Windows HANDLE cannot be safely cast to int.
+        // For proper Windows code, use the handle_ member directly or add a GetWindowsHandle() method.
+        return static_cast<int>(reinterpret_cast<intptr_t>(handle_));
+    }
+
+    // Platform-specific factory function implementation
+    std::unique_ptr<FileOperations> CreatePlatformFileOperations()
+    {
+        return std::make_unique<WindowsFileOperations>();
+    }
+
+} // namespace rpi_imager

--- a/src/windows/file_operations_windows.cpp
+++ b/src/windows/file_operations_windows.cpp
@@ -5,545 +5,487 @@
 
 #include "file_operations_windows.h"
 
-#include <winioctl.h>
 #include <iostream>
+#include <winioctl.h>
 
-namespace rpi_imager
-{
+namespace rpi_imager {
 
-    WindowsFileOperations::WindowsFileOperations() : handle_(INVALID_HANDLE_VALUE) {}
+WindowsFileOperations::WindowsFileOperations() : handle_(INVALID_HANDLE_VALUE) {
+}
 
-    WindowsFileOperations::~WindowsFileOperations()
-    {
+WindowsFileOperations::~WindowsFileOperations() {
+    Close();
+}
+
+DetailedError WindowsFileOperations::MapWinDetail(DWORD e) {
+    switch (e) {
+    case ERROR_DISK_FULL:
+        return DetailedError::kNoSpace;
+    case ERROR_WRITE_PROTECT:
+        return DetailedError::kWriteProtected;
+    case ERROR_SECTOR_NOT_FOUND:
+        return DetailedError::kBadSector;
+    case ERROR_CRC:
+        return DetailedError::kCrcError;
+    case ERROR_INVALID_PARAMETER:
+        return DetailedError::kInvalidParameter;
+    case ERROR_IO_DEVICE:
+        return DetailedError::kIoDevice;
+    case ERROR_ACCESS_DENIED:
+        return DetailedError::kAccessDenied;
+    case ERROR_BUSY:
+        return DetailedError::kBusy;
+    default:
+        return DetailedError::kNoDetails;
+    }
+}
+
+FileError WindowsFileOperations::OpenDevice(const std::string &path) {
+    // Windows device paths like \\.\PHYSICALDRIVE0
+    std::cout << "Opening Windows device: " << path << std::endl;
+
+    // Check if this is a physical drive
+    bool isPhysicalDrive = (path.find("\\\\.\\PHYSICALDRIVE") == 0);
+
+    if (isPhysicalDrive) {
+        std::cout << "Detected physical drive, ensuring no volumes are mounted"
+                  << std::endl;
+
+        // For physical drives, we need to ensure no volumes are mounted
+        // This is handled by the calling code in downloadthread.cpp
+        // but we can add additional safety here
+    }
+
+    FileError result =
+        OpenInternal(path, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING);
+    if (result != FileError::kSuccess) {
+        std::cout << "Failed to open device: " << path << std::endl;
+        // OpenInternal already sets last error
+        return result;
+    }
+
+    // Enable extended DASD I/O for raw disk access
+    DWORD bytes_returned;
+    if (!DeviceIoControl(handle_, FSCTL_ALLOW_EXTENDED_DASD_IO, nullptr, 0,
+                         nullptr, 0, &bytes_returned, nullptr)) {
+        // This may fail on some systems, but we can continue
+        std::cout
+            << "Warning: FSCTL_ALLOW_EXTENDED_DASD_IO failed, continuing anyway"
+            << std::endl;
+    }
+
+    // Only try to lock volume if this is not a physical drive
+    if (!isPhysicalDrive) {
+        FileError lock_result = LockVolume();
+        if (lock_result != FileError::kSuccess) {
+            std::cout << "Warning: Failed to lock volume, continuing anyway"
+                      << std::endl;
+        }
+    } else {
+        std::cout << "Skipping volume lock for physical drive" << std::endl;
+    }
+
+    std::cout << "Successfully opened device: " << path << std::endl;
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError WindowsFileOperations::CreateTestFile(const std::string &path,
+                                                std::uint64_t size) {
+    // For test files, create a regular file
+    FileError result =
+        OpenInternal(path, GENERIC_READ | GENERIC_WRITE, CREATE_ALWAYS);
+    if (result != FileError::kSuccess) {
+        SetLastErr(result);
+        return result;
+    }
+
+    // Set file size using SetFilePointer and SetEndOfFile
+    LARGE_INTEGER file_size;
+    file_size.QuadPart = static_cast<LONGLONG>(size);
+
+    if (!SetFilePointerEx(handle_, file_size, nullptr, FILE_BEGIN)) {
         Close();
+        SetLastErr(FileError::kSeekError);
+        return FileError::kSeekError;
     }
 
-    DetailedError WindowsFileOperations::MapWinDetail(DWORD e)
-    {
-        switch (e)
-        {
-        case ERROR_DISK_FULL:
-            return DetailedError::kNoSpace;
-        case ERROR_WRITE_PROTECT:
-            return DetailedError::kWriteProtected;
-        case ERROR_SECTOR_NOT_FOUND:
-            return DetailedError::kBadSector;
-        case ERROR_CRC:
-            return DetailedError::kCrcError;
-        case ERROR_INVALID_PARAMETER:
-            return DetailedError::kInvalidParameter;
-        case ERROR_IO_DEVICE:
-            return DetailedError::kIoDevice;
-        case ERROR_ACCESS_DENIED:
-            return DetailedError::kAccessDenied;
-        case ERROR_BUSY:
-            return DetailedError::kBusy;
-        default:
-            return DetailedError::kNoDetails;
-        }
+    if (!SetEndOfFile(handle_)) {
+        Close();
+        SetLastErr(FileError::kSizeError);
+        return FileError::kSizeError;
     }
 
-    // convenience macro to set detailed error
-    #define SET_LAST_ERR(coarseCode)                                     \
-        do                                                               \
-        {                                                                \
-            DWORD _e = GetLastError();                                   \
-            last_error_ = {(coarseCode), MapWinDetail(_e), (int)_e}; \
-        } while (0)
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-    // and a way to clear it on success
-    #define CLEAR_LAST_ERR()  \
-        do                    \
-        {                     \
-            last_error_ = {}; \
-        } while (0)
+static bool IsTransientWinWriteError(DWORD e) {
+    switch (e) {
+    case ERROR_NOT_READY:         // device temporarily not ready
+    case ERROR_BUSY:              // sharing/busy state that may clear
+    case ERROR_SEM_TIMEOUT:       // timeouts can succeed on retry
+    case ERROR_OPERATION_ABORTED: // sporadic USB hiccups
+        return true;
+    default:
+        return false;
+    }
+}
 
-    FileError WindowsFileOperations::OpenDevice(const std::string &path)
-    {
-        // Windows device paths like \\.\PHYSICALDRIVE0
-        std::cout << "Opening Windows device: " << path << std::endl;
+#define SetLastErr_FROM_WIN32(coarse, winerr)                                \
+    do {                                                                       \
+        last_error_ = {(coarse), MapWinDetail((winerr)), (int)(winerr)};       \
+    } while (0)
 
-        // Check if this is a physical drive
-        bool isPhysicalDrive = (path.find("\\\\.\\PHYSICALDRIVE") == 0);
+FileError WindowsFileOperations::WriteAtOffset(std::uint64_t offset,
+                                               const std::uint8_t *data,
+                                               std::size_t size) {
 
-        if (isPhysicalDrive)
-        {
-            std::cout << "Detected physical drive, ensuring no volumes are mounted" << std::endl;
+    if (!IsOpen()) {
+        std::cout << "WriteAtOffset: Device not open" << std::endl;
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
+    }
 
-            // For physical drives, we need to ensure no volumes are mounted
-            // This is handled by the calling code in downloadthread.cpp
-            // but we can add additional safety here
+    // Set file pointer to the desired offset
+    LARGE_INTEGER offset_large;
+    offset_large.QuadPart = static_cast<LONGLONG>(offset);
+
+    if (!SetFilePointerEx(handle_, offset_large, nullptr, FILE_BEGIN)) {
+        DWORD error = GetLastError();
+        std::cout << "WriteAtOffset: SetFilePointerEx failed, offset=" << offset
+                  << ", error=" << error << std::endl;
+        SetLastErr(FileError::kSeekError);
+        return FileError::kSeekError;
+    }
+
+    // Write data in chunks with retry logic
+    std::size_t bytes_written = 0;
+    int retry_count = 0;
+    const int max_retries = 3;
+
+    while (bytes_written < size) {
+        DWORD chunk_size = static_cast<DWORD>(
+            std::min(size - bytes_written, static_cast<std::size_t>(MAXDWORD)));
+        DWORD written = 0;
+
+        if (!WriteFile(handle_, data + bytes_written, chunk_size, &written,
+                       nullptr)) {
+            DWORD error = GetLastError();
+            std::cout << "WriteAtOffset: WriteFile failed, offset="
+                      << offset + bytes_written << ", chunk_size=" << chunk_size
+                      << ", error=" << error << std::endl;
+
+            SetLastErr_FROM_WIN32(FileError::kWriteError, error);
+
+            // Retry only for transient errors
+            if (retry_count < max_retries && IsTransientWinWriteError(error)) {
+                retry_count++;
+                std::cout << "WriteAtOffset: Retrying write operation, attempt "
+                          << retry_count << std::endl;
+
+                // Wait a bit before retry
+                Sleep(100 * retry_count);
+
+                // Reset file pointer
+                if (!SetFilePointerEx(handle_, offset_large, nullptr,
+                                      FILE_BEGIN)) {
+                    std::cout << "WriteAtOffset: Failed to reset file pointer "
+                                 "for retry"
+                              << std::endl;
+                    SetLastErr(FileError::kSeekError);
+                    return FileError::kSeekError;
+                }
+
+                continue;
+            }
+
+            return FileError::kWriteError;
         }
 
-        FileError result = OpenInternal(path,
-                                        GENERIC_READ | GENERIC_WRITE,
-                                        OPEN_EXISTING);
-        if (result != FileError::kSuccess)
-        {
-            std::cout << "Failed to open device: " << path << std::endl;
-            // OpenInternal already sets last error
-            return result;
+        if (written == 0) {
+            std::cout << "WriteAtOffset: WriteFile returned 0 bytes written"
+                      << std::endl;
+
+            if (retry_count < max_retries) {
+                retry_count++;
+                std::cout << "WriteAtOffset: Retrying write operation, attempt "
+                          << retry_count << std::endl;
+                Sleep(100 * retry_count);
+                LARGE_INTEGER cur;
+                // start the retry at the correct offset to not risk duplication
+                // or corruption
+                cur.QuadPart = static_cast<LONGLONG>(offset + bytes_written);
+                if (!SetFilePointerEx(handle_, cur, nullptr, FILE_BEGIN)) {
+                    SetLastErr(FileError::kSeekError);
+                    return FileError::kSeekError;
+                }
+                continue;
+            }
+
+            // No progress after retries -> fail generically.
+            last_error_ = {FileError::kWriteError, DetailedError::kNoDetails,
+                           0};
+            return FileError::kWriteError;
         }
 
-        // Enable extended DASD I/O for raw disk access
+        bytes_written += written;
+        retry_count = 0; // Reset retry count on successful write
+    }
+
+    // Flush to ensure data is written
+    if (!FlushFileBuffers(handle_)) {
+        DWORD error = GetLastError();
+        std::cout << "WriteAtOffset: FlushFileBuffers failed, error=" << error
+                  << std::endl;
+        // Continue anyway, as this is not always critical
+    }
+
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError WindowsFileOperations::GetSize(std::uint64_t &size) {
+    if (!IsOpen()) {
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
+    }
+
+    LARGE_INTEGER file_size;
+    if (!GetFileSizeEx(handle_, &file_size)) {
+        // For devices, try to get geometry information
+        DISK_GEOMETRY geometry;
         DWORD bytes_returned;
-        if (!DeviceIoControl(handle_, FSCTL_ALLOW_EXTENDED_DASD_IO,
-                             nullptr, 0, nullptr, 0, &bytes_returned, nullptr))
-        {
-            // This may fail on some systems, but we can continue
-            std::cout << "Warning: FSCTL_ALLOW_EXTENDED_DASD_IO failed, continuing anyway" << std::endl;
+
+        if (DeviceIoControl(handle_, IOCTL_DISK_GET_DRIVE_GEOMETRY, nullptr, 0,
+                            &geometry, sizeof(geometry), &bytes_returned,
+                            nullptr)) {
+
+            size = static_cast<std::uint64_t>(geometry.Cylinders.QuadPart) *
+                   geometry.TracksPerCylinder * geometry.SectorsPerTrack *
+                   geometry.BytesPerSector;
+            ClearLastErr();
+            return FileError::kSuccess;
         }
 
-        // Only try to lock volume if this is not a physical drive
-        if (!isPhysicalDrive)
-        {
-            FileError lock_result = LockVolume();
-            if (lock_result != FileError::kSuccess)
-            {
-                std::cout << "Warning: Failed to lock volume, continuing anyway" << std::endl;
-            }
-        }
-        else
-        {
-            std::cout << "Skipping volume lock for physical drive" << std::endl;
-        }
-
-        std::cout << "Successfully opened device: " << path << std::endl;
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+        SetLastErr(FileError::kSizeError);
+        return FileError::kSizeError;
     }
 
-    FileError WindowsFileOperations::CreateTestFile(const std::string &path, std::uint64_t size)
-    {
-        // For test files, create a regular file
-        FileError result = OpenInternal(path,
-                                        GENERIC_READ | GENERIC_WRITE,
-                                        CREATE_ALWAYS);
-        if (result != FileError::kSuccess)
-        {
-            SET_LAST_ERR(result);
-            return result;
+    size = static_cast<std::uint64_t>(file_size.QuadPart);
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError WindowsFileOperations::Close() {
+    if (handle_ != INVALID_HANDLE_VALUE) {
+        // Only unlock volume if this is not a physical drive
+        bool isPhysicalDrive =
+            (current_path_.find("\\\\.\\PHYSICALDRIVE") == 0);
+        if (!isPhysicalDrive) {
+            UnlockVolume(); // Unlock if it was locked
         }
 
-        // Set file size using SetFilePointer and SetEndOfFile
-        LARGE_INTEGER file_size;
-        file_size.QuadPart = static_cast<LONGLONG>(size);
-
-        if (!SetFilePointerEx(handle_, file_size, nullptr, FILE_BEGIN))
-        {
-            Close();
-            SET_LAST_ERR(FileError::kSeekError);
-            return FileError::kSeekError;
-        }
-
-        if (!SetEndOfFile(handle_))
-        {
-            Close();
-            SET_LAST_ERR(FileError::kSizeError);
-            return FileError::kSizeError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
-    }
-
-    static bool IsTransientWinWriteError(DWORD e) {
-        switch (e) {
-        case ERROR_NOT_READY:        // device temporarily not ready
-        case ERROR_BUSY:             // sharing/busy state that may clear
-        case ERROR_SEM_TIMEOUT:      // timeouts can succeed on retry
-        case ERROR_OPERATION_ABORTED:// sporadic USB hiccups
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    #define SET_LAST_ERR_FROM_WIN32(coarse, winerr) \
-        do { last_error_ = { (coarse), MapWinDetail((winerr)), (int)(winerr) }; } while (0)
-
-    FileError WindowsFileOperations::WriteAtOffset(
-        std::uint64_t offset,
-        const std::uint8_t *data,
-        std::size_t size)
-    {
-
-        if (!IsOpen())
-        {
-            std::cout << "WriteAtOffset: Device not open" << std::endl;
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
-
-        // Set file pointer to the desired offset
-        LARGE_INTEGER offset_large;
-        offset_large.QuadPart = static_cast<LONGLONG>(offset);
-
-        if (!SetFilePointerEx(handle_, offset_large, nullptr, FILE_BEGIN))
-        {
-            DWORD error = GetLastError();
-            std::cout << "WriteAtOffset: SetFilePointerEx failed, offset=" << offset << ", error=" << error << std::endl;
-            SET_LAST_ERR(FileError::kSeekError);
-            return FileError::kSeekError;
-        }
-
-        // Write data in chunks with retry logic
-        std::size_t bytes_written = 0;
-        int retry_count = 0;
-        const int max_retries = 3;
-
-        while (bytes_written < size)
-        {
-            DWORD chunk_size = static_cast<DWORD>(std::min(size - bytes_written,
-                                                           static_cast<std::size_t>(MAXDWORD)));
-            DWORD written = 0;
-
-            if (!WriteFile(handle_, data + bytes_written, chunk_size, &written, nullptr))
-            {
-                DWORD error = GetLastError();
-                std::cout << "WriteAtOffset: WriteFile failed, offset=" << offset + bytes_written
-                          << ", chunk_size=" << chunk_size << ", error=" << error << std::endl;
-
-                SET_LAST_ERR_FROM_WIN32(FileError::kWriteError, error);
-
-                // Retry only for transient errors
-                if (retry_count < max_retries && IsTransientWinWriteError(error))
-                {
-                    retry_count++;
-                    std::cout << "WriteAtOffset: Retrying write operation, attempt " << retry_count << std::endl;
-
-                    // Wait a bit before retry
-                    Sleep(100 * retry_count);
-
-                    // Reset file pointer
-                    if (!SetFilePointerEx(handle_, offset_large, nullptr, FILE_BEGIN))
-                    {
-                        std::cout << "WriteAtOffset: Failed to reset file pointer for retry" << std::endl;
-                        SET_LAST_ERR(FileError::kSeekError);
-                        return FileError::kSeekError;
-                    }
-
-                    continue;
-                }
-
-                return FileError::kWriteError;
-            }
-
-            if (written == 0)
-            {
-                std::cout << "WriteAtOffset: WriteFile returned 0 bytes written" << std::endl;
-
-                if (retry_count < max_retries)
-                {
-                    retry_count++;
-                    std::cout << "WriteAtOffset: Retrying write operation, attempt " << retry_count << std::endl;
-                    Sleep(100 * retry_count);
-                    LARGE_INTEGER cur;
-                    // start the retry at the correct offset to not risk duplication or corruption
-                    cur.QuadPart = static_cast<LONGLONG>(offset + bytes_written);
-                    if (!SetFilePointerEx(handle_, cur, nullptr, FILE_BEGIN)) {
-                        SET_LAST_ERR(FileError::kSeekError);
-                        return FileError::kSeekError;
-                    }
-                    continue;
-                }
-
-                // No progress after retries -> fail generically.
-                last_error_ = { FileError::kWriteError, DetailedError::kNoDetails, 0 };
-                return FileError::kWriteError;
-            }
-
-            bytes_written += written;
-            retry_count = 0; // Reset retry count on successful write
-        }
-
-        // Flush to ensure data is written
-        if (!FlushFileBuffers(handle_))
-        {
-            DWORD error = GetLastError();
-            std::cout << "WriteAtOffset: FlushFileBuffers failed, error=" << error << std::endl;
-            // Continue anyway, as this is not always critical
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
-    }
-
-    FileError WindowsFileOperations::GetSize(std::uint64_t &size)
-    {
-        if (!IsOpen())
-        {
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
-
-        LARGE_INTEGER file_size;
-        if (!GetFileSizeEx(handle_, &file_size))
-        {
-            // For devices, try to get geometry information
-            DISK_GEOMETRY geometry;
-            DWORD bytes_returned;
-
-            if (DeviceIoControl(handle_, IOCTL_DISK_GET_DRIVE_GEOMETRY,
-                                nullptr, 0, &geometry, sizeof(geometry),
-                                &bytes_returned, nullptr))
-            {
-
-                size = static_cast<std::uint64_t>(geometry.Cylinders.QuadPart) *
-                       geometry.TracksPerCylinder *
-                       geometry.SectorsPerTrack *
-                       geometry.BytesPerSector;
-                CLEAR_LAST_ERR();
-                return FileError::kSuccess;
-            }
-
-            SET_LAST_ERR(FileError::kSizeError);
-            return FileError::kSizeError;
-        }
-
-        size = static_cast<std::uint64_t>(file_size.QuadPart);
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
-    }
-
-    FileError WindowsFileOperations::Close()
-    {
-        if (handle_ != INVALID_HANDLE_VALUE)
-        {
-            // Only unlock volume if this is not a physical drive
-            bool isPhysicalDrive = (current_path_.find("\\\\.\\PHYSICALDRIVE") == 0);
-            if (!isPhysicalDrive)
-            {
-                UnlockVolume(); // Unlock if it was locked
-            }
-
-            if (!CloseHandle(handle_))
-            {
-                handle_ = INVALID_HANDLE_VALUE;
-                SET_LAST_ERR(FileError::kCloseError);
-                return FileError::kCloseError;
-            }
+        if (!CloseHandle(handle_)) {
             handle_ = INVALID_HANDLE_VALUE;
+            SetLastErr(FileError::kCloseError);
+            return FileError::kCloseError;
         }
-        current_path_.clear();
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+        handle_ = INVALID_HANDLE_VALUE;
+    }
+    current_path_.clear();
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+bool WindowsFileOperations::IsOpen() const {
+    return handle_ != INVALID_HANDLE_VALUE;
+}
+
+FileError WindowsFileOperations::LockVolume() {
+    if (!IsOpen()) {
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
     }
 
-    bool WindowsFileOperations::IsOpen() const
-    {
-        return handle_ != INVALID_HANDLE_VALUE;
+    DWORD bytes_returned;
+    if (!DeviceIoControl(handle_, FSCTL_LOCK_VOLUME, nullptr, 0, nullptr, 0,
+                         &bytes_returned, nullptr)) {
+        // Lock may fail for files (not devices), which is okay
+        DWORD error = GetLastError();
+        if (error != ERROR_INVALID_FUNCTION) {
+            SetLastErr(FileError::kLockError);
+            return FileError::kLockError;
+        }
     }
 
-    FileError WindowsFileOperations::LockVolume()
-    {
-        if (!IsOpen())
-        {
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
+FileError WindowsFileOperations::UnlockVolume() {
+    if (IsOpen()) {
         DWORD bytes_returned;
-        if (!DeviceIoControl(handle_, FSCTL_LOCK_VOLUME,
-                             nullptr, 0, nullptr, 0, &bytes_returned, nullptr))
-        {
-            // Lock may fail for files (not devices), which is okay
-            DWORD error = GetLastError();
-            if (error != ERROR_INVALID_FUNCTION)
-            {
-                SET_LAST_ERR(FileError::kLockError);
-                return FileError::kLockError;
-            }
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+        DeviceIoControl(handle_, FSCTL_UNLOCK_VOLUME, nullptr, 0, nullptr, 0,
+                        &bytes_returned, nullptr);
     }
 
-    FileError WindowsFileOperations::UnlockVolume()
-    {
-        if (IsOpen())
-        {
-            DWORD bytes_returned;
-            DeviceIoControl(handle_, FSCTL_UNLOCK_VOLUME,
-                            nullptr, 0, nullptr, 0, &bytes_returned, nullptr);
-        }
+    // Already closed or
+    // Ignore errors here as we're likely closing anyway
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        // Already closed or
-        // Ignore errors here as we're likely closing anyway
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+FileError WindowsFileOperations::OpenInternal(const std::string &path,
+                                              DWORD access, DWORD creation) {
+    // Close any existing handle
+    Close();
+
+    handle_ =
+        CreateFileA(path.c_str(), access, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    nullptr, creation,
+                    FILE_ATTRIBUTE_NORMAL, // Removed FILE_FLAG_NO_BUFFERING to
+                                           // fix alignment issues
+                    nullptr);
+
+    if (handle_ == INVALID_HANDLE_VALUE) {
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
     }
 
-    FileError WindowsFileOperations::OpenInternal(const std::string &path, DWORD access, DWORD creation)
-    {
-        // Close any existing handle
-        Close();
+    current_path_ = path;
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        handle_ = CreateFileA(path.c_str(),
-                              access,
-                              FILE_SHARE_READ | FILE_SHARE_WRITE,
-                              nullptr,
-                              creation,
-                              FILE_ATTRIBUTE_NORMAL, // Removed FILE_FLAG_NO_BUFFERING to fix alignment issues
-                              nullptr);
-
-        if (handle_ == INVALID_HANDLE_VALUE)
-        {
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
-
-        current_path_ = path;
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+// Streaming I/O operations
+FileError WindowsFileOperations::WriteSequential(const std::uint8_t *data,
+                                                 std::size_t size) {
+    if (!IsOpen()) {
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
     }
 
-    // Streaming I/O operations
-    FileError WindowsFileOperations::WriteSequential(const std::uint8_t *data, std::size_t size)
-    {
-        if (!IsOpen())
-        {
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
+    DWORD bytes_written = 0;
+    DWORD total_written = 0;
+
+    while (total_written < size) {
+        BOOL result = WriteFile(handle_, data + total_written,
+                                static_cast<DWORD>(size - total_written),
+                                &bytes_written, nullptr);
+
+        if (!result) {
+            SetLastErr(FileError::kWriteError);
+            return FileError::kWriteError;
         }
 
-        DWORD bytes_written = 0;
-        DWORD total_written = 0;
-
-        while (total_written < size)
-        {
-            BOOL result = WriteFile(handle_,
-                                    data + total_written,
-                                    static_cast<DWORD>(size - total_written),
-                                    &bytes_written,
-                                    nullptr);
-
-            if (!result)
-            {
-                SET_LAST_ERR(FileError::kWriteError);
-                return FileError::kWriteError;
-            }
-
-            total_written += bytes_written;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+        total_written += bytes_written;
     }
 
-    FileError WindowsFileOperations::ReadSequential(std::uint8_t *data, std::size_t size, std::size_t &bytes_read)
-    {
-        if (!IsOpen())
-        {
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        DWORD win_bytes_read = 0;
-        BOOL result = ReadFile(handle_, data, static_cast<DWORD>(size), &win_bytes_read, nullptr);
-
-        if (!result)
-        {
-            bytes_read = 0;
-            SET_LAST_ERR(FileError::kReadError);
-            return FileError::kReadError;
-        }
-
-        bytes_read = static_cast<std::size_t>(win_bytes_read);
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+FileError WindowsFileOperations::ReadSequential(std::uint8_t *data,
+                                                std::size_t size,
+                                                std::size_t &bytes_read) {
+    if (!IsOpen()) {
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
     }
 
-    FileError WindowsFileOperations::Seek(std::uint64_t position)
-    {
-        if (!IsOpen())
-        {
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
+    DWORD win_bytes_read = 0;
+    BOOL result = ReadFile(handle_, data, static_cast<DWORD>(size),
+                           &win_bytes_read, nullptr);
 
-        LARGE_INTEGER pos;
-        pos.QuadPart = static_cast<LONGLONG>(position);
-
-        LARGE_INTEGER new_pos;
-        if (!SetFilePointerEx(handle_, pos, &new_pos, FILE_BEGIN))
-        {
-            SET_LAST_ERR(FileError::kSeekError);
-            return FileError::kSeekError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    if (!result) {
+        bytes_read = 0;
+        SetLastErr(FileError::kReadError);
+        return FileError::kReadError;
     }
 
-    std::uint64_t WindowsFileOperations::Tell() const
-    {
-        if (!IsOpen())
-        {
-            return 0;
-        }
+    bytes_read = static_cast<std::size_t>(win_bytes_read);
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        LARGE_INTEGER zero = {};
-        LARGE_INTEGER current_pos;
-
-        if (!SetFilePointerEx(handle_, zero, &current_pos, FILE_CURRENT))
-        {
-            return 0;
-        }
-
-        return static_cast<std::uint64_t>(current_pos.QuadPart);
+FileError WindowsFileOperations::Seek(std::uint64_t position) {
+    if (!IsOpen()) {
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
     }
 
-    FileError WindowsFileOperations::ForceSync()
-    {
-        if (!IsOpen())
-        {
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
+    LARGE_INTEGER pos;
+    pos.QuadPart = static_cast<LONGLONG>(position);
 
-        // Force filesystem sync using FlushFileBuffers - same logic as WinFile::forceSync()
-        if (!FlushFileBuffers(handle_))
-        {
-            SET_LAST_ERR(FileError::kSyncError);
-            return FileError::kSyncError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+    LARGE_INTEGER new_pos;
+    if (!SetFilePointerEx(handle_, pos, &new_pos, FILE_BEGIN)) {
+        SetLastErr(FileError::kSeekError);
+        return FileError::kSeekError;
     }
 
-    FileError WindowsFileOperations::Flush()
-    {
-        if (!IsOpen())
-        {
-            SET_LAST_ERR(FileError::kOpenError);
-            return FileError::kOpenError;
-        }
+    ClearLastErr();
+    return FileError::kSuccess;
+}
 
-        // On Windows, FlushFileBuffers handles both buffer flush and disk sync
-        if (!FlushFileBuffers(handle_))
-        {
-            SET_LAST_ERR(FileError::kFlushError);
-            return FileError::kFlushError;
-        }
-
-        CLEAR_LAST_ERR();
-        return FileError::kSuccess;
+std::uint64_t WindowsFileOperations::Tell() const {
+    if (!IsOpen()) {
+        return 0;
     }
 
-    int WindowsFileOperations::GetHandle() const
-    {
-        // Note: This is a compatibility method. Windows HANDLE cannot be safely cast to int.
-        // For proper Windows code, use the handle_ member directly or add a GetWindowsHandle() method.
-        return static_cast<int>(reinterpret_cast<intptr_t>(handle_));
+    LARGE_INTEGER zero = {};
+    LARGE_INTEGER current_pos;
+
+    if (!SetFilePointerEx(handle_, zero, &current_pos, FILE_CURRENT)) {
+        return 0;
     }
 
-    // Platform-specific factory function implementation
-    std::unique_ptr<FileOperations> CreatePlatformFileOperations()
-    {
-        return std::make_unique<WindowsFileOperations>();
+    return static_cast<std::uint64_t>(current_pos.QuadPart);
+}
+
+FileError WindowsFileOperations::ForceSync() {
+    if (!IsOpen()) {
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
     }
+
+    // Force filesystem sync using FlushFileBuffers - same logic as
+    // WinFile::forceSync()
+    if (!FlushFileBuffers(handle_)) {
+        SetLastErr(FileError::kSyncError);
+        return FileError::kSyncError;
+    }
+
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+FileError WindowsFileOperations::Flush() {
+    if (!IsOpen()) {
+        SetLastErr(FileError::kOpenError);
+        return FileError::kOpenError;
+    }
+
+    // On Windows, FlushFileBuffers handles both buffer flush and disk sync
+    if (!FlushFileBuffers(handle_)) {
+        SetLastErr(FileError::kFlushError);
+        return FileError::kFlushError;
+    }
+
+    ClearLastErr();
+    return FileError::kSuccess;
+}
+
+int WindowsFileOperations::GetHandle() const {
+    // Note: This is a compatibility method. Windows HANDLE cannot be safely
+    // cast to int. For proper Windows code, use the handle_ member directly or
+    // add a GetWindowsHandle() method.
+    return static_cast<int>(reinterpret_cast<intptr_t>(handle_));
+}
+
+// Platform-specific factory function implementation
+std::unique_ptr<FileOperations> CreatePlatformFileOperations() {
+    return std::make_unique<WindowsFileOperations>();
+}
 
 } // namespace rpi_imager

--- a/src/windows/file_operations_windows.h
+++ b/src/windows/file_operations_windows.h
@@ -15,49 +15,54 @@ namespace rpi_imager {
 
 // Windows implementation using Win32 API
 class WindowsFileOperations : public FileOperations {
- public:
-  WindowsFileOperations();
-  ~WindowsFileOperations() override;
+public:
+    WindowsFileOperations();
+    ~WindowsFileOperations() override;
 
-  // Non-copyable, movable
-  WindowsFileOperations(const WindowsFileOperations&) = delete;
-  WindowsFileOperations& operator=(const WindowsFileOperations&) = delete;
-  WindowsFileOperations(WindowsFileOperations&&) = default;
-  WindowsFileOperations& operator=(WindowsFileOperations&&) = default;
+    // Non-copyable, movable
+    WindowsFileOperations(const WindowsFileOperations&) = delete;
+    WindowsFileOperations& operator=(const WindowsFileOperations&) = delete;
+    WindowsFileOperations(WindowsFileOperations&&) = default;
+    WindowsFileOperations& operator=(WindowsFileOperations&&) = default;
 
-  FileError OpenDevice(const std::string& path) override;
-  FileError CreateTestFile(const std::string& path, std::uint64_t size) override;
-  FileError WriteAtOffset(
-      std::uint64_t offset,
-      const std::uint8_t* data,
-      std::size_t size) override;
-  FileError GetSize(std::uint64_t& size) override;
-  FileError Close() override;
-  bool IsOpen() const override;
+    FileError OpenDevice(const std::string& path) override;
+    FileError CreateTestFile(const std::string& path, std::uint64_t size) override;
+    FileError WriteAtOffset(
+        std::uint64_t offset,
+        const std::uint8_t* data,
+        std::size_t size) override;
+    FileError GetSize(std::uint64_t& size) override;
+    FileError Close() override;
+    bool IsOpen() const override;
 
-  // Streaming I/O operations
-  FileError WriteSequential(const std::uint8_t* data, std::size_t size) override;
-  FileError ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) override;
-  
-  // File positioning
-  FileError Seek(std::uint64_t position) override;
-  std::uint64_t Tell() const override;
-  
-  // Sync operations
-  FileError ForceSync() override;
-  FileError Flush() override;
-  
-  // Handle access (Windows uses HANDLE, so we return a cast to int)
-  int GetHandle() const override;
+    // Streaming I/O operations
+    FileError WriteSequential(const std::uint8_t* data, std::size_t size) override;
+    FileError ReadSequential(std::uint8_t* data, std::size_t size, std::size_t& bytes_read) override;
 
- private:
-  HANDLE handle_;
-  std::string current_path_;
-  
-   FileError LockVolume();
-   FileError UnlockVolume();
-   FileError OpenInternal(const std::string& path, DWORD access, DWORD creation);
- };
+    // File positioning
+    FileError Seek(std::uint64_t position) override;
+    std::uint64_t Tell() const override;
+
+    // Sync operations
+    FileError ForceSync() override;
+    FileError Flush() override;
+
+    // Handle access (Windows uses HANDLE, so we return a cast to int)
+    int GetHandle() const override;
+
+    ErrorInfo LastError() const override { return last_error_; }
+
+private:
+    HANDLE handle_;
+    std::string current_path_;
+    ErrorInfo last_error_{};
+
+    FileError LockVolume();
+    FileError UnlockVolume();
+    FileError OpenInternal(const std::string& path, DWORD access, DWORD creation);
+
+    static DetailedError MapWinDetail(DWORD e);
+};
 
 } // namespace rpi_imager
 


### PR DESCRIPTION
+ Fix windows build

Sorry for some of the formatting changes the platform file-ops implementations for some reason had 2-space indent and at some places it was mixed compared to the 4-space indent in the rest of the project. I only formatted in the places I also needed to change stuff so the editor doesn't freak out. 