### PR TITLE
Fix display of customRepoHost

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -45,7 +45,7 @@ ApplicationWindow {
         }
 
         if (customRepoHost.length > 0) {
-            baseTitle += qsTr(" — Using data from %2").arg(imageWriter.constantVersion()).arg(customRepoHost)
+            baseTitle += " — " + qsTr("Using data from %1").arg(customRepoHost)
         }
 
         return baseTitle


### PR DESCRIPTION
This fixes the `QString::arg: Argument missing:  — Using data from v2.0.2-88-g24fd876e, os_list_local.json` warning that I was getting in the terminal.