### PR TITLE
Modify _clearLine to use an ANSI escape

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -305,9 +305,8 @@ void Cli::onSuccess()
 
 void Cli::_clearLine()
 {
-    /* Properly clearing line requires platform specific code.
-       Just write some spaces for now, and return to beginning of line. */
-    std::cerr << "                                          \r";
+    // ANSI "Erase in Line" escape sequence
+    std::cerr << "\e[0K";
 }
 
 void Cli::onError(QVariant msg)


### PR DESCRIPTION
...instead of just printing an arbitrary number of spaces!

See #1399 for a description of the problem. This is a better way of fixing that.