### PR TITLE
Update German Translation

### DIFF
--- a/src/i18n/rpi-imager_de.ts
+++ b/src/i18n/rpi-imager_de.ts
@@ -5,39 +5,39 @@
     <name>AppOptionsDialog</name>
     <message>
         <source>App Options</source>
-        <translation type="unfinished"></translation>
+        <translation>Programm Optionen</translation>
     </message>
     <message>
         <source>Play sound when finished</source>
-        <translation type="unfinished">Tonsignal nach Beenden abspielen</translation>
+        <translation>Tonsignal nach Beenden abspielen</translation>
     </message>
     <message>
         <source>Eject media when finished</source>
-        <translation type="unfinished">Medien nach Beenden auswerfen</translation>
+        <translation>Medien nach Beenden auswerfen</translation>
     </message>
     <message>
         <source>Enable anonymous statistics (telemetry)</source>
-        <translation type="unfinished"></translation>
+        <translation>Anonyme Statistiken aktivieren (Telemetrie)</translation>
     </message>
     <message>
         <source>What is this?</source>
-        <translation type="unfinished"></translation>
+        <translation>Was ist das?</translation>
     </message>
     <message>
         <source>Disable warnings</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnungen ausschalten</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation>Speichern</translation>
     </message>
     <message>
         <source>Disable warnings?</source>
-        <translation type="unfinished"></translation>
+        <translation>Warnungen ausschalten?</translation>
     </message>
     <message>
         <source>If you disable warnings, Raspberry Pi Imager will &lt;b&gt;not show confirmation prompts before writing images&lt;/b&gt;. You will still be required to &lt;b&gt;type the exact name&lt;/b&gt; when selecting a system drive.</source>
@@ -119,7 +119,7 @@
     </message>
     <message>
         <source>CONTINUE</source>
-        <translation type="unfinished">WEITER</translation>
+        <translation>WEITER</translation>
     </message>
 </context>
 <context>
@@ -145,7 +145,7 @@
     <name>DeviceSelectionStep</name>
     <message>
         <source>Select your Raspberry Pi device</source>
-        <translation type="unfinished"></translation>
+        <translation>Wählen Sie Ihr Raspberry Pi-Gerät aus</translation>
     </message>
 </context>
 <context>
@@ -228,7 +228,7 @@
     </message>
     <message>
         <source>Reboot</source>
-        <translation type="unfinished"></translation>
+        <translation>Neustart</translation>
     </message>
 </context>
 <context>
@@ -251,11 +251,11 @@
     </message>
     <message>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
-        <translation type="unfinished">Fehler beim Lesen vom Speicher.&lt;br&gt;Die SD-Karte könnte defekt sein.</translation>
+        <translation>Fehler beim Lesen vom Speicher.&lt;br&gt;Die SD-Karte könnte defekt sein.</translation>
     </message>
     <message>
         <source>Verifying write failed. Contents of SD card is different from what was written to it.</source>
-        <translation type="unfinished">Verifizierung fehlgeschlagen. Der Inhalt der SD-Karte weicht von dem Inhalt ab, der geschrieben werden sollte.</translation>
+        <translation>Verifizierung fehlgeschlagen. Der Inhalt der SD-Karte weicht von dem Inhalt ab, der geschrieben werden sollte.</translation>
     </message>
 </context>
 <context>
@@ -448,7 +448,7 @@
     <name>HostnameCustomizationStep</name>
     <message>
         <source>raspberrypi</source>
-        <translation type="unfinished"></translation>
+        <translation>raspberrypi</translation>
     </message>
     <message>
         <source>A hostname is a unique name that identifies your Raspberry Pi on the network. It should contain only letters, numbers, and hyphens.</source>
@@ -499,7 +499,7 @@
     </message>
     <message>
         <source>Console</source>
-        <translation type="unfinished"></translation>
+        <translation>Konsole</translation>
     </message>
     <message>
         <source>USB Gadget Mode can change how your device behaves and may impact connectivity and host interaction.</source>
@@ -515,7 +515,7 @@
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
         <source>I understand, continue</source>
@@ -534,23 +534,23 @@
     </message>
     <message>
         <source>Documents</source>
-        <translation type="unfinished"></translation>
+        <translation>Dokumente</translation>
     </message>
     <message>
         <source>Downloads</source>
-        <translation type="unfinished"></translation>
+        <translation>Downloads</translation>
     </message>
     <message>
         <source>Pictures</source>
-        <translation type="unfinished"></translation>
+        <translation>Bilder</translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"></translation>
+        <translation>Musik</translation>
     </message>
     <message>
         <source>Movies</source>
-        <translation type="unfinished"></translation>
+        <translation>Filme</translation>
     </message>
     <message>
         <source>Root</source>
@@ -562,15 +562,15 @@
     </message>
     <message>
         <source>Folders</source>
-        <translation type="unfinished"></translation>
+        <translation>Ordner</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation>Öffnen</translation>
     </message>
 </context>
 <context>
@@ -597,23 +597,23 @@
     </message>
     <message>
         <source>B</source>
-        <translation type="unfinished"></translation>
+        <translation>B</translation>
     </message>
     <message>
         <source>TB</source>
-        <translation type="unfinished"></translation>
+        <translation>TB</translation>
     </message>
     <message>
         <source>GB</source>
-        <translation type="unfinished">GB</translation>
+        <translation>GB</translation>
     </message>
     <message>
         <source>MB</source>
-        <translation type="unfinished"></translation>
+        <translation>MB</translation>
     </message>
     <message>
         <source>KB</source>
-        <translation type="unfinished"></translation>
+        <translation>KB</translation>
     </message>
     <message>
         <source>%1 %2</source>
@@ -672,26 +672,26 @@
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>Nein</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Ja</translation>
     </message>
 </context>
 <context>
     <name>LanguageSelectionStep</name>
     <message>
         <source>Welcome</source>
-        <translation type="unfinished"></translation>
+        <translation>Willkommen</translation>
     </message>
     <message>
         <source>Language:</source>
-        <translation type="unfinished"></translation>
+        <translation>Sprache:</translation>
     </message>
     <message>
         <source>Choose your language for Raspberry Pi Imager</source>
-        <translation type="unfinished"></translation>
+        <translation>Wählen Sie die Sprache für Raspberry Pi Imager</translation>
     </message>
 </context>
 <context>
@@ -725,7 +725,7 @@
     <name>LocaleCustomizationStep</name>
     <message>
         <source>Keyboard layout:</source>
-        <translation type="unfinished">Tastaturlayout:</translation>
+        <translation>Tastaturlayout:</translation>
     </message>
     <message>
         <source>Customisation: Choose locale</source>
@@ -737,7 +737,7 @@
     </message>
     <message>
         <source>Time zone:</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeitzone:</translation>
     </message>
 </context>
 <context>
@@ -755,11 +755,11 @@
     </message>
     <message>
         <source>Cached on your computer</source>
-        <translation type="unfinished">Auf Ihrem Computer zwischengespeichert</translation>
+        <translation>Auf Ihrem Computer zwischengespeichert</translation>
     </message>
     <message>
         <source>Local file</source>
-        <translation type="unfinished">Lokale Datei</translation>
+        <translation>Lokale Datei</translation>
     </message>
     <message>
         <source>Online - %1 download</source>
@@ -767,23 +767,23 @@
     </message>
     <message>
         <source>Back</source>
-        <translation type="unfinished">Zurück</translation>
+        <translation>Zurück</translation>
     </message>
     <message>
         <source>Go back to main menu</source>
-        <translation type="unfinished">Zurück zum Hauptmenü</translation>
+        <translation>Zurück zum Hauptmenü</translation>
     </message>
     <message>
         <source>Select image</source>
-        <translation type="unfinished">Image wählen</translation>
+        <translation>Image wählen</translation>
     </message>
     <message>
         <source>Choose operating system</source>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem auswählen</translation>
     </message>
     <message>
         <source>Select an operating system to install on your Raspberry Pi</source>
-        <translation type="unfinished"></translation>
+        <translation>Wählen Sie ein Betriebssystem zur Installation auf Ihrem Raspberry Pi aus</translation>
     </message>
 </context>
 <context>
@@ -825,11 +825,11 @@
     <name>RemoteAccessStep</name>
     <message>
         <source>Enable SSH</source>
-        <translation type="unfinished">SSH aktivieren</translation>
+        <translation>SSH aktivieren</translation>
     </message>
     <message>
         <source>Use password authentication</source>
-        <translation type="unfinished">Passwort zur Authentifizierung verwenden</translation>
+        <translation>Passwort zur Authentifizierung verwenden</translation>
     </message>
     <message>
         <source>Use public key authentication</source>
@@ -895,19 +895,19 @@
     <name>UpdateAvailableDialog</name>
     <message>
         <source>Update available</source>
-        <translation type="unfinished">Update verfügbar</translation>
+        <translation>Update verfügbar</translation>
     </message>
     <message>
         <source>There is a newer version of Imager available. Would you like to visit the website to download it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Es ist eine neuere Version von Imager verfügbar. Möchten Sie die Website besuchen, um sie herunterzuladen?</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>Nein</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Ja</translation>
     </message>
 </context>
 <context>
@@ -969,19 +969,19 @@
     </message>
     <message>
         <source>Password:</source>
-        <translation type="unfinished">Passwort:</translation>
+        <translation>Passwort:</translation>
     </message>
     <message>
         <source>Network password</source>
-        <translation type="unfinished"></translation>
+        <translation>Netzwerk Passwort</translation>
     </message>
     <message>
         <source>Wireless LAN country:</source>
-        <translation type="unfinished">Wifi-Land:</translation>
+        <translation>Wifi-Land:</translation>
     </message>
     <message>
         <source>Hidden SSID</source>
-        <translation type="unfinished">Verborgene SSID</translation>
+        <translation>Verborgene SSID</translation>
     </message>
     <message>
         <source>Customisation: Choose Wi‑Fi</source>
@@ -1067,15 +1067,15 @@
     <name>WizardStepBase</name>
     <message>
         <source>Next</source>
-        <translation type="unfinished">Weiter</translation>
+        <translation>Weiter</translation>
     </message>
     <message>
         <source>Back</source>
-        <translation type="unfinished">Zurück</translation>
+        <translation>Zurück</translation>
     </message>
     <message>
         <source>Skip customisation</source>
-        <translation type="unfinished"></translation>
+        <translation>Anpassung überspringen</translation>
     </message>
 </context>
 <context>
@@ -1257,15 +1257,15 @@
     </message>
     <message>
         <source>Raspberry Pi Imager is still busy. Are you sure you want to quit?</source>
-        <translation type="unfinished"></translation>
+        <translation>Raspberry Pi Imager ist noch beschäftigt. Möchten Sie wirklich beenden?</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation>Nein</translation>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation>Ja</translation>
     </message>
     <message>
         <source>Storage device removed</source>
@@ -1273,7 +1273,7 @@
     </message>
     <message>
         <source>Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>Weiter</translation>
     </message>
     <message>
         <source>The storage device was removed while writing, so the operation was cancelled. Please reinsert the device or select a different one to continue.</source>

--- a/src/i18n/rpi-imager_de.ts
+++ b/src/i18n/rpi-imager_de.ts
@@ -145,7 +145,7 @@
     <name>DeviceSelectionStep</name>
     <message>
         <source>Select your Raspberry Pi device</source>
-        <translation>Wählen Sie Ihr Raspberry Pi-Gerät aus</translation>
+        <translation>Wählen Sie Ihr Raspberry Pi-Modell aus</translation>
     </message>
 </context>
 <context>
@@ -156,27 +156,27 @@
     </message>
     <message>
         <source>Device:</source>
-        <translation type="unfinished"></translation>
+        <translation>Modell:</translation>
     </message>
     <message>
         <source>No device selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Modell ausgewählt</translation>
     </message>
     <message>
         <source>Operating System:</source>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem:</translation>
     </message>
     <message>
         <source>No image selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Image ausgewählt</translation>
     </message>
     <message>
         <source>Storage Device:</source>
-        <translation type="unfinished"></translation>
+        <translation>Speichergerät:</translation>
     </message>
     <message>
         <source>No storage device selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Speichergerät ausgewählt</translation>
     </message>
     <message>
         <source>✓ Hostname configured</source>
@@ -751,7 +751,7 @@
     <name>OSSelectionStep</name>
     <message>
         <source>Local - %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Lokal - %1</translation>
     </message>
     <message>
         <source>Cached on your computer</source>
@@ -763,7 +763,7 @@
     </message>
     <message>
         <source>Online - %1 download</source>
-        <translation type="unfinished"></translation>
+        <translation>Online - %1 download</translation>
     </message>
     <message>
         <source>Back</source>
@@ -872,11 +872,11 @@
     <name>StorageSelectionStep</name>
     <message>
         <source>No storage devices found</source>
-        <translation type="unfinished">Keine SD-Karte gefunden</translation>
+        <translation>Kein Speichergerät gefunden</translation>
     </message>
     <message>
         <source>Mounted as %1</source>
-        <translation type="unfinished">Als %1 eingebunden</translation>
+        <translation>Als %1 eingebunden</translation>
     </message>
     <message>
         <source>Read-only</source>
@@ -914,7 +914,7 @@
     <name>UserCustomizationStep</name>
     <message>
         <source>Username:</source>
-        <translation type="unfinished">Benutzername:</translation>
+        <translation>Benutzername:</translation>
     </message>
     <message>
         <source>pi</source>
@@ -922,7 +922,7 @@
     </message>
     <message>
         <source>Password:</source>
-        <translation type="unfinished">Passwort:</translation>
+        <translation>Passwort:</translation>
     </message>
     <message>
         <source>Enter password</source>
@@ -961,7 +961,7 @@
     <name>WifiCustomizationStep</name>
     <message>
         <source>SSID:</source>
-        <translation type="unfinished">SSID:</translation>
+        <translation>SSID:</translation>
     </message>
     <message>
         <source>Network name</source>
@@ -1000,15 +1000,15 @@
     <name>WizardContainer</name>
     <message>
         <source>Device</source>
-        <translation type="unfinished"></translation>
+        <translation>Modell</translation>
     </message>
     <message>
         <source>OS</source>
-        <translation type="unfinished"></translation>
+        <translation>Betriebssystem</translation>
     </message>
     <message>
         <source>Storage</source>
-        <translation type="unfinished">SD-Karte</translation>
+        <translation>Speicher</translation>
     </message>
     <message>
         <source>Writing</source>
@@ -1086,23 +1086,23 @@
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>Abbrechen</translation>
     </message>
     <message>
         <source>Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>Fortsetzen</translation>
     </message>
     <message>
         <source>Write</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreiben</translation>
     </message>
     <message>
         <source>Summary</source>
-        <translation type="unfinished"></translation>
+        <translation>Zusammenfassung</translation>
     </message>
     <message>
         <source>Device:</source>
-        <translation type="unfinished"></translation>
+        <translation>Modell:</translation>
     </message>
     <message>
         <source>No device selected</source>
@@ -1110,7 +1110,7 @@
     </message>
     <message>
         <source>No image selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Image ausgewählt</translation>
     </message>
     <message>
         <source>Storage:</source>
@@ -1142,7 +1142,7 @@
     </message>
     <message>
         <source>Write cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>Schreiben abgebrochen</translation>
     </message>
     <message>
         <source>You are about to ERASE all data on: %1</source>
@@ -1162,15 +1162,15 @@
     </message>
     <message>
         <source>Please wait...</source>
-        <translation type="unfinished"></translation>
+        <translation>Bitte warten...</translation>
     </message>
     <message>
         <source>Writing... %1%</source>
-        <translation type="unfinished">Schreiben... %1%</translation>
+        <translation>Schreiben... %1%</translation>
     </message>
     <message>
         <source>Verifying... %1%</source>
-        <translation type="unfinished">Verifizieren... %1%</translation>
+        <translation>Verifizieren... %1%</translation>
     </message>
     <message>
         <source>Write completed successfully!</source>
@@ -1269,7 +1269,7 @@
     </message>
     <message>
         <source>Storage device removed</source>
-        <translation type="unfinished"></translation>
+        <translation>Speichergerät entfernt</translation>
     </message>
     <message>
         <source>Continue</source>
@@ -1281,7 +1281,7 @@
     </message>
     <message>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Still work in progress due to the large changes in the v2-rc.

Also got some questions:

- Can the "storage device" be something else than a SD-card? Both terms seem to be used ATM in english. For example "DownloadExtractThread" uses SD-card in its error message while a lot of places talk about the "storage" or "storage device". 

- Is there a way of getting rid of unused translations in the ".ts" files? Or are all in there really used for v2?