### PR TITLE
 Fix: Add timeout protection for fsync/fdatasync on Linux

### DIFF
--- a/src/linux/file_operations_linux.h
+++ b/src/linux/file_operations_linux.h
@@ -54,8 +54,11 @@ class LinuxFileOperations : public FileOperations {
   int fd_;
   std::string current_path_;
   int last_error_code_;
-  
+
   FileError OpenInternal(const char* path, int flags, mode_t mode = 0);
+
+  // Timeout-protected sync helper
+  FileError SyncWithTimeout(bool use_fsync);
 };
 
 } // namespace rpi_imager


### PR DESCRIPTION
Prevents the '99% hang' issue where the kernel accumulates gigabytes of dirty pages, causing the final fsync() to stall for minutes on slow media.

- Add posix_fadvise(..., POSIX_FADV_DONTNEED) to WriteSequential
- Hints kernel to flush data immediately and free page cache
- Distributes I/O load throughout the write process instead of one massive blocking sync
- Maintains full data integrity (no timeouts)

Fixes #480 