### PR TITLE
Fix error message displayed when CLI build is run without sudo

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -83,7 +83,11 @@ int Cli::run()
         
         std::cerr << "ERROR: Not running as root." << std::endl;
         std::cerr << commonMsg << std::endl;
-        std::cerr << "Please run with sudo: sudo " << execName.toStdString() << " --cli ..." << std::endl;
+        std::cerr << "Please run with sudo: sudo " << execName.toStdString()
+#ifndef CLI_ONLY_BUILD
+        << " --cli"
+#endif
+        << " ..." << std::endl;
 #elif defined(Q_OS_WIN)
         std::cerr << "ERROR: Not running as Administrator." << std::endl;
         std::cerr << commonMsg << std::endl;


### PR DESCRIPTION
...to not display the --cli flag (which the CLI build doesn't need / support)