### PR TITLE
Increase number of spaces written out in _clearLine

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -307,7 +307,7 @@ void Cli::_clearLine()
 {
     /* Properly clearing line requires platform specific code.
        Just write some spaces for now, and return to beginning of line. */
-    std::cerr << "                                          \r";
+    std::cerr << "                                                            \r";
 }
 
 void Cli::onError(QVariant msg)


### PR DESCRIPTION
Existing _clearLine function wasn't always overwriting previous contents.

Without this fix, the output from RPi Imager in CLI mode looks like:
```
Loading cache settings:
  Caching enabled: true
  Last file name: ""
  Uncompressed hash (extract_sha256): "(empty)"
  Compressed hash (image_download_sha256): "(empty)"
CacheManager initialized with background thread
Starting background cache operations
Starting background drive list polling
Background: Checking disk space for cache operations
Write successful.                         ..
```
There's an extra `..` at the end of the last line, because `_clearLine` wasn't printing enough spaces to overwrite all of `Zero'ing out first and last MB of drive...` https://github.com/raspberrypi/rpi-imager/blob/main/src/downloadthread.cpp#L446
And this is a translatable string, so it might be even longer in other languages, so I padded out `_clearLine` with a whole bunch of extra spaces.