### PR TITLE
(i18n) Updated Irish translations (~556 strings for v2.0.3)

### DIFF
--- a/src/i18n/rpi-imager_ga.ts
+++ b/src/i18n/rpi-imager_ga.ts
@@ -2,6 +2,423 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ga">
 <context>
+    <name>AppOptionsDialog</name>
+    <message>
+        <source>App Options</source>
+        <translation>Roghanna Aipe</translation>
+    </message>
+    <message>
+        <source>Play sound when finished</source>
+        <translation>Seinn fuaim nuair a bheidh sé críochnaithe</translation>
+    </message>
+    <message>
+        <source>Eject media when finished</source>
+        <translation>Díbirt na meáin nuair a bheidh siad críochnaithe</translation>
+    </message>
+    <message>
+        <source>Enable anonymous statistics (telemetry)</source>
+        <translation>Cumasaigh staitisticí gan ainm (teileiméadracht)</translation>
+    </message>
+    <message>
+        <source>What is this?</source>
+        <translation>Cad é seo?</translation>
+    </message>
+    <message>
+        <source>Disable warnings</source>
+        <translation>Díchumasaigh rabhaidh</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Sábháil</translation>
+    </message>
+    <message>
+        <source>Disable warnings?</source>
+        <translation>Díchumasaigh rabhaidh?</translation>
+    </message>
+    <message>
+        <source>If you disable warnings, Raspberry Pi Imager will &lt;b&gt;not show confirmation prompts before writing images&lt;/b&gt;. You will still be required to &lt;b&gt;type the exact name&lt;/b&gt; when selecting a system drive.</source>
+        <translation>Mura ndéanann tú rabhaidh a dhíchumasú, &lt;b&gt;ní thaispeánfaidh Raspberry Pi Imager leideanna deimhnithe sula scríobhfar íomhánna&lt;/b&gt;. Beidh ort fós &lt;b&gt;an t-ainm cruinn a chlóscríobh&lt;/b&gt; agus tiomántán córais á roghnú agat.</translation>
+    </message>
+    <message>
+        <source>Content Repository</source>
+        <translation>Stór Ábhair</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Eagar</translation>
+    </message>
+    <message>
+        <source>Close the options dialog without saving any changes</source>
+        <translation>Dún an dialóg roghanna gan aon athruithe a shábháil</translation>
+    </message>
+    <message>
+        <source>Save the selected options and apply them to Raspberry Pi Imager</source>
+        <translation>Sábháil na roghanna roghnaithe agus cuir i bhfeidhm iad ar Raspberry Pi Imager</translation>
+    </message>
+    <message>
+        <source>Keep warnings enabled and return to the options dialog</source>
+        <translation>Coinnigh rabhaidh cumasaithe agus fill ar an dialóg roghanna</translation>
+    </message>
+    <message>
+        <source>Disable confirmation prompts before writing images, requiring only exact name entry for system drives</source>
+        <translation>Díchumasaigh leideanna deimhnithe sula scríobhtar íomhánna, agus ní gá ach ainm cruinn a iontráil do thiomántáin chórais</translation>
+    </message>
+    <message>
+        <source>Play an audio notification when the image write process completes</source>
+        <translation>Seinn fógra fuaime nuair a bheidh an próiseas scríofa íomhá críochnaithe</translation>
+    </message>
+    <message>
+        <source>Automatically eject the storage device when the write process completes successfully</source>
+        <translation>Díbirt an gléas stórála go huathoibríoch nuair a bheidh an próiseas scríbhneoireachta críochnaithe go rathúil</translation>
+    </message>
+    <message>
+        <source>Send anonymous usage statistics to help improve Raspberry Pi Imager</source>
+        <translation>Seol staitisticí úsáide gan ainm chun cabhrú le Raspberry Pi Imager a fheabhsú</translation>
+    </message>
+    <message>
+        <source>Skip confirmation dialogs before writing images (advanced users only)</source>
+        <translation>Seachain dialóga deimhnithe sula scríobhtar íomhánna (d'úsáideoirí ardleibhéil amháin)</translation>
+    </message>
+    <message>
+        <source>Change the source of operating system images between official Raspberry Pi repository and custom sources</source>
+        <translation>Athraigh foinse íomhánna an chórais oibriúcháin idir stór oifigiúil Raspberry Pi agus foinsí saincheaptha</translation>
+    </message>
+    <message>
+        <source>Secure Boot RSA Key</source>
+        <translation>Eochair RSA Tosaithe Slán</translation>
+    </message>
+    <message>
+        <source>Change</source>
+        <translation>Athraigh</translation>
+    </message>
+    <message>
+        <source>Select</source>
+        <translation>Roghnaigh</translation>
+    </message>
+    <message>
+        <source>Select an RSA 2048-bit private key for signing boot images in secure boot mode</source>
+        <translation>Roghnaigh eochair phríobháideach RSA 2048-giotán chun íomhánna tosaithe a shíniú i mód tosaithe slán</translation>
+    </message>
+    <message>
+        <source>Select RSA Private Key</source>
+        <translation>Roghnaigh Eochair Phríobháideach RSA</translation>
+    </message>
+    <message>
+        <source>PEM Files (*.pem);;All Files (*)</source>
+        <translation>Comhaid PEM (*.pem);;Gach Comhad (*)</translation>
+    </message>
+    <message>
+        <source>PEM Files (*.pem)</source>
+        <translation>Comhaid PEM (*.pem)</translation>
+    </message>
+    <message>
+        <source>All Files (*)</source>
+        <translation>Gach Comhad (*)</translation>
+    </message>
+</context>
+<context>
+    <name>AsyncCacheWriter</name>
+    <message>
+        <source>Cache write error: %1</source>
+        <translation>Earráid scríbhneoireachta taisce: %1</translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>Only proceed if you fully understand the risks.</source>
+        <translation>Ná lean ar aghaidh ach amháin má thuigeann tú na rioscaí go hiomlán.</translation>
+    </message>
+    <message>
+        <source>Selecting the wrong drive will permanently erase data and can render your computer inoperable.</source>
+        <translation>Scriosfaidh an tiomántán mícheart sonraí go buan agus d’fhéadfadh sé go mbeadh do ríomhaire neamhoibríoch.</translation>
+    </message>
+    <message>
+        <source>System drives typically contain files essential to the operation of your computer, and may include your personal files (photos, videos, documents).</source>
+        <translation>De ghnáth bíonn comhaid atá riachtanach d’oibriú do ríomhaire i dtiomántáin chórais, agus d’fhéadfadh do chuid comhad pearsanta (grianghraif, físeáin, doiciméid) a bheith iontu.</translation>
+    </message>
+    <message>
+        <source>All files (*)</source>
+        <translation>Gach comhad (*)</translation>
+    </message>
+    <message>
+        <source>Image files (%1)</source>
+        <translation>Comhaid íomhá (%1)</translation>
+    </message>
+    <message>
+        <source>Imager Repository Files (*.json)</source>
+        <translation>Imager Repository Files (*.json)</translation>
+    </message>
+    <message>
+        <source>Public Key files (*.pub)</source>
+        <translation>Comhaid Eochrach Phoiblí (*.pub)</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cealaigh</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>Tá</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation>Níl</translation>
+    </message>
+    <message>
+        <source>Browse</source>
+        <translation>Brabhsáil</translation>
+    </message>
+    <message>
+        <source>Continue</source>
+        <translation>Lean ar aghaidh</translation>
+    </message>
+    <message>
+        <source>Back</source>
+        <translation>Ar ais</translation>
+    </message>
+    <message>
+        <source>Finish</source>
+        <translation>Críochnaigh</translation>
+    </message>
+    <message>
+        <source>Select image</source>
+        <translation>Roghnaigh íomhá</translation>
+    </message>
+    <message>
+        <source>Password:</source>
+        <translation>Pasfhocal:</translation>
+    </message>
+    <message>
+        <source>Device:</source>
+        <translation>Gléas:</translation>
+    </message>
+    <message>
+        <source>Storage:</source>
+        <translation>Stóráil:</translation>
+    </message>
+    <message>
+        <source>No device selected</source>
+        <translation>Níl aon ghléas roghnaithe</translation>
+    </message>
+    <message>
+        <source>No image selected</source>
+        <translation>Níl aon íomhá roghnaithe</translation>
+    </message>
+    <message>
+        <source>No storage selected</source>
+        <translation>Níl aon stóráil roghnaithe</translation>
+    </message>
+    <message>
+        <source>Hostname configured</source>
+        <translation>Ainm óstach cumraithe</translation>
+    </message>
+    <message>
+        <source>User account configured</source>
+        <translation>Cumraíocht cuntas úsáideora</translation>
+    </message>
+    <message>
+        <source>SSH enabled</source>
+        <translation>SSH cumasaithe</translation>
+    </message>
+    <message>
+        <source>Wi‑Fi configured</source>
+        <translation>Wi-Fi cumraithe</translation>
+    </message>
+    <message>
+        <source>Raspberry Pi Connect enabled</source>
+        <translation>Cumasaithe Ceangail Raspberry Pi</translation>
+    </message>
+    <message>
+        <source>I2C enabled</source>
+        <translation>I2C cumasaithe</translation>
+    </message>
+    <message>
+        <source>SPI enabled</source>
+        <translation>SPI cumasaithe</translation>
+    </message>
+    <message>
+        <source>USB Gadget mode enabled</source>
+        <translation>Mód Gléasanna USB cumasaithe</translation>
+    </message>
+    <message>
+        <source>1-Wire enabled</source>
+        <translation>Cumasaithe 1-Sreang</translation>
+    </message>
+    <message>
+        <source>Serial configured</source>
+        <translation>Cumraithe sraitheach</translation>
+    </message>
+    <message>
+        <source>Localisation configured</source>
+        <translation>Cumrú logánaithe</translation>
+    </message>
+    <message>
+        <source>Authorized keys files (authorized_keys)</source>
+        <translation>Comhaid eochracha údaraithe (authorized_keys)</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmSystemDriveDialog</name>
+    <message>
+        <source>Size: %1</source>
+        <translation>Méid: %1</translation>
+    </message>
+    <message>
+        <source>Mounted as: %1</source>
+        <translation>Suiteáilte mar: %1</translation>
+    </message>
+    <message>
+        <source>Not mounted</source>
+        <translation>Gan a bheith suiteáilte</translation>
+    </message>
+    <message>
+        <source>To continue, type the exact drive name below:</source>
+        <translation>Chun leanúint ar aghaidh, clóscríobh ainm cruinn an tiomántáin thíos:</translation>
+    </message>
+    <message>
+        <source>Type drive name exactly as shown above</source>
+        <translation>Clóscríobh ainm an tiomántáin díreach mar a thaispeántar thuas</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>CEALAIGH</translation>
+    </message>
+    <message>
+        <source>CONTINUE</source>
+        <translation>LEAN AR AGHAIDH</translation>
+    </message>
+    <message>
+        <source>Cancel operation and return to storage selection to choose a different device</source>
+        <translation>Cealaigh an oibríocht agus fill ar ais chuig an rogha stórála chun gléas eile a roghnú</translation>
+    </message>
+    <message>
+        <source>Proceed to write the image to this system drive after confirming the drive name</source>
+        <translation>Lean ar aghaidh ag scríobh an íomhá chuig an tiomántán córais seo tar éis duit ainm an tiomántáin a dheimhniú</translation>
+    </message>
+    <message>
+        <source>Drive information</source>
+        <translation>Faisnéis tiomána</translation>
+    </message>
+    <message>
+        <source>Drive name to type: %1</source>
+        <translation>Ainm an tiomántáin le clóscríobh: %1</translation>
+    </message>
+    <message>
+        <source>Drive name input. Type exactly: %1. %2</source>
+        <translation>Ionchur ainm tiomántáin. Clóscríobh go beacht: %1. %2</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmUnfilterDialog</name>
+    <message>
+        <source>By disabling system drive filtering, &lt;b&gt;system drives will be shown&lt;/b&gt; in the list.</source>
+        <translation>Trí scagadh tiomántán córais a dhíchumasú, &lt;b&gt;taispeánfar tiomántáin chórais&lt;/b&gt; sa liosta.</translation>
+    </message>
+    <message>
+        <source>KEEP FILTER ON</source>
+        <translation>COINNIGH AN SCAGAIRE AR SIÚL</translation>
+    </message>
+    <message>
+        <source>SHOW SYSTEM DRIVES</source>
+        <translation>TAISPEÁIN TIOMÁNTAÍ AN CHÓRAIS</translation>
+    </message>
+    <message>
+        <source>Keep system drives hidden to prevent accidental damage to your operating system</source>
+        <translation>Coinnigh tiomántáin chórais i bhfolach chun damáiste de thaisme do do chóras oibriúcháin a chosc</translation>
+    </message>
+    <message>
+        <source>Remove the safety filter and display system drives in the storage device list</source>
+        <translation>Bain an scagaire sábháilteachta agus taispeáin tiomántáin an chórais sa liosta gléasanna stórála</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceSelectionStep</name>
+    <message>
+        <source>Select your Raspberry Pi device</source>
+        <translation>Roghnaigh do ghléas Raspberry Pi</translation>
+    </message>
+    <message>
+        <source>Device selection list</source>
+        <translation>Liosta roghnúcháin gléasanna</translation>
+    </message>
+    <message>
+        <source>No devices</source>
+        <translation>Gan aon fheistí</translation>
+    </message>
+    <message>
+        <source>1 device</source>
+        <translation>1 gléas</translation>
+    </message>
+    <message>
+        <source>%1 devices</source>
+        <translation>%1 gléas</translation>
+    </message>
+    <message>
+        <source>Use arrow keys to navigate, Enter or Space to select</source>
+        <translation>Úsáid na heochracha saigheada chun nascleanúint a dhéanamh, Iontráil nó Spás chun roghnú</translation>
+    </message>
+</context>
+<context>
+    <name>DoneStep</name>
+    <message>
+        <source>Your choices:</source>
+        <translation>Do roghanna:</translation>
+    </message>
+    <message>
+        <source>The storage device was ejected automatically. You can now remove it safely.</source>
+        <translation>Díbríodh an gléas stórála go huathoibríoch. Is féidir leat é a bhaint go sábháilte anois.</translation>
+    </message>
+    <message>
+        <source>Please eject the storage device before removing it from your computer.</source>
+        <translation>Díbirt an gléas stórála sula mbaintear as do ríomhaire é.</translation>
+    </message>
+    <message>
+        <source>Write Another</source>
+        <translation>Scríobh Ceann Eile</translation>
+    </message>
+    <message>
+        <source>Write complete!</source>
+        <translation>Scríobh críochnaithe!</translation>
+    </message>
+    <message>
+        <source>Customisations applied:</source>
+        <translation>Saincheaptha curtha i bhfeidhm:</translation>
+    </message>
+    <message>
+        <source>Reboot</source>
+        <translation>Atosaigh</translation>
+    </message>
+    <message>
+        <source>Operating system:</source>
+        <translation>Córas oibriúcháin:</translation>
+    </message>
+    <message>
+        <source>Storage:</source>
+        <translation>Stóráil:</translation>
+    </message>
+    <message>
+        <source>Reboot the system to apply changes</source>
+        <translation>Atosaigh an córas chun na hathruithe a chur i bhfeidhm</translation>
+    </message>
+    <message>
+        <source>Close Raspberry Pi Imager and exit the application</source>
+        <translation>Dún Raspberry Pi Imager agus scoir an feidhmchlár</translation>
+    </message>
+    <message>
+        <source>Return to storage selection to write the same image to another storage device</source>
+        <translation>Fill ar ais chuig an rogha stórála chun an íomhá chéanna a scríobh chuig gléas stórála eile</translation>
+    </message>
+    <message>
+        <source>customization</source>
+        <translation>saincheapadh</translation>
+    </message>
+    <message>
+        <source>customizations</source>
+        <translation>saincheaptha</translation>
+    </message>
+</context>
+<context>
     <name>DownloadExtractThread</name>
     <message>
         <source>Error extracting archive: %1</source>
@@ -16,8 +433,8 @@
         <translation>Níor fheistiú an córas oibriúcháin an chuid FAT32</translation>
     </message>
     <message>
-        <source>Error changing to directory &apos;%1&apos;</source>
-        <translation>Earráid ag athrú go dtí an eolaire &apos;%1&apos;</translation>
+        <source>Error changing to directory '%1'</source>
+        <translation>Earráid ag athrú go dtí an eolaire '%1'</translation>
     </message>
     <message>
         <source>Error reading from storage.&lt;br&gt;SD card may be broken.</source>
@@ -31,56 +448,20 @@
 <context>
     <name>DownloadThread</name>
     <message>
-        <source>unmounting drive</source>
-        <translation>tiomántán a dhíshuiteáil</translation>
+        <source>Please verify if 'Raspberry Pi Imager' is allowed access to 'removable volumes' in privacy settings (under 'files and folders' or alternatively give it 'full disk access').</source>
+        <translation>Deimhnigh le do thoil an bhfuil cead ag 'Raspberry Pi Imager' rochtain a fháil ar 'imleabhair inbhainte' i socruithe príobháideachta (faoi 'comhaid agus fillteáin' nó tabhair 'rochtain iomlán ar dhiosca' dó.</translation>
     </message>
     <message>
-        <source>opening drive</source>
-        <translation>tiomáint oscailte</translation>
+        <source>Cannot open storage device '%1'.</source>
+        <translation>Ní féidir gléas stórála '%1' a oscailt.</translation>
     </message>
     <message>
-        <source>Error running diskpart: %1</source>
-        <translation>Earráid ag rith diskpart: %1</translation>
-    </message>
-    <message>
-        <source>Error removing existing partitions</source>
-        <translation>Earráid agus críochdheighiltí atá ann cheana á mbaint</translation>
-    </message>
-    <message>
-        <source>Authentication cancelled</source>
-        <translation>Cealaíodh an fíordheimhniú</translation>
-    </message>
-    <message>
-        <source>Error running authopen to gain access to disk device &apos;%1&apos;</source>
-        <translation>Earráid ag rith autoopen chun rochtain a fháil ar ghléas diosca &apos;%1&apos;</translation>
-    </message>
-    <message>
-        <source>Please verify if &apos;Raspberry Pi Imager&apos; is allowed access to &apos;removable volumes&apos; in privacy settings (under &apos;files and folders&apos; or alternatively give it &apos;full disk access&apos;).</source>
-        <translation>Deimhnigh le do thoil an bhfuil cead ag &apos;Raspberry Pi Imager&apos; rochtain a fháil ar &apos;imleabhair inbhainte&apos; i socruithe príobháideachta (faoi &apos;comhaid agus fillteáin&apos; nó tabhair &apos;rochtain iomlán ar dhiosca&apos; dó.</translation>
-    </message>
-    <message>
-        <source>Cannot open storage device &apos;%1&apos;.</source>
-        <translation>Ní féidir gléas stórála &apos;%1&apos; a oscailt.</translation>
-    </message>
-    <message>
-        <source>discarding existing data on drive</source>
-        <translation>sonraí atá ann cheana féin ar thiomántán a scriosadh</translation>
-    </message>
-    <message>
-        <source>zeroing out first and last MB of drive</source>
-        <translation>ag nialadh an chéad MB agus an MB deireanach den tiomántán</translation>
-    </message>
-    <message>
-        <source>Write error while zero&apos;ing out MBR</source>
+        <source>Write error while zero'ing out MBR</source>
         <translation>Earráid scríbhneoireachta agus MBR á nialáil</translation>
     </message>
     <message>
         <source>Write error while trying to zero out last part of card.&lt;br&gt;Card could be advertising wrong capacity (possible counterfeit).</source>
         <translation>Earráid scríbhneoireachta agus iarracht á déanamh an chuid dheireanach den chárta a bhaint amach.&lt;br&gt;D’fhéadfadh an cárta a bheith ag fógairt acmhainn mhícheart (góchumtha b’fhéidir).</translation>
-    </message>
-    <message>
-        <source>starting download</source>
-        <translation>ag tosú íoslódáil</translation>
     </message>
     <message>
         <source>Error downloading: %1</source>
@@ -89,10 +470,6 @@
     <message>
         <source>Access denied error while writing file to disk.</source>
         <translation>Earráid rochtana diúltaithe agus comhad á scríobh chuig diosca.</translation>
-    </message>
-    <message>
-        <source>Error writing file to disk</source>
-        <translation>Earráid ag scríobh comhaid chuig diosca</translation>
     </message>
     <message>
         <source>Error writing to storage (while flushing)</source>
@@ -115,10 +492,6 @@
         <translation>Theip ar fhíorú an scríbhneoireachta. Tá ábhar an chárta SD difriúil ón méid a scríobhadh air.</translation>
     </message>
     <message>
-        <source>Customizing image</source>
-        <translation>Íomhá á saincheapadh</translation>
-    </message>
-    <message>
         <source>Cached file is corrupt. SHA256 hash does not match expected value.&lt;br&gt;The cache file will be removed and the download will restart.</source>
         <translation>Tá an comhad taisceáilte truaillithe. Ní mheaitseálann an hais SHA256 an luach ionchais.&lt;br&gt;Bainfear an comhad taisce agus atosófar an íoslódáil.</translation>
     </message>
@@ -134,13 +507,173 @@
         <source>Controlled Folder Access seems to be enabled. Please add rpi-imager.exe to the list of allowed apps and try again.</source>
         <translation>Is cosúil go bhfuil Rochtain Rialaithe ar Fhillteáin cumasaithe. Cuir rpi-imager.exe leis an liosta aipeanna ceadaithe agus déan iarracht arís.</translation>
     </message>
+    <message>
+        <source>Error: Multiple partitions found on disk. Please ensure the disk is completely clean.</source>
+        <translation>Earráid: Fuarthas roinnt críochdheighiltí ar an diosca. Cinntigh go bhfuil an diosca glan go hiomlán.</translation>
+    </message>
+    <message>
+        <source>The disk may be write-protected or in use by another application. Please ensure the disk is not mounted and try again.</source>
+        <translation>B’fhéidir go bhfuil an diosca cosanta ó scríobh nó in úsáid ag feidhmchlár eile. Cinntigh nach bhfuil an diosca feistithe agus déan iarracht arís.</translation>
+    </message>
+    <message>
+        <source>Disk is full. Please use a larger storage device.</source>
+        <translation>Tá an diosca lán. Bain úsáid as gléas stórála níos mó le do thoil.</translation>
+    </message>
+    <message>
+        <source>The disk is write-protected. Please check if the disk has a physical write-protect switch or is read-only.</source>
+        <translation>Tá an diosca cosanta ó scríobh. Seiceáil le do thoil an bhfuil lasc fisiciúil cosanta scríbhneoireachta ar an diosca nó an bhfuil sé inléite amháin.</translation>
+    </message>
+    <message>
+        <source>Media error detected. The storage device may be damaged or counterfeit. Please try a different device.</source>
+        <translation>Braitheadh ​​earráid sna meáin. Seans go bhfuil an gléas stórála millte nó góchumtha. Bain triail as gléas eile.</translation>
+    </message>
+    <message>
+        <source>Invalid disk parameter. The storage device may not be properly recognized. Please try reconnecting the device.</source>
+        <translation>Paraiméadar diosca neamhbhailí. B’fhéidir nach n-aithnítear an gléas stórála i gceart. Déan iarracht an gléas a athcheangal.</translation>
+    </message>
+    <message>
+        <source>I/O device error. The storage device may have been disconnected or is malfunctioning.</source>
+        <translation>Earráid gléas ionchuir/aschur. B’fhéidir go bhfuil an gléas stórála dícheangailte nó go bhfuil sé ag mífheidhmiú.</translation>
+    </message>
+    <message>
+        <source>Error opening disk device '%1'</source>
+        <translation>Earráid ag oscailt gléas diosca '%1'</translation>
+    </message>
+    <message>
+        <source>Error getting device size</source>
+        <translation>Earráid ag fáil méid an ghléis</translation>
+    </message>
+    <message>
+        <source>Error writing to storage device. Please check if the device is writable, has sufficient space, and is not write-protected.</source>
+        <translation>Earráid ag scríobh chuig gléas stórála. Seiceáil le do thoil an bhfuil an gléas inscríofa, an bhfuil dóthain spáis ann, agus nach bhfuil sé cosanta ó scríobh.</translation>
+    </message>
+    <message>
+        <source>Unmounting drive...</source>
+        <translation>Tiomántán á dhíshuiteáil...</translation>
+    </message>
+    <message>
+        <source>Opening drive...</source>
+        <translation>Tiomántán á oscailt...</translation>
+    </message>
+    <message>
+        <source>Discarding existing data on drive...</source>
+        <translation>Ag fáil réidh le sonraí atá ar an tiomántán atá ann cheana féin...</translation>
+    </message>
+    <message>
+        <source>Zero'ing out first and last MB of drive...</source>
+        <translation>Ag baint an chéad MB agus an MB deireanach den tiomántán as an áireamh...</translation>
+    </message>
+    <message>
+        <source>Starting download...</source>
+        <translation>Ag tosú ag íoslódáil...</translation>
+    </message>
+    <message>
+        <source>Writing image...</source>
+        <translation>Íomhá á scríobh...</translation>
+    </message>
+    <message>
+        <source>Customising OS...</source>
+        <translation>Ag saincheapadh an chórais oibriúcháin...</translation>
+    </message>
+    <message>
+        <source>Cannot open storage device '%1'. Please run with elevated privileges (sudo).</source>
+        <translation>Ní féidir gléas stórála '%1' a oscailt. Rith le ceadanna ardaithe (sudo) le do thoil.</translation>
+    </message>
+    <message>
+        <source>Creating signed boot image...</source>
+        <translation>Íomhá tosaithe sínithe á chruthú...</translation>
+    </message>
+    <message>
+        <source>Failed to create secure boot files</source>
+        <translation>Theip ar chomhaid tosaithe slána a chruthú</translation>
+    </message>
+    <message>
+        <source>No RSA key configured for secure boot. Please select a key in App Options.</source>
+        <translation>Níl aon eochair RSA cumraithe le haghaidh tosaithe slán. Roghnaigh eochair i Roghanna na bhFeidhmchlár le do thoil.</translation>
+    </message>
+    <message>
+        <source>RSA key file not found: %1</source>
+        <translation>Comhad eochrach RSA gan aimsiú: %1</translation>
+    </message>
+    <message>
+        <source>Extracting boot partition files...</source>
+        <translation>Ag baint comhaid deighilte tosaithe...</translation>
+    </message>
+    <message>
+        <source>Failed to extract boot partition files</source>
+        <translation>Theip ar chomhaid an deighilte tosaithe a bhaint amach</translation>
+    </message>
+    <message>
+        <source>No boot files found to package</source>
+        <translation>Níor aimsíodh aon chomhaid tosaithe le pacáiste</translation>
+    </message>
+    <message>
+        <source>Failed to create temporary directory</source>
+        <translation>Theip ar chruthú eolaire sealadach</translation>
+    </message>
+    <message>
+        <source>Creating boot.img...</source>
+        <translation>Ag cruthú boot.img...</translation>
+    </message>
+    <message>
+        <source>Failed to create boot.img</source>
+        <translation>Theip ar chruthú boot.img</translation>
+    </message>
+    <message>
+        <source>Signing boot image...</source>
+        <translation>Íomhá tosaithe á síniú...</translation>
+    </message>
+    <message>
+        <source>Failed to generate boot.sig</source>
+        <translation>Theip ar boot.sig a ghiniúint</translation>
+    </message>
+    <message>
+        <source>Failed to read boot.img</source>
+        <translation>Theip ar boot.img a léamh</translation>
+    </message>
+    <message>
+        <source>Failed to read boot.sig</source>
+        <translation>Theip ar boot.sig a léamh</translation>
+    </message>
+    <message>
+        <source>Cleaning up boot partition...</source>
+        <translation>Ag glanadh an chuid tosaithe...</translation>
+    </message>
+    <message>
+        <source>Syncing deletions to disk...</source>
+        <translation>Ag sioncrónú scriostaí chuig diosca...</translation>
+    </message>
+    <message>
+        <source>Writing signed boot files...</source>
+        <translation>Ag scríobh comhaid tosaithe sínithe...</translation>
+    </message>
+    <message>
+        <source>Failed to write secure boot files: %1</source>
+        <translation>Theip ar chomhaid tosaithe slána a scríobh: %1</translation>
+    </message>
+    <message>
+        <source>Unmounting volumes...</source>
+        <translation>Ag díghléasadh imleabhair...</translation>
+    </message>
+    <message>
+        <source>Cleaning disk...</source>
+        <translation>Glanadh diosca...</translation>
+    </message>
+    <message>
+        <source>Cleaning disk (legacy method)...</source>
+        <translation>Diosca a ghlanadh (modh oidhreachta)...</translation>
+    </message>
+    <message>
+        <source>Writing customization files...</source>
+        <translation>Comhaid saincheaptha á scríobh...</translation>
+    </message>
+    <message>
+        <source>Failed to allocate buffer for MBR zeroing</source>
+        <translation>Theip ar mhaolán a leithdháileadh le haghaidh nialúcháin MBR</translation>
+    </message>
 </context>
 <context>
     <name>DriveFormatThread</name>
-    <message>
-        <source>Error formatting (through udisks2)</source>
-        <translation>Earráid ag formáidiú (trí udisks2)</translation>
-    </message>
     <message>
         <source>Error opening device for formatting</source>
         <translation>Earráid ag oscailt an ghléis le haghaidh formáidithe</translation>
@@ -166,47 +699,20 @@
         <translation>Earráid formáidithe anaithnid</translation>
     </message>
     <message>
-        <source>Cannot format device: insufficient permissions and udisks2 not available</source>
-        <translation>Ní féidir an gléas a fhormáidiú: ceadanna neamhleor agus níl udisks2 ar fáil</translation>
-    </message>
-</context>
-<context>
-    <name>DstPopup</name>
-    <message>
-        <source>Storage</source>
-        <translation>Stóráil</translation>
+        <source>Preparing disk for formatting...</source>
+        <translation>Diosca á ullmhú le haghaidh formáidithe...</translation>
     </message>
     <message>
-        <source>No storage devices found</source>
-        <translation>Níor aimsíodh aon fheistí stórála</translation>
+        <source>Cleaning disk...</source>
+        <translation>Glanadh diosca...</translation>
     </message>
     <message>
-        <source>Exclude System Drives</source>
-        <translation>Eisiamh Tiomántáin an Chórais</translation>
+        <source>Writing filesystem...</source>
+        <translation>Córas comhad á scríobh...</translation>
     </message>
     <message>
-        <source>gigabytes</source>
-        <translation>gigibheart</translation>
-    </message>
-    <message>
-        <source>Mounted as %1</source>
-        <translation>Suiteáilte mar %1</translation>
-    </message>
-    <message>
-        <source>GB</source>
-        <translation>GB</translation>
-    </message>
-    <message>
-        <source>[WRITE PROTECTED]</source>
-        <translation>[COSANT Ó SCRÍOBH]</translation>
-    </message>
-    <message>
-        <source>SYSTEM</source>
-        <translation>CÓRAS</translation>
-    </message>
-    <message>
-        <source>SD card is write protected.&lt;br&gt;Push the lock switch on the left side of the card upwards, and try again.</source>
-        <translation>Tá an cárta SD cosanta ó scríobh.&lt;br&gt;Brúigh an lasc glasála ar thaobh clé an chárta suas, agus déan iarracht arís.</translation>
+        <source>Cannot format device: insufficient permissions. Please run with elevated privileges (sudo).</source>
+        <translation>Ní féidir an gléas a fhormáidiú: ceadanna neamhleor. Rith le ceadanna ardaithe (sudo) le do thoil.</translation>
     </message>
 </context>
 <context>
@@ -217,56 +723,443 @@
     </message>
 </context>
 <context>
-    <name>HwPopup</name>
+    <name>HostnameCustomizationStep</name>
     <message>
-        <source>Raspberry Pi Device</source>
-        <translation>Gléas Raspberry Pi</translation>
+        <source>A hostname is a unique name that identifies your Raspberry Pi on the network. It should contain only letters, numbers, and hyphens.</source>
+        <translation>Is ainm uathúil é ainm óstach a shainaithníonn do Raspberry Pi ar an líonra. Níor cheart go mbeadh ann ach litreacha, uimhreacha agus fleiscíní.</translation>
+    </message>
+    <message>
+        <source>Customisation: Choose hostname</source>
+        <translation>Saincheapadh: Roghnaigh ainm óstach</translation>
+    </message>
+    <message>
+        <source>Enter your hostname</source>
+        <translation>Cuir isteach d'ainm óstach</translation>
+    </message>
+    <message>
+        <source>Save hostname and continue to next customisation step</source>
+        <translation>Sábháil ainm an óstaigh agus lean ar aghaidh go dtí an chéad chéim saincheaptha eile</translation>
+    </message>
+    <message>
+        <source>Return to previous step</source>
+        <translation>Fill ar ais go dtí an chéim roimhe seo</translation>
+    </message>
+    <message>
+        <source>Skip all customisation and proceed directly to writing the image</source>
+        <translation>Seachain an saincheapadh go léir agus téigh ar aghaidh go díreach chuig scríobh na híomhá</translation>
+    </message>
+</context>
+<context>
+    <name>IfAndFeaturesCustomizationStep</name>
+    <message>
+        <source>Enable hardware interfaces and connectivity options.</source>
+        <translation>Cumasaigh comhéadain crua-earraí agus roghanna nascachta.</translation>
+    </message>
+    <message>
+        <source>Interfaces</source>
+        <translation>Comhéadain</translation>
+    </message>
+    <message>
+        <source>Enable SPI</source>
+        <translation>Cumasaigh SPI</translation>
+    </message>
+    <message>
+        <source>Enable Serial:</source>
+        <translation>Cumasaigh Sraitheach:</translation>
+    </message>
+    <message>
+        <source>Features</source>
+        <translation>Gnéithe</translation>
+    </message>
+    <message>
+        <source>Enable USB Gadget Mode</source>
+        <translation>Enable USB Gadget Mode</translation>
+    </message>
+    <message>
+        <source>Learn more about USB Gadget Mode</source>
+        <translation>Foghlaim tuilleadh faoi Mhód Gléasanna USB</translation>
+    </message>
+    <message>
+        <source>Console</source>
+        <translation>Consól</translation>
+    </message>
+    <message>
+        <source>USB Gadget Mode can change how your device behaves and may impact connectivity and host interaction.</source>
+        <translation>Is féidir le Mód Gléas USB athrú a dhéanamh ar iompar do ghléis agus d’fhéadfadh tionchar a bheith aige ar nascacht agus ar idirghníomhaíocht an óstach.</translation>
+    </message>
+    <message>
+        <source>Please review the &lt;a href='%1'&gt;documentation&lt;/a&gt; before proceeding.</source>
+        <translation>Léigh an &lt;a href='%1'&gt;doiciméadú&lt;/a&gt; le do thoil sula leanann tú ar aghaidh.</translation>
+    </message>
+    <message>
+        <source>Only continue if you are sure you know what you are doing.</source>
+        <translation>Ná lean ar aghaidh ach amháin má tá tú cinnte go bhfuil a fhios agat cad atá á dhéanamh agat.</translation>
+    </message>
+    <message>
+        <source>I understand, continue</source>
+        <translation>Tuigim, lean ar aghaidh</translation>
+    </message>
+    <message>
+        <source>Customisation: Interfaces &amp; Features</source>
+        <translation>Saincheapadh: Comhéadain &amp; Gnéithe</translation>
+    </message>
+    <message>
+        <source>Enable I2C</source>
+        <translation>Cumasaigh I2C</translation>
+    </message>
+    <message>
+        <source>Enable 1-Wire</source>
+        <translation>Cumasaigh 1-Sreang</translation>
+    </message>
+    <message>
+        <source>Enable the I2C (Inter-Integrated Circuit) interface for connecting sensors and other low-speed peripherals</source>
+        <translation>Cumasaigh an comhéadan I2C (Ciorcad Idir-Chomhtháite) chun braiteoirí agus forimeallaigh eile ísealluais a nascadh</translation>
+    </message>
+    <message>
+        <source>Enable the SPI (Serial Peripheral Interface) for high-speed communication with displays and sensors</source>
+        <translation>Cumasaigh an SPI (Comhéadan Forimeallach Sraitheach) le haghaidh cumarsáide ardluais le taispeántais agus braiteoirí</translation>
+    </message>
+    <message>
+        <source>Enable the 1-Wire interface for connecting temperature sensors and other Dallas/Maxim devices</source>
+        <translation>Cumasaigh an comhéadan 1-Wire chun braiteoirí teochta agus gléasanna Dallas/Maxim eile a nascadh</translation>
+    </message>
+    <message>
+        <source>Enable USB device mode to use your Raspberry Pi as a USB peripheral for networking and storage</source>
+        <translation>Cumasaigh mód gléas USB chun do Raspberry Pi a úsáid mar imeallach USB le haghaidh líonrú agus stórála</translation>
+    </message>
+    <message>
+        <source>Save interface and feature settings and continue to writing step</source>
+        <translation>Sábháil socruithe comhéadain agus gnéithe agus lean ar aghaidh leis an gcéim scríbhneoireachta</translation>
+    </message>
+    <message>
+        <source>Return to previous step</source>
+        <translation>Fill ar ais go dtí an chéim roimhe seo</translation>
+    </message>
+    <message>
+        <source>Skip all customisation and proceed directly to writing the image</source>
+        <translation>Seachain an saincheapadh go léir agus téigh ar aghaidh go díreach chuig scríobh na híomhá</translation>
+    </message>
+    <message>
+        <source>Configure the serial interface: Disabled, Default (system decides), Console &amp; Hardware (both console and UART), Hardware (UART only), or Console (console only on supported devices).</source>
+        <translation>Cumraigh an comhéadan sraitheach: Díchumasaithe, Réamhshocraithe (cinneann an córas), Consól &amp; Crua-earraí (consól agus UART araon), Crua-earraí (UART amháin), nó Consól (consól ar ghléasanna tacaithe amháin).</translation>
+    </message>
+    <message>
+        <source>USB Gadget Mode Warning</source>
+        <translation>Rabhadh maidir le Mód Gléasanna USB</translation>
+    </message>
+    <message>
+        <source>Please review the documentation before proceeding.</source>
+        <translation>Athbhreithnigh an doiciméadacht le do thoil sula leanann tú ar aghaidh.</translation>
+    </message>
+    <message>
+        <source>Cancel and return to the interfaces and features settings without enabling USB Gadget Mode</source>
+        <translation>Cealaigh agus fill ar ais chuig na socruithe comhéadain agus gnéithe gan Mód Gléas USB a chumasú</translation>
+    </message>
+    <message>
+        <source>Confirm that you understand the risks and continue with USB Gadget Mode enabled</source>
+        <translation>Deimhnigh go dtuigeann tú na rioscaí agus lean ar aghaidh le Mód Gléasanna USB cumasaithe</translation>
+    </message>
+    <message>
+        <source>This button will be enabled after 2 seconds</source>
+        <translation>Cuirfear an cnaipe seo ar siúl tar éis 2 shoicind</translation>
+    </message>
+</context>
+<context>
+    <name>ImComboBox</name>
+    <message>
+        <source>Type to search: "%1"</source>
+        <translation>Clóscríobh le cuardach: "%1"</translation>
+    </message>
+    <message>
+        <source>(press again to cycle)</source>
+        <translation>(brúigh arís chun rothlú)</translation>
+    </message>
+</context>
+<context>
+    <name>ImFileDialog</name>
+    <message>
+        <source>Select File</source>
+        <translation>Roghnaigh Comhad</translation>
+    </message>
+    <message>
+        <source>Enter path or URL…</source>
+        <translation>Cuir isteach cosán nó URL…</translation>
+    </message>
+    <message>
+        <source>Folders</source>
+        <translation>Fillteáin</translation>
+    </message>
+    <message>
+        <source>Open</source>
+        <translation>Oscail</translation>
+    </message>
+    <message>
+        <source>Removable drives</source>
+        <translation>Tiomántáin inbhainte</translation>
+    </message>
+    <message>
+        <source>Go up a folder</source>
+        <translation>Téigh suas fillteán</translation>
+    </message>
+    <message>
+        <source>No files in this folder</source>
+        <translation>Níl aon chomhaid sa bhfillteán seo</translation>
+    </message>
+    <message>
+        <source>Folder: %1</source>
+        <translation>Fillteán: %1</translation>
+    </message>
+    <message>
+        <source>File: %1</source>
+        <translation>Comhad: %1</translation>
+    </message>
+    <message>
+        <source>Documents</source>
+        <translation>Doiciméid</translation>
+    </message>
+    <message>
+        <source>Downloads</source>
+        <translation>Íoslódálacha</translation>
+    </message>
+    <message>
+        <source>Home</source>
+        <translation>Baile</translation>
+    </message>
+    <message>
+        <source>File name:</source>
+        <translation>Ainm comhaid:</translation>
+    </message>
+    <message>
+        <source>Enter filename…</source>
+        <translation>Cuir isteach ainm comhaid…</translation>
+    </message>
+    <message>
+        <source>Navigate to a folder using the panel on the left,
+or type a path in the address bar above.</source>
+        <translation>Téigh chuig fillteán ag baint úsáide as an bpainéal ar chlé, 
+nó clóscríobh cosán sa bharra seoltaí thuas.</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>Sábháil</translation>
+    </message>
+</context>
+<context>
+    <name>ImOptionButton</name>
+    <message>
+        <source>Opens in browser</source>
+        <translation>Osclaítear sa bhrabhsálaí</translation>
+    </message>
+</context>
+<context>
+    <name>ImOptionPill</name>
+    <message>
+        <source>Opens in browser</source>
+        <translation>Osclaítear sa bhrabhsálaí</translation>
+    </message>
+</context>
+<context>
+    <name>ImPasswordField</name>
+    <message>
+        <source>Password is visible. Press F2 to hide.</source>
+        <translation>Tá an focal faire le feiceáil. Brúigh F2 le cur i bhfolach.</translation>
+    </message>
+    <message>
+        <source>Password is hidden. Press F2 to show.</source>
+        <translation>Tá an focal faire i bhfolach. Brúigh F2 le taispeáint.</translation>
+    </message>
+    <message>
+        <source>Hide password</source>
+        <translation>Folaigh an focal faire</translation>
+    </message>
+    <message>
+        <source>Show password</source>
+        <translation>Taispeáin an focal faire</translation>
+    </message>
+    <message>
+        <source>Password is currently visible. Activate to hide it.</source>
+        <translation>Tá an focal faire le feiceáil faoi láthair. Gníomhachtaigh chun é a cheilt.</translation>
+    </message>
+    <message>
+        <source>Password is currently hidden. Activate to show it.</source>
+        <translation>Tá an focal faire i bhfolach faoi láthair. Gníomhachtaigh chun é a thaispeáint.</translation>
+    </message>
+</context>
+<context>
+    <name>ImPopup</name>
+    <message>
+        <source>Dialog</source>
+        <translation>Dialóg</translation>
+    </message>
+</context>
+<context>
+    <name>ImSaveFileDialog</name>
+    <message>
+        <source>Save File</source>
+        <translation>Sábháil Comhad</translation>
+    </message>
+</context>
+<context>
+    <name>ImTextField</name>
+    <message>
+        <source>Cut</source>
+        <translation>Gearr</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation>Cóipeáil</translation>
+    </message>
+    <message>
+        <source>Paste</source>
+        <translation>Greamaigh</translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation>Roghnaigh Uile</translation>
     </message>
 </context>
 <context>
     <name>ImageWriter</name>
     <message>
-        <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1 GB.</source>
-        <translation>Níl an cumas stórála mór go leor.&lt;br&gt;Ní mór dó a bheith %1 GB ar a laghad.</translation>
-    </message>
-    <message>
         <source>Input file is not a valid disk image.&lt;br&gt;File size %1 bytes is not a multiple of 512 bytes.</source>
         <translation>Ní íomhá diosca bailí é an comhad ionchuir.&lt;br&gt;Ní iolraí de 512 beart é méid an chomhaid %1 beart.</translation>
-    </message>
-    <message>
-        <source>Downloading and writing image</source>
-        <translation>Íomhá á íoslódáil agus á scríobh</translation>
     </message>
     <message>
         <source>Select image</source>
         <translation>Roghnaigh íomhá</translation>
     </message>
     <message>
-        <source>Error synchronizing time. Trying again in 3 seconds</source>
-        <translation>Earráid ag sioncrónú an ama. Ag iarraidh arís i gceann 3 soicind</translation>
-    </message>
-    <message>
         <source>STP is enabled on your Ethernet switch. Getting IP will take long time.</source>
         <translation>Tá STP cumasaithe ar do lasc Ethernet. Tógfaidh sé tamall fada IP a fháil.</translation>
     </message>
     <message>
-        <source>Would you like to prefill the wifi password from the system keychain?</source>
-        <translation>Ar mhaith leat an focal faire wifi a réamh-líonadh ón eochairchód córais?</translation>
+        <source>Storage capacity is not large enough.&lt;br&gt;Needs to be at least %1.</source>
+        <translation>Níl an cumas stórála mór go leor.&lt;br&gt;Ní mór dó a bheith %1 ar a laghad.</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation>B</translation>
+    </message>
+    <message>
+        <source>TB</source>
+        <translation>TB</translation>
+    </message>
+    <message>
+        <source>GB</source>
+        <translation>GB</translation>
+    </message>
+    <message>
+        <source>MB</source>
+        <translation>MB</translation>
+    </message>
+    <message>
+        <source>KB</source>
+        <translation>KB</translation>
+    </message>
+    <message>
+        <source>%1 %2</source>
+        <translation>%1 %2</translation>
+    </message>
+    <message>
+        <source>%1.%2 %3</source>
+        <translation>%1.%2 %3</translation>
+    </message>
+    <message>
+        <source>Unknown precondition failure.</source>
+        <translation>Teip réamhchoinníoll anaithnid.</translation>
+    </message>
+    <message>
+        <source>Cannot start write. %1</source>
+        <translation>Ní féidir tosú ag scríobh. %1</translation>
+    </message>
+    <message>
+        <source>Source file not found: %1</source>
+        <translation>Níor aimsíodh an comhad foinse: %1</translation>
+    </message>
+    <message>
+        <source>Source is not a regular file: %1</source>
+        <translation>Ní comhad rialta é an fhoinse: %1</translation>
+    </message>
+    <message>
+        <source>Source file is not readable: %1</source>
+        <translation>Ní féidir an comhad foinse a léamh: %1</translation>
+    </message>
+    <message>
+        <source>image</source>
+        <translation>íomhá</translation>
+    </message>
+    <message>
+        <source>storage device</source>
+        <translation>gléas stórála</translation>
+    </message>
+    <message>
+        <source>valid storage device (device no longer available)</source>
+        <translation>gléas stórála bailí (níl an gléas ar fáil a thuilleadh)</translation>
+    </message>
+    <message>
+        <source>No %1 selected.</source>
+        <translation>Níl %1 roghnaithe.</translation>
+    </message>
+    <message>
+        <source> or </source>
+        <translation> nó </translation>
+    </message>
+    <message>
+        <source>Save Performance Data</source>
+        <translation>Sábháil Sonraí Feidhmíochta</translation>
+    </message>
+    <message>
+        <source>JSON files (*.json);;All files (*)</source>
+        <translation>Comhaid JSON (*.json);;Gach comhad (*)</translation>
+    </message>
+</context>
+<context>
+    <name>KeychainPermissionDialog</name>
+    <message>
+        <source>Keychain Access</source>
+        <translation>Rochtain Eochairshlabhra</translation>
+    </message>
+    <message>
+        <source>Would you like to prefill the Wi‑Fi password from the system keychain?</source>
+        <translation>Ar mhaith leat an focal faire Wi-Fi a réamh-líonadh ón eochairchód córais?</translation>
+    </message>
+    <message>
+        <source>This will require administrator authentication on macOS.</source>
+        <translation>Beidh fíordheimhniú riarthóra ag teastáil ar macOS chun seo a dhéanamh.</translation>
+    </message>
+    <message>
+        <source>Skip keychain access and manually enter the Wi-Fi password</source>
+        <translation>Seachain rochtain eochairshlabhra agus cuir isteach an focal faire Wi-Fi de láimh</translation>
+    </message>
+    <message>
+        <source>Retrieve the Wi-Fi password from the system keychain using administrator authentication</source>
+        <translation>Aisghabh an focal faire Wi-Fi ón eochairchócaire córais ag baint úsáide as fíordheimhniú riarthóra</translation>
+    </message>
+</context>
+<context>
+    <name>LanguageSelectionStep</name>
+    <message>
+        <source>Welcome</source>
+        <translation>Fáilte</translation>
+    </message>
+    <message>
+        <source>Language:</source>
+        <translation>Teanga:</translation>
+    </message>
+    <message>
+        <source>Choose your language for Raspberry Pi Imager</source>
+        <translation>Roghnaigh do theanga le haghaidh Raspberry Pi Imager</translation>
+    </message>
+    <message>
+        <source>Select the language for the Raspberry Pi Imager interface</source>
+        <translation>Roghnaigh an teanga don chomhéadan Raspberry Pi Imager</translation>
     </message>
 </context>
 <context>
     <name>LocalFileExtractThread</name>
     <message>
-        <source>opening image file</source>
-        <translation>comhad íomhá á oscailt</translation>
-    </message>
-    <message>
         <source>Error opening image file</source>
         <translation>Earráid ag oscailt comhad íomhá</translation>
-    </message>
-    <message>
-        <source>starting extraction</source>
-        <translation>ag tosú eastóscadh</translation>
     </message>
     <message>
         <source>Error reading from image file</source>
@@ -280,24 +1173,74 @@
         <source>Failed to read complete image file</source>
         <translation>Theip ar an gcomhad íomhá iomlán a léamh</translation>
     </message>
+    <message>
+        <source>Opening image file...</source>
+        <translation>Ag oscailt comhad íomhá...</translation>
+    </message>
+    <message>
+        <source>Starting extraction...</source>
+        <translation>Ag tosú eastóscadh...</translation>
+    </message>
 </context>
 <context>
-    <name>MsgPopup</name>
+    <name>LocaleCustomizationStep</name>
     <message>
-        <source>NO</source>
-        <translation>NÍL</translation>
+        <source>Keyboard layout:</source>
+        <translation>Leagan amach méarchláir:</translation>
     </message>
     <message>
-        <source>YES</source>
-        <translation>TÁ</translation>
+        <source>Time zone:</source>
+        <translation>Crios ama:</translation>
     </message>
     <message>
-        <source>CONTINUE</source>
-        <translation>LEAN AR AGHAIDH</translation>
+        <source>Customisation: Localisation</source>
+        <translation>Saincheapadh: Logánú</translation>
     </message>
     <message>
-        <source>QUIT</source>
-        <translation>SCOR</translation>
+        <source>Select your location for suggested time zone and keyboard layout</source>
+        <translation>Roghnaigh do shuíomh le haghaidh crios ama agus leagan amach méarchláir molta</translation>
+    </message>
+    <message>
+        <source>Capital city:</source>
+        <translation>Príomhchathair:</translation>
+    </message>
+    <message>
+        <source>Save localisation settings and continue to next customisation step</source>
+        <translation>Sábháil socruithe logánaithe agus lean ar aghaidh go dtí an chéad chéim saincheaptha eile</translation>
+    </message>
+    <message>
+        <source>Return to previous step</source>
+        <translation>Fill ar ais go dtí an chéim roimhe seo</translation>
+    </message>
+    <message>
+        <source>Skip all customisation and proceed directly to writing the image</source>
+        <translation>Seachain an saincheapadh go léir agus téigh ar aghaidh go díreach chuig scríobh na híomhá</translation>
+    </message>
+    <message>
+        <source>Choose your nearest capital city. This will automatically recommend the correct time zone and keyboard layout for your region, and set the wireless regulatory domain for your country's Wi-Fi regulations.</source>
+        <translation>Roghnaigh an phríomhchathair is gaire duit. Molfaidh sé seo go huathoibríoch an crios ama agus leagan amach an mhéarchláir cheart do do réigiún, agus socróidh sé an fearann ​​rialála gan sreang do rialacháin Wi-Fi do thíre.</translation>
+    </message>
+    <message>
+        <source>Choose your time zone so your Raspberry Pi displays the correct local time. This is automatically recommended based on your capital city selection, but you can change it if the suggestion is incorrect.</source>
+        <translation>Roghnaigh do chrios ama ionas go dtaispeánfaidh do Raspberry Pi an t-am áitiúil ceart. Moltar é seo go huathoibríoch bunaithe ar do rogha príomhchathrach, ach is féidir leat é a athrú mura bhfuil an moladh ceart.</translation>
+    </message>
+    <message>
+        <source>Choose your keyboard layout so keys produce the correct characters when typing. This is automatically recommended based on your capital city selection, but you can change it if you use a different keyboard layout.</source>
+        <translation>Roghnaigh leagan amach do mhéarchláir ionas go dtáirgfidh na heochracha na carachtair chearta agus tú ag clóscríobh. Moltar é seo go huathoibríoch bunaithe ar do rogha príomhchathair, ach is féidir leat é a athrú má úsáideann tú leagan amach méarchláir difriúil.</translation>
+    </message>
+</context>
+<context>
+    <name>MacFile</name>
+    <message>
+        <source>Raspberry Pi Imager needs to access the disk to write the image.</source>
+        <translation>Caithfidh Raspberry Pi Imager rochtain a fháil ar an diosca chun an íomhá a scríobh.</translation>
+    </message>
+</context>
+<context>
+    <name>NativeFileDialog</name>
+    <message>
+        <source>File type:</source>
+        <translation>Cineál comhaid:</translation>
     </message>
 </context>
 <context>
@@ -308,143 +1251,188 @@
     </message>
 </context>
 <context>
-    <name>OSPopup</name>
+    <name>OSSelectionStep</name>
     <message>
-        <source>Operating System</source>
-        <translation>Córas Oibriúcháin</translation>
-    </message>
-    <message>
-        <source>Back</source>
-        <translation>Ar ais</translation>
-    </message>
-    <message>
-        <source>Go back to main menu</source>
-        <translation>Téigh ar ais go dtí an príomh-roghchlár</translation>
-    </message>
-    <message>
-        <source>Released: %1</source>
-        <translation>Scaoilte: %1</translation>
+        <source>Local - %1</source>
+        <translation>Áitiúil - %1</translation>
     </message>
     <message>
         <source>Cached on your computer</source>
-        <translation>Taisceadh ar do ríomhaire</translation>
+        <translation>Taisceáilte ar do ríomhaire</translation>
     </message>
     <message>
         <source>Local file</source>
         <translation>Comhad áitiúil</translation>
     </message>
     <message>
-        <source>Online - %1 GB download</source>
-        <translation>Ar líne - íoslódáil %1 GB</translation>
+        <source>Online - %1 download</source>
+        <translation>Ar líne - íoslódáil %1</translation>
     </message>
     <message>
-        <source>Connect an USB stick containing images first.&lt;br&gt;The images must be located in the root folder of the USB stick.</source>
-        <translation>Ceangail bata USB ina bhfuil íomhánna ar dtús.&lt;br&gt;Ní mór na híomhánna a bheith suite i bhfillteán fréimhe an bhata USB.</translation>
+        <source>Go back to main menu</source>
+        <translation>Téigh ar ais go dtí an príomh-roghchlár</translation>
+    </message>
+    <message>
+        <source>Select image</source>
+        <translation>Roghnaigh íomhá</translation>
+    </message>
+    <message>
+        <source>Choose operating system</source>
+        <translation>Roghnaigh córas oibriúcháin</translation>
+    </message>
+    <message>
+        <source>Select an operating system to install on your Raspberry Pi</source>
+        <translation>Roghnaigh córas oibriúcháin le suiteáil ar do Raspberry Pi</translation>
+    </message>
+    <message>
+        <source>Operating system list</source>
+        <translation>Liosta córas oibriúcháin</translation>
+    </message>
+    <message>
+        <source>No operating systems</source>
+        <translation>No operating systems</translation>
+    </message>
+    <message>
+        <source>1 operating system</source>
+        <translation>1 chóras oibriúcháin</translation>
+    </message>
+    <message>
+        <source>%1 operating systems</source>
+        <translation>%1 córas oibriúcháin</translation>
+    </message>
+    <message>
+        <source>Use arrow keys to navigate, Enter or Space to select</source>
+        <translation>Úsáid na heochracha saigheada chun nascleanúint a dhéanamh, Iontráil nó Spás chun roghnú</translation>
+    </message>
+    <message>
+        <source>Operating system category</source>
+        <translation>Catagóir an chórais oibriúcháin</translation>
+    </message>
+    <message>
+        <source>Use arrow keys to navigate, Enter or Space to select, Left arrow to go back</source>
+        <translation>Úsáid na heochracha saigheada chun nascleanúint a dhéanamh, Iontráil nó Spás chun roghnú, Saighead chlé chun dul ar ais</translation>
+    </message>
+    <message>
+        <source>Released: %1</source>
+        <translation>Scaoilte: %1</translation>
     </message>
 </context>
 <context>
-    <name>OptionsGeneralTab</name>
+    <name>PiConnectCustomizationStep</name>
     <message>
-        <source>Set hostname:</source>
-        <translation>Socraigh ainm óstach:</translation>
+        <source>Customisation: Raspberry Pi Connect</source>
+        <translation>Saincheapadh: Ceangail Raspberry Pi</translation>
     </message>
     <message>
-        <source>Set username and password</source>
-        <translation>Socraigh ainm úsáideora agus pasfhocal</translation>
+        <source>Enable Raspberry Pi Connect</source>
+        <translation>Cumasaigh Ceangal Raspberry Pi</translation>
     </message>
     <message>
-        <source>Username:</source>
-        <translation>Ainm úsáideora:</translation>
+        <source>What is Raspberry Pi Connect?</source>
+        <translation>Cad é Ceangal Raspberry Pi?</translation>
     </message>
     <message>
-        <source>Password:</source>
-        <translation>Pasfhocal:</translation>
+        <source>Open Raspberry Pi Connect</source>
+        <translation>Oscail Raspberry Pi Connect</translation>
     </message>
     <message>
-        <source>Configure wireless LAN</source>
-        <translation>Cumraigh LAN gan sreang</translation>
+        <source>Token received from browser</source>
+        <translation>Fuarthas comhartha ón mbrabhsálaí</translation>
     </message>
     <message>
-        <source>SSID:</source>
-        <translation>SSID:</translation>
+        <source>Open the Raspberry Pi Connect website in your browser to sign in and receive an authentication token</source>
+        <translation>Oscail suíomh Gréasáin Raspberry Pi Connect i do bhrabhsálaí chun síniú isteach agus comhartha fíordheimhnithe a fháil</translation>
     </message>
     <message>
-        <source>Hidden SSID</source>
-        <translation>SSID i bhfolach</translation>
+        <source>Enable secure remote access to your Raspberry Pi through the Raspberry Pi Connect cloud service</source>
+        <translation>Cumasaigh rochtain iargúlta slán ar do Raspberry Pi tríd an tseirbhís scamall Raspberry Pi Connect</translation>
     </message>
     <message>
-        <source>Wireless LAN country:</source>
-        <translation>Tír LAN gan sreang:</translation>
+        <source>Save Raspberry Pi Connect settings and continue to next customisation step</source>
+        <translation>Sábháil socruithe Raspberry Pi Connect agus lean ar aghaidh go dtí an chéad chéim saincheaptha eile</translation>
     </message>
     <message>
-        <source>Set locale settings</source>
-        <translation>Socraigh socruithe logánta</translation>
+        <source>Return to previous step</source>
+        <translation>Fill ar ais go dtí an chéim roimhe seo</translation>
     </message>
     <message>
-        <source>Time zone:</source>
-        <translation>Crios ama:</translation>
+        <source>Skip all customisation and proceed directly to writing the image</source>
+        <translation>Seachain an saincheapadh go léir agus téigh ar aghaidh go díreach chuig scríobh na híomhá</translation>
     </message>
     <message>
-        <source>Keyboard layout:</source>
-        <translation>Leagan amach méarchláir:</translation>
-    </message>
-</context>
-<context>
-    <name>OptionsMiscTab</name>
-    <message>
-        <source>Play sound when finished</source>
-        <translation>Seinn fuaim nuair a bheidh sé críochnaithe</translation>
+        <source>Enter or paste the authentication token from Raspberry Pi Connect. The token will be automatically filled if you use the 'Open Raspberry Pi Connect' button to sign in.</source>
+        <translation>Cuir isteach nó greamaigh an comhartha fíordheimhnithe ó Raspberry Pi Connect. Líonfar an comhartha go huathoibríoch má úsáideann tú an cnaipe 'Oscail Raspberry Pi Connect' chun síniú isteach.</translation>
     </message>
     <message>
-        <source>Eject media when finished</source>
-        <translation>Díbirt na meáin nuair a bheidh siad críochnaithe</translation>
+        <source>Waiting for token (%1s)</source>
+        <translation>Ag fanacht leis an gcomhartha (%1s)</translation>
     </message>
     <message>
-        <source>Enable telemetry</source>
-        <translation>Cumasaigh teileiméadracht</translation>
-    </message>
-</context>
-<context>
-    <name>OptionsPopup</name>
-    <message>
-        <source>OS Customization</source>
-        <translation>Saincheapadh OS</translation>
+        <source>Paste token here</source>
+        <translation>Greamaigh an comhartha anseo</translation>
     </message>
     <message>
-        <source>General</source>
-        <translation>Ginearálta</translation>
+        <source>Invalid Token</source>
+        <translation>Comhartha Neamhbhailí</translation>
     </message>
     <message>
-        <source>Services</source>
-        <translation>Seirbhísí</translation>
+        <source>The token you entered is not valid. Please check the token and try again, or use the 'Open Raspberry Pi Connect' button to get a valid token.</source>
+        <translation>Níl an comhartha a chuir tú isteach bailí. Seiceáil an comhartha agus déan iarracht arís, nó bain úsáid as an gcnaipe 'Oscail Raspberry Pi Connect' chun comhartha bailí a fháil.</translation>
     </message>
     <message>
-        <source>Options</source>
-        <translation>Roghanna</translation>
+        <source>OK</source>
+        <translation>Ceart go leor</translation>
     </message>
     <message>
-        <source>SAVE</source>
-        <translation>SÁBHÁIL</translation>
+        <source>Close this dialog and return to the token field</source>
+        <translation>Dún an dialóg seo agus fill ar ais chuig an réimse comharthaí</translation>
     </message>
     <message>
-        <source>CANCEL</source>
-        <translation>CEALAIGH</translation>
+        <source>Authentication token:</source>
+        <translation>Authentication token:</translation>
     </message>
     <message>
-        <source>Please fix validation errors in General and Services tabs</source>
-        <translation>Deisigh earráidí bailíochtaithe sna cluaisíní Ginearálta agus Seirbhísí</translation>
-    </message>
-    <message>
-        <source>Please fix validation errors in General tab</source>
-        <translation>Deisigh earráidí bailíochtaithe sa chluaisín Ginearálta le do thoil</translation>
-    </message>
-    <message>
-        <source>Please fix validation errors in Services tab</source>
-        <translation>Deisigh earráidí bailíochtaithe sa chluaisín Seirbhísí le do thoil</translation>
+        <source>Sign in to receive a token and enable Raspberry Pi Connect</source>
+        <translation>Sínigh isteach chun comhartha a fháil agus Raspberry Pi Connect a chumasú</translation>
     </message>
 </context>
 <context>
-    <name>OptionsServicesTab</name>
+    <name>QObject</name>
+    <message>
+        <source>Raspberry Pi Imager requires elevated privileges to write to storage devices.</source>
+        <translation>Éilíonn Raspberry Pi Imager pribhléidí ardaithe chun scríobh chuig gléasanna stórála.</translation>
+    </message>
+    <message>
+        <source>Without this, you will encounter permission errors when writing images.</source>
+        <translation>Gan é seo, beidh earráidí ceadanna agat agus íomhánna á scríobh agat.</translation>
+    </message>
+    <message>
+        <source>You are not running as Administrator.
+
+Please run as Administrator.</source>
+        <translation>Níl tú ag rith mar Riarthóir.
+
+Rith mar Riarthóir le do thoil.</translation>
+    </message>
+    <message>
+        <source>You are not running as root.
+
+Please run with elevated privileges: sudo %1</source>
+        <translation>Níl tú ag rith mar fhréamh.
+
+Rith le ceadanna ardaithe le do thoil: sudo %1</translation>
+    </message>
+    <message>
+        <source>You are not running as root.
+
+Click "Install Authorization" to set up automatic privilege elevation, or run manually with: sudo %1</source>
+        <translation>Níl tú ag rith mar fhréamh.
+
+Cliceáil "Suiteáil Údarú" chun ardú uathoibríoch pribhléide a shocrú, nó rith de láimh le: sudo %1</translation>
+    </message>
+</context>
+<context>
+    <name>RemoteAccessStep</name>
     <message>
         <source>Enable SSH</source>
         <translation>Cumasaigh SSH</translation>
@@ -454,170 +1442,755 @@
         <translation>Úsáid fíordheimhniú pasfhocail</translation>
     </message>
     <message>
-        <source>Allow public-key authentication only</source>
-        <translation>Ceadaigh fíordheimhniú eochrach-poiblí amháin</translation>
+        <source>Use public key authentication</source>
+        <translation>Úsáid fíordheimhniú eochrach poiblí</translation>
     </message>
     <message>
-        <source>Set authorized_keys for &apos;%1&apos;:</source>
-        <translation>Socraigh eochracha_údaraithe do &apos;%1&apos;:</translation>
+        <source>Customisation: SSH authentication</source>
+        <translation>Saincheapadh: Fíordheimhniú SSH</translation>
     </message>
     <message>
-        <source>Delete Key</source>
-        <translation>Eochair Scriosta</translation>
+        <source>Learn about SSH</source>
+        <translation>Foghlaim faoi SSH</translation>
     </message>
     <message>
-        <source>RUN SSH-KEYGEN</source>
-        <translation>Rith SSH-KEYGEN</translation>
+        <source>Configure SSH access</source>
+        <translation>Cumraigh rochtain SSH</translation>
     </message>
     <message>
-        <source>Add SSH Key</source>
-        <translation>Cuir Eochair SSH leis</translation>
+        <source>Authentication mechanism:</source>
+        <translation>Sásra fíordheimhnithe:</translation>
     </message>
     <message>
-        <source>Paste your SSH public key here.
-Supported formats: ssh-rsa, ssh-ed25519, ssh-dss, ecdsa-sha2-nistp, sk-ssh-ed25519@openssh.com, sk-ecdsa-sha2-nistp256@openssh.com, and SSH certificates
-Example: ssh-rsa AAAAB3NzaC1yc2E... user@hostname</source>
-        <translation>Greamaigh d’eochair phoiblí SSH anseo.
-Formáidí tacaithe: ssh-rsa, ssh-ed25519, ssh-dss, ecdsa-sha2-nistp, sk-ssh-ed25519@openssh.com, sk-ecdsa-sha2-nistp256@openssh.com, agus deimhnithe SSH
-Sampla: ssh-rsa AAAAB3NzaC1yc2E... ainm úsáideora@óstach</translation>
+        <source>Enable secure shell access for remote command-line control of your Raspberry Pi</source>
+        <translation>Cumasaigh rochtain shlán ar an sliogán le haghaidh rialú iargúlta ar líne ordaithe ar do Raspberry Pi</translation>
     </message>
     <message>
-        <source>Invalid SSH key format. SSH keys must start with ssh-rsa, ssh-ed25519, ssh-dss, ecdsa-sha2-nistp, sk-ssh-ed25519@openssh.com, sk-ecdsa-sha2-nistp256@openssh.com, or SSH certificates, followed by the key data and optional comment.</source>
-        <translation>Formáid eochrach SSH neamhbhailí. Ní mór eochracha SSH a thosú le ssh-rsa, ssh-ed25519, ssh-dss, ecdsa-sha2-nistp, sk-ssh-ed25519@openssh.com, sk-ecdsa-sha2-nistp256@openssh.com, nó teastais SSH, agus sonraí na heochrach agus trácht roghnach ina dhiaidh sin.</translation>
-    </message>
-</context>
-<context>
-    <name>UseSavedSettingsPopup</name>
-    <message>
-        <source>Would you like to apply OS customization settings?</source>
-        <translation>Ar mhaith leat socruithe saincheaptha OS a chur i bhfeidhm?</translation>
+        <source>Save SSH settings and continue to next customisation step</source>
+        <translation>Sábháil socruithe SSH agus lean ar aghaidh go dtí an chéad chéim saincheaptha eile</translation>
     </message>
     <message>
-        <source>NO</source>
-        <translation>NÍL</translation>
+        <source>Return to previous step</source>
+        <translation>Fill ar ais go dtí an chéim roimhe seo</translation>
     </message>
     <message>
-        <source>NO, CLEAR SETTINGS</source>
-        <translation>NÍL, GLAN NA SOCRAITHE</translation>
+        <source>Skip all customisation and proceed directly to writing the image</source>
+        <translation>Seachain an saincheapadh go léir agus téigh ar aghaidh go díreach chuig scríobh na híomhá</translation>
     </message>
     <message>
-        <source>YES</source>
-        <translation>TÁ</translation>
+        <source>Allow SSH login using the username and password you configured in the previous step.</source>
+        <translation>Ceadaigh logáil isteach SSH ag baint úsáide as an ainm úsáideora agus an focal faire a chumraigh tú sa chéim roimhe seo.</translation>
     </message>
     <message>
-        <source>EDIT SETTINGS</source>
-        <translation>Socruithe a Chur in Eagar</translation>
+        <source>Allow SSH login using a cryptographic key pair instead of a password. More secure than password authentication.</source>
+        <translation>Ceadaigh logáil isteach SSH ag baint úsáide as péire eochracha cripteagrafacha in ionad pasfhocail. Níos sláine ná fíordheimhniú pasfhocail.</translation>
+    </message>
+    <message>
+        <source>Choose how you will authenticate when connecting to your Raspberry Pi via SSH. Password authentication uses the account credentials you configured. Public key authentication uses a cryptographic key pair and is more secure.</source>
+        <translation>Roghnaigh conas a dhéanfaidh tú fíordheimhniú agus tú ag ceangal le do Raspberry Pi trí SSH. Úsáideann fíordheimhniú pasfhocail dintiúir an chuntais a chumraigh tú. Úsáideann fíordheimhniú eochrach poiblí péire eochrach cripteagrafach agus tá sé níos sláine.</translation>
     </message>
 </context>
 <context>
-    <name>main</name>
+    <name>RepositoryDialog</name>
     <message>
-        <source>Raspberry Pi Imager v%1</source>
-        <translation>Íomháitheoir Raspberry Pi leagan v%1</translation>
+        <source>Content Repository</source>
+        <translation>Stór Ábhair</translation>
     </message>
     <message>
-        <source>Raspberry Pi Device</source>
-        <translation>Gléas Raspberry Pi</translation>
+        <source>Repository source:</source>
+        <translation>Foinse an stórais:</translation>
     </message>
     <message>
-        <source>Select this button to choose your target Raspberry Pi</source>
-        <translation>Roghnaigh an cnaipe seo chun do Raspberry Pi sprice a roghnú</translation>
+        <source>Use custom file</source>
+        <translation>Úsáid comhad saincheaptha</translation>
     </message>
     <message>
-        <source>Operating System</source>
-        <translation>Córas Oibriúcháin</translation>
+        <source>Please select a custom repository json file</source>
+        <translation>Roghnaigh comhad json stórtha saincheaptha le do thoil</translation>
     </message>
     <message>
-        <source>CHOOSE OS</source>
-        <translation>ROGHNAIGH OS</translation>
+        <source>Select Repository</source>
+        <translation>Roghnaigh Stór</translation>
     </message>
     <message>
-        <source>Select this button to change the operating system</source>
-        <translation>Roghnaigh an cnaipe seo chun an córas oibriúcháin a athrú</translation>
+        <source>Apply &amp; Restart</source>
+        <translation>Cuir i bhFeidhm &amp; Atosaigh</translation>
+    </message>
+    <message>
+        <source>Select custom repository</source>
+        <translation>Roghnaigh stórlann saincheaptha</translation>
+    </message>
+    <message>
+        <source>Use custom URL</source>
+        <translation>Úsáid URL saincheaptha</translation>
+    </message>
+    <message>
+        <source>Select a custom repository JSON file from your computer</source>
+        <translation>Roghnaigh comhad JSON stórtha saincheaptha ó do ríomhaire</translation>
+    </message>
+    <message>
+        <source>Close the repository dialog without changing the content source</source>
+        <translation>Close the repository dialog without changing the content source</translation>
+    </message>
+    <message>
+        <source>Apply the new content repository and restart the wizard from the beginning</source>
+        <translation>Cuir an stór ábhair nua i bhfeidhm agus atosú an draoi ón tús</translation>
+    </message>
+    <message>
+        <source>Choose the source for operating system images</source>
+        <translation>Roghnaigh an fhoinse le haghaidh íomhánna an chórais oibriúcháin</translation>
+    </message>
+    <message>
+        <source>Use the official Raspberry Pi operating system repository</source>
+        <translation>Bain úsáid as stór oifigiúil chóras oibriúcháin Raspberry Pi</translation>
+    </message>
+    <message>
+        <source>Load operating system list from a JSON file on your computer</source>
+        <translation>Luchtaigh liosta córas oibriúcháin ó chomhad JSON ar do ríomhaire</translation>
+    </message>
+    <message>
+        <source>Download operating system list from a custom web address</source>
+        <translation>Íoslódáil liosta córas oibriúcháin ó sheoladh gréasáin saincheaptha</translation>
+    </message>
+</context>
+<context>
+    <name>SecureBootCustomizationStep</name>
+    <message>
+        <source>Customisation: Secure Boot</source>
+        <translation>Saincheapadh: Tosaithe Slán</translation>
+    </message>
+    <message>
+        <source>Configure secure boot image signing</source>
+        <translation>Cumraigh síniú íomhá tosaithe slán</translation>
+    </message>
+    <message>
+        <source>Save secure boot settings and continue to next customisation step</source>
+        <translation>Sábháil socruithe tosaithe slána agus lean ar aghaidh go dtí an chéad chéim saincheaptha eile</translation>
+    </message>
+    <message>
+        <source>Return to previous step</source>
+        <translation>Fill ar ais go dtí an chéim roimhe seo</translation>
+    </message>
+    <message>
+        <source>Skip all customisation and proceed directly to writing the image</source>
+        <translation>Seachain an saincheapadh go léir agus téigh ar aghaidh go díreach chuig scríobh na híomhá</translation>
+    </message>
+    <message>
+        <source>Enable Secure Boot Signing</source>
+        <translation>Cumasaigh Síniú Tosaithe Slán</translation>
+    </message>
+    <message>
+        <source>Sign the boot partition with your RSA key to enable secure boot verification on Raspberry Pi</source>
+        <translation>Sínigh an deighilt tosaithe le d'eochair RSA chun fíorú tosaithe slán a chumasú ar Raspberry Pi</translation>
+    </message>
+    <message>
+        <source>Learn about Secure Boot</source>
+        <translation>Foghlaim faoi Tosaithe Slán</translation>
+    </message>
+    <message>
+        <source>This will create boot.img and boot.sig files required for Raspberry Pi Secure Boot.</source>
+        <translation>Cruthóidh sé seo comhaid boot.img agus boot.sig atá riachtanach le haghaidh Tosaithe Slán Raspberry Pi.</translation>
+    </message>
+    <message>
+        <source>Public Key Fingerprint: %1</source>
+        <translation>Méarlorg Eochrach Phoiblí: %1</translation>
+    </message>
+    <message>
+        <source>(unavailable)</source>
+        <translation>(níl sé ar fáil)</translation>
+    </message>
+    <message>
+        <source>(unable to compute)</source>
+        <translation>(ní féidir a ríomh)</translation>
+    </message>
+    <message>
+        <source>RSA Private Key</source>
+        <translation>Eochair Phríobháideach RSA</translation>
+    </message>
+    <message>
+        <source>Change</source>
+        <translation>Athraigh</translation>
+    </message>
+    <message>
+        <source>Select</source>
+        <translation>Líonra slán</translation>
+    </message>
+    <message>
+        <source>Select an RSA 2048-bit private key for signing boot images in secure boot mode</source>
+        <translation>Roghnaigh eochair phríobháideach RSA 2048-giotán chun íomhánna tosaithe a shíniú i mód tosaithe slán</translation>
+    </message>
+    <message>
+        <source>Select RSA Private Key</source>
+        <translation>Roghnaigh Eochair Phríobháideach RSA</translation>
+    </message>
+    <message>
+        <source>PEM Files (*.pem);;All Files (*)</source>
+        <translation>Comhaid PEM (*.pem);;Gach Comhad (*)</translation>
+    </message>
+    <message>
+        <source>Selected: %1</source>
+        <translation>Roghnaithe: %1</translation>
+    </message>
+    <message>
+        <source>Your boot partition will be signed using the selected RSA private key.</source>
+        <translation>Síneofar do dheighilt tosaithe ag baint úsáide as an eochair phríobháideach RSA roghnaithe.</translation>
+    </message>
+    <message>
+        <source>Please select an RSA private key above to enable secure boot signing.</source>
+        <translation>Roghnaigh eochair phríobháideach RSA thuas le do thoil chun síniú tosaithe slán a chumasú.</translation>
+    </message>
+    <message>
+        <source>PEM Files (*.pem)</source>
+        <translation>Comhaid PEM (*.pem)</translation>
+    </message>
+    <message>
+        <source>All Files (*)</source>
+        <translation>Gach Comhad (*)</translation>
+    </message>
+</context>
+<context>
+    <name>SshKeyManager</name>
+    <message>
+        <source>No SSH keys configured</source>
+        <translation>Gan aon eochracha SSH cumraithe</translation>
+    </message>
+    <message>
+        <source>1 SSH key configured</source>
+        <translation>1 eochair SSH cumraithe</translation>
+    </message>
+    <message>
+        <source>%1 SSH keys configured</source>
+        <translation>%1 eochair SSH cumraithe</translation>
+    </message>
+    <message>
+        <source>Hide</source>
+        <translation>Folaigh</translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation>Taispeáin</translation>
+    </message>
+    <message>
+        <source>Hide the list of SSH keys</source>
+        <translation>Folaigh an liosta eochracha SSH</translation>
+    </message>
+    <message>
+        <source>Show the list of SSH keys</source>
+        <translation>Taispeáin an liosta eochracha SSH</translation>
+    </message>
+    <message>
+        <source>SSH keys list</source>
+        <translation>Liosta eochracha SSH</translation>
+    </message>
+    <message>
+        <source>SSH key %1: %2, %3</source>
+        <translation>Eochair SSH %1: %2, %3</translation>
+    </message>
+    <message>
+        <source>SSH key %1: %2</source>
+        <translation>Eochair SSH %1: %2</translation>
+    </message>
+    <message>
+        <source>SSH key %1</source>
+        <translation>Eochair SSH %1</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Bain</translation>
+    </message>
+    <message>
+        <source>Remove SSH key: %1</source>
+        <translation>Bain eochair SSH: %1</translation>
+    </message>
+    <message>
+        <source>Remove SSH key %1</source>
+        <translation>Bain eochair SSH %1</translation>
+    </message>
+    <message>
+        <source>Paste key or click BROWSE to select file</source>
+        <translation>Greamaigh eochair nó cliceáil BROWSE chun comhad a roghnú</translation>
+    </message>
+    <message>
+        <source>SSH public key input</source>
+        <translation>Ionchur eochair phoiblí SSH</translation>
+    </message>
+    <message>
+        <source>Paste an SSH public key here or use the browse button to select a key file</source>
+        <translation>Greamaigh eochair phoiblí SSH anseo nó bain úsáid as an gcnaipe brabhsála chun comhad eochrach a roghnú</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Cuir leis</translation>
+    </message>
+    <message>
+        <source>Select SSH Public Key</source>
+        <translation>Roghnaigh Eochair Phoiblí SSH</translation>
+    </message>
+    <message>
+        <source>Add the entered SSH key</source>
+        <translation>Cuir an eochair SSH iontráilte leis</translation>
+    </message>
+    <message>
+        <source>Select an SSH public key file to add</source>
+        <translation>Roghnaigh comhad eochrach poiblí SSH le cur leis</translation>
+    </message>
+</context>
+<context>
+    <name>StorageSelectionStep</name>
+    <message>
+        <source>No storage devices found</source>
+        <translation>Níor aimsíodh aon fheistí stórála</translation>
+    </message>
+    <message>
+        <source>Mounted as %1</source>
+        <translation>Suiteáilte mar %1</translation>
+    </message>
+    <message>
+        <source>Read-only</source>
+        <translation>Léamh amháin</translation>
+    </message>
+    <message>
+        <source>Select your storage device</source>
+        <translation>Roghnaigh do ghléas stórála</translation>
+    </message>
+    <message>
+        <source>Exclude system drives</source>
+        <translation>Eisiamh tiomántáin chórais</translation>
+    </message>
+    <message>
+        <source>Storage device list</source>
+        <translation>Liosta gléasanna stórála</translation>
+    </message>
+    <message>
+        <source>No devices</source>
+        <translation>Gan aon fheistí</translation>
+    </message>
+    <message>
+        <source>1 device</source>
+        <translation>1 gléas</translation>
+    </message>
+    <message>
+        <source>%1 devices</source>
+        <translation>%1 gléas</translation>
+    </message>
+    <message>
+        <source>Use arrow keys to navigate, Enter or Space to select</source>
+        <translation>Úsáid na heochracha saigheada chun nascleanúint a dhéanamh, Iontráil nó Spás chun roghnú</translation>
+    </message>
+    <message>
+        <source>All visible devices are read-only.
+Try connecting a new device, or uncheck
+'Exclude system drives' below.</source>
+        <translation>Is féidir gach gléas atá le feiceáil a léamh amháin.
+Bain triail as gléas nua a nascadh, nó díthiceáil 
+'Eisiamh tiomántáin chórais' thíos.</translation>
+    </message>
+    <message>
+        <source>All devices are read-only.
+Please connect a writable storage device.</source>
+        <translation>Is gléasanna inléite amháin iad na gléasanna uile.
+Ceangail gléas stórála inscríofa le do thoil.</translation>
+    </message>
+    <message>
+        <source>All devices are hidden by the filter.
+Uncheck 'Exclude system drives' below
+to show system drives.</source>
+        <translation>Tá gach gléas i bhfolach ag an scagaire.
+Díthiceáil 'Eisiamh tiomántáin chórais' thíos chun tiomántáin chórais a thaispeáint.</translation>
+    </message>
+    <message>
+        <source>When checked, system drives are hidden from the list. Uncheck to show all drives including system drives.</source>
+        <translation>Nuair a bhíonn sé seo seiceáilte, bíonn tiomántáin chórais i bhfolach ón liosta. Díthiceáil chun gach tiomántán a thaispeáint, lena n-áirítear tiomántáin chórais.</translation>
+    </message>
+    <message>
+        <source>No storage devices found. Please connect a storage device to continue.</source>
+        <translation>Níor aimsíodh aon fheistí stórála. Ceangail gléas stórála le leanúint ar aghaidh.</translation>
+    </message>
+    <message>
+        <source>No valid storage devices are currently available. All visible devices are read-only. Try connecting a new storage device, or uncheck 'Exclude system drives' to show hidden system drives.</source>
+        <translation>Níl aon fheistí stórála bailí ar fáil faoi láthair. Is féidir gach feiste infheicthe a léamh amháin. Bain triail as feiste stórála nua a nascadh, nó díthiceáil 'Eisiamh tiomántáin chórais' chun tiomántáin chórais i bhfolach a thaispeáint.</translation>
+    </message>
+    <message>
+        <source>No valid storage devices are currently available. All devices are read-only. Please connect a writable storage device to continue.</source>
+        <translation>Níl aon fheistí stórála bailí ar fáil faoi láthair. Is gléasanna inléite amháin iad na feistí uile. Ceangail gléas stórála inscríofa le leanúint ar aghaidh.</translation>
+    </message>
+    <message>
+        <source>No valid storage devices are currently available. Uncheck 'Exclude system drives' to show hidden system drives, or connect a new storage device.</source>
+        <translation>Níl aon fheistí stórála bailí ar fáil faoi láthair. Díthiceáil 'Eisiamh tiomántáin chórais' chun tiomántáin chórais i bhfolach a thaispeáint, nó ceangail gléas stórála nua.</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateAvailableDialog</name>
+    <message>
+        <source>Update available</source>
+        <translation>Nuashonrú ar fáil</translation>
+    </message>
+    <message>
+        <source>There is a newer version of Imager available. Would you like to visit the website to download it?</source>
+        <translation>Tá leagan níos nuaí de Imager ar fáil. Ar mhaith leat cuairt a thabhairt ar an suíomh Gréasáin chun é a íoslódáil?</translation>
+    </message>
+    <message>
+        <source>Continue using the current version of Raspberry Pi Imager</source>
+        <translation>Lean ort ag úsáid an leagan reatha de Raspberry Pi Imager</translation>
+    </message>
+    <message>
+        <source>Open the Raspberry Pi website in your browser to download the latest version</source>
+        <translation>Oscail suíomh Gréasáin Raspberry Pi i do bhrabhsálaí chun an leagan is déanaí a íoslódáil</translation>
+    </message>
+</context>
+<context>
+    <name>UserCustomizationStep</name>
+    <message>
+        <source>Username:</source>
+        <translation>Ainm úsáideora:</translation>
+    </message>
+    <message>
+        <source>Enter password</source>
+        <translation>Cuir isteach focal faire</translation>
+    </message>
+    <message>
+        <source>Confirm password:</source>
+        <translation>Deimhnigh an focal faire:</translation>
+    </message>
+    <message>
+        <source>Re-enter password</source>
+        <translation>Ath-iontráil an focal faire</translation>
+    </message>
+    <message>
+        <source>The username must be lowercase and contain only letters, numbers, underscores, and hyphens.</source>
+        <translation>Ní mór don ainm úsáideora a bheith i litreacha beaga agus gan ach litreacha, uimhreacha, fo-línte agus fleiscíní a bheith ann.</translation>
+    </message>
+    <message>
+        <source>Customisation: Choose username</source>
+        <translation>Saincheapadh: Roghnaigh ainm úsáideora</translation>
+    </message>
+    <message>
+        <source>Saved (hidden) — leave blank to keep</source>
+        <translation>Sábháilte (i bhfolach) — fág bán le coinneáil</translation>
+    </message>
+    <message>
+        <source>Re-enter to change password</source>
+        <translation>Athiontráil chun an focal faire a athrú</translation>
+    </message>
+    <message>
+        <source>Create a user account for your Raspberry Pi</source>
+        <translation>Cruthaigh cuntas úsáideora do do Raspberry Pi</translation>
+    </message>
+    <message>
+        <source>Enter your username</source>
+        <translation>Cuir isteach d'ainm úsáideora</translation>
+    </message>
+    <message>
+        <source>Save user account settings and continue to next customisation step</source>
+        <translation>Sábháil socruithe cuntais úsáideora agus lean ar aghaidh go dtí an chéad chéim saincheaptha eile</translation>
+    </message>
+    <message>
+        <source>Return to previous step</source>
+        <translation>Fill ar ais go dtí an chéim roimhe seo</translation>
+    </message>
+    <message>
+        <source>Skip all customisation and proceed directly to writing the image</source>
+        <translation>Seachain an saincheapadh go léir agus téigh ar aghaidh go díreach chuig scríobh na híomhá</translation>
+    </message>
+    <message>
+        <source>Enter a username for your Raspberry Pi account. The username must be lowercase and contain only letters, numbers, underscores, and hyphens.</source>
+        <translation>Cuir isteach ainm úsáideora do do chuntas Raspberry Pi. Ní mór don ainm úsáideora a bheith i litreacha beaga agus gan ach litreacha, uimhreacha, fo-línte agus fleiscíní a bheith ann.</translation>
+    </message>
+    <message>
+        <source>Enter a new password for this account, or leave blank to keep the previously saved password.</source>
+        <translation>Cuir isteach pasfhocal nua don chuntas seo, nó fág bán é chun an pasfhocal a sábháladh roimhe seo a choinneáil.</translation>
+    </message>
+    <message>
+        <source>Enter a password for this account. You will need to re-enter it in the next field to confirm.</source>
+        <translation>Cuir isteach pasfhocal don chuntas seo. Beidh ort é a chur isteach arís sa réimse seo chugainn chun é a dheimhniú.</translation>
+    </message>
+    <message>
+        <source>Re-enter the new password to confirm, or leave blank to keep the previously saved password.</source>
+        <translation>Athiontráil an focal faire nua le deimhniú, nó fág bán é chun an focal faire a sábháladh roimhe seo a choinneáil.</translation>
+    </message>
+    <message>
+        <source>Re-enter the password to confirm it matches.</source>
+        <translation>Athiontráil an focal faire chun a dheimhniú go bhfuil sé ag teacht leis.</translation>
+    </message>
+</context>
+<context>
+    <name>WifiCustomizationStep</name>
+    <message>
+        <source>SSID:</source>
+        <translation>SSID:</translation>
+    </message>
+    <message>
+        <source>Network name</source>
+        <translation>Ainm an líonra</translation>
+    </message>
+    <message>
+        <source>Network password</source>
+        <translation>Pasfhocal líonra</translation>
+    </message>
+    <message>
+        <source>Hidden SSID</source>
+        <translation>SSID i bhfolach</translation>
+    </message>
+    <message>
+        <source>Customisation: Choose Wi‑Fi</source>
+        <translation>Saincheapadh: Roghnaigh Wi-Fi</translation>
+    </message>
+    <message>
+        <source>No password (open network)</source>
+        <translation>Gan focal faire (líonra oscailte)</translation>
+    </message>
+    <message>
+        <source>Saved (hidden) — leave blank to keep</source>
+        <translation>Sábháilte (i bhfolach) — fág bán le coinneáil</translation>
+    </message>
+    <message>
+        <source>Secure network</source>
+        <translation>Líonra slán</translation>
+    </message>
+    <message>
+        <source>Configure Wi-Fi for a password-protected network with WPA2/WPA3 encryption</source>
+        <translation>Cumraigh Wi-Fi le haghaidh líonra atá cosanta ag pasfhocal le criptiú WPA2/WPA3</translation>
+    </message>
+    <message>
+        <source>Open network</source>
+        <translation>Líonra oscailte</translation>
+    </message>
+    <message>
+        <source>Configure Wi-Fi for an unencrypted network without password protection</source>
+        <translation>Cumraigh Wi-Fi le haghaidh líonra neamhchriptithe gan chosaint pasfhocail</translation>
+    </message>
+    <message>
+        <source>Enter a password</source>
+        <translation>Cuir isteach focal faire</translation>
+    </message>
+    <message>
+        <source>Password is too short (min 8 characters)</source>
+        <translation>Tá an focal faire ró-ghearr (8 gcarachtar ar a laghad)</translation>
+    </message>
+    <message>
+        <source>Password is too long (max 63 characters)</source>
+        <translation>Tá an focal faire rófhada (uasmhéid 63 carachtar)</translation>
+    </message>
+    <message>
+        <source>Password contains unsupported characters</source>
+        <translation>Tá carachtair nach dtacaítear leo sa phasfhocal</translation>
+    </message>
+    <message>
+        <source>Confirm password:</source>
+        <translation>Deimhnigh an focal faire:</translation>
+    </message>
+    <message>
+        <source>Re-enter password</source>
+        <translation>Ath-iontráil an focal faire</translation>
+    </message>
+    <message>
+        <source>Save Wi-Fi settings and continue to next customisation step</source>
+        <translation>Sábháil socruithe Wi-Fi agus lean ar aghaidh go dtí an chéad chéim saincheaptha eile</translation>
+    </message>
+    <message>
+        <source>Return to previous step</source>
+        <translation>Fill ar ais go dtí an chéim roimhe seo</translation>
+    </message>
+    <message>
+        <source>Skip all customisation and proceed directly to writing the image</source>
+        <translation>Seachain an saincheapadh go léir agus téigh ar aghaidh go díreach chuig scríobh na híomhá</translation>
+    </message>
+    <message>
+        <source>Enter the network name (SSID) of your Wi-Fi network. This is the name that appears when you search for available networks.</source>
+        <translation>Cuir isteach ainm líonra (SSID) do líonra Wi-Fi. Seo an t-ainm a thaispeántar nuair a dhéanann tú cuardach ar líonraí atá ar fáil.</translation>
+    </message>
+    <message>
+        <source>Enter a new Wi-Fi password, or leave blank to keep the previously saved password. Must be 8-63 characters or a 64-character hexadecimal key.</source>
+        <translation>Cuir isteach pasfhocal Wi-Fi nua, nó fág bán é chun an pasfhocal a sábháladh roimhe seo a choinneáil. Ní mór go mbeadh sé 8-63 carachtar nó eochair heicsidheachúlach 64 carachtar.</translation>
+    </message>
+    <message>
+        <source>Enter your Wi-Fi network password. Must be 8-63 characters or a 64-character hexadecimal key. You will need to re-enter it in the next field to confirm.</source>
+        <translation>Cuir isteach do phasfhocal líonra Wi-Fi. Ní mór é a bheith 8-63 carachtar nó eochair heicsidheachúlach 64 carachtar. Beidh ort é a ath-iontráil sa chéad réimse eile chun a dheimhniú.</translation>
+    </message>
+    <message>
+        <source>Re-enter the new Wi-Fi password to confirm, or leave blank to keep the previously saved password.</source>
+        <translation>Athiontráil an focal faire Wi-Fi nua le deimhniú, nó fág bán é chun an focal faire a sábháladh roimhe seo a choinneáil.</translation>
+    </message>
+    <message>
+        <source>Re-enter the Wi-Fi password to confirm it matches.</source>
+        <translation>Cuir isteach an focal faire Wi-Fi arís chun a dheimhniú go bhfuil sé ag teacht leis.</translation>
+    </message>
+    <message>
+        <source>Check this if your Wi-Fi network does not broadcast its name and requires manual SSID entry to connect.</source>
+        <translation>Seiceáil seo mura gcraolann do líonra Wi-Fi a ainm agus má theastaíonn iontráil SSID de láimh chun ceangal.</translation>
+    </message>
+    <message>
+        <source>Passwords don't match</source>
+        <translation>Ní hionann na pasfhocail</translation>
+    </message>
+    <message>
+        <source>Re-enter to change password</source>
+        <translation>Athiontráil chun an focal faire a athrú</translation>
+    </message>
+</context>
+<context>
+    <name>WizardContainer</name>
+    <message>
+        <source>Device</source>
+        <translation>Gléas</translation>
+    </message>
+    <message>
+        <source>OS</source>
+        <translation>CO</translation>
     </message>
     <message>
         <source>Storage</source>
         <translation>Stóráil</translation>
     </message>
     <message>
-        <source>Network not ready yet</source>
-        <translation>Níl an líonra réidh fós</translation>
+        <source>Writing</source>
+        <translation>Scríbhneoireacht</translation>
     </message>
     <message>
-        <source>CHOOSE STORAGE</source>
-        <translation>ROGHNAIGH STÓRÁIL</translation>
+        <source>Done</source>
+        <translation>Déanta</translation>
     </message>
     <message>
-        <source>Select this button to change the destination storage device</source>
-        <translation>Roghnaigh an cnaipe seo chun an gléas stórála ceann scríbe a athrú</translation>
+        <source>Customisation</source>
+        <translation>Saincheapadh</translation>
     </message>
     <message>
-        <source>CANCEL WRITE</source>
-        <translation>CEALAIGH SCRÍOBH</translation>
+        <source>Hostname</source>
+        <translation>Ainm óstach</translation>
     </message>
     <message>
-        <source>Cancelling...</source>
-        <translation>Ag cealú...</translation>
+        <source>User</source>
+        <translation>Úsáideoir</translation>
     </message>
     <message>
-        <source>CANCEL VERIFY</source>
-        <translation>CEALAIGH FÍORÚ</translation>
+        <source>Wi‑Fi</source>
+        <translation>Wi‑Fi</translation>
     </message>
     <message>
-        <source>Finalizing...</source>
-        <translation>Ag críochnú...</translation>
+        <source>Raspberry Pi Connect</source>
+        <translation>Ceangal Raspberry Pi</translation>
     </message>
+    <message>
+        <source>App Options</source>
+        <translation>Roghanna Aipe</translation>
+    </message>
+    <message>
+        <source>Interfaces &amp; Features</source>
+        <translation>Comhéadain &amp; Gnéithe</translation>
+    </message>
+    <message>
+        <source>Setup steps</source>
+        <translation>Céimeanna socraithe</translation>
+    </message>
+    <message>
+        <source>Localisation</source>
+        <translation>Logánú</translation>
+    </message>
+    <message>
+        <source>Remote access</source>
+        <translation>Rochtain iargúlta</translation>
+    </message>
+    <message>
+        <source>Open application settings to configure sound alerts, auto-eject, telemetry, and content repository</source>
+        <translation>Oscail socruithe an fheidhmchláir chun foláirimh fuaime, uath-díbirt, teileamaitríocht agus stór ábhair a chumrú</translation>
+    </message>
+    <message>
+        <source>Replace existing Raspberry Pi Connect token?</source>
+        <translation>An bhfuil sé i gceist an comhartha Raspberry Pi Connect atá ann cheana a athsholáthar?</translation>
+    </message>
+    <message>
+        <source>A new Raspberry Pi Connect token was received that differs from your current one.
+
+</source>
+        <translation>A new Raspberry Pi Connect token was received that differs from your current one.
+
+</translation>
+    </message>
+    <message>
+        <source>Do you want to overwrite the existing token?
+
+</source>
+        <translation>Ar mhaith leat an comhartha atá ann cheana a athscríobh?
+
+</translation>
+    </message>
+    <message>
+        <source>Replace token</source>
+        <translation>Cuir comhartha in ionad</translation>
+    </message>
+    <message>
+        <source>Please wait…</source>
+        <translation>Fan le do thoil…</translation>
+    </message>
+    <message>
+        <source>Replace the current token with the newly received one</source>
+        <translation>Cuir an comhartha reatha in ionad an cheann nua a fuarthas</translation>
+    </message>
+    <message>
+        <source>Keep existing</source>
+        <translation>Coinnigh atá ann cheana féin</translation>
+    </message>
+    <message>
+        <source>Keep your current Raspberry Pi Connect token</source>
+        <translation>Coinnigh do chomhartha Raspberry Pi Connect reatha</translation>
+    </message>
+    <message>
+        <source>Secure Boot</source>
+        <translation>Tosaithe Slán</translation>
+    </message>
+    <message>
+        <source>Warning: Only overwrite the token if you initiated this action.</source>
+        <translation>Rabhadh: Ná scríobh an comhartha arís ach amháin má thionscain tú an gníomh seo.</translation>
+    </message>
+</context>
+<context>
+    <name>WizardStepBase</name>
     <message>
         <source>Next</source>
         <translation>Ar Aghaidh</translation>
     </message>
     <message>
-        <source>Select this button to start writing the image</source>
-        <translation>Roghnaigh an cnaipe seo chun tús a chur le scríobh na híomhá</translation>
+        <source>Skip customisation</source>
+        <translation>Seachain an saincheapadh</translation>
+    </message>
+</context>
+<context>
+    <name>WritingStep</name>
+    <message>
+        <source>Review your choices and write the image to the storage device</source>
+        <translation>Athbhreithnigh do roghanna agus scríobh an íomhá chuig an ngléas stórála</translation>
     </message>
     <message>
-        <source>Using custom repository: %1</source>
-        <translation>Ag baint úsáide as stórlann saincheaptha: %1</translation>
+        <source>Write</source>
+        <translation>Scríobh</translation>
     </message>
     <message>
-        <source>Keyboard navigation: &lt;tab&gt; navigate to next button &lt;space&gt; press button/select item &lt;arrow up/down&gt; go up/down in lists</source>
-        <translation>Nascleanúint méarchláir: &lt;tab&gt; nascleanúint go dtí an chéad chnaipe eile &lt;space&gt; brúigh an cnaipe/roghnaigh mír &lt;saighead suas/síos&gt; téigh suas/síos sna liostaí</translation>
+        <source>Summary</source>
+        <translation>Achoimre</translation>
     </message>
     <message>
-        <source>Language: </source>
-        <translation>Teanga: </translation>
+        <source>Starting write process...</source>
+        <translation>Ag tosú an phróisis scríbhneoireachta...</translation>
     </message>
     <message>
-        <source>Keyboard: </source>
-        <translation>Méarchlár: </translation>
+        <source>You are about to ERASE all data on: %1</source>
+        <translation>Tá tú ar tí na sonraí go léir a SCRIOSADH ar: %1</translation>
     </message>
     <message>
-        <source>Are you sure you want to quit?</source>
-        <translation>An bhfuil tú cinnte gur mian leat éirí as?</translation>
+        <source>the storage device</source>
+        <translation>an gléas stórála</translation>
     </message>
     <message>
-        <source>Raspberry Pi Imager is still busy.&lt;br&gt;Are you sure you want to quit?</source>
-        <translation>Tá Raspberry Pi Imager fós gnóthach.&lt;br&gt;An bhfuil tú cinnte gur mhaith leat scor?</translation>
+        <source>This action is PERMANENT and CANNOT be undone.</source>
+        <translation>Tá an gníomh seo BUAN agus NÍ FÉIDIR é a chealú.</translation>
     </message>
     <message>
-        <source>Warning</source>
-        <translation>Rabhadh</translation>
+        <source>I understand, erase and write</source>
+        <translation>Tuigim, scrios agus scríobh</translation>
     </message>
     <message>
-        <source>Preparing to write...</source>
-        <translation>Ag ullmhú le scríobh...</translation>
-    </message>
-    <message>
-        <source>All existing data on &apos;%1&apos; will be erased.&lt;br&gt;Are you sure you want to continue?</source>
-        <translation>Scriosfar na sonraí go léir atá ann cheana féin ar &apos;%1&apos;.&lt;br&gt;An bhfuil tú cinnte gur mian leat leanúint ar aghaidh?</translation>
-    </message>
-    <message>
-        <source>Update available</source>
-        <translation>Nuashonrú ar fáil</translation>
-    </message>
-    <message>
-        <source>There is a newer version of Imager available.&lt;br&gt;Would you like to visit the website to download it?</source>
-        <translation>Tá leagan níos nuaí de Imager ar fáil.&lt;br&gt;Ar mhaith leat cuairt a thabhairt ar an suíomh Gréasáin chun é a íoslódáil?</translation>
+        <source>Please wait...</source>
+        <translation>Fan le do thoil...</translation>
     </message>
     <message>
         <source>Writing... %1%</source>
@@ -628,28 +2201,107 @@ Sampla: ssh-rsa AAAAB3NzaC1yc2E... ainm úsáideora@óstach</translation>
         <translation>Ag fíorú... %1%</translation>
     </message>
     <message>
-        <source>Preparing to write... (%1)</source>
-        <translation>Ag ullmhú le scríobh... (%1)</translation>
+        <source>Write completed successfully!</source>
+        <translation>Scríobh críochnaithe go rathúil!</translation>
+    </message>
+    <message>
+        <source>Write failed: %1</source>
+        <translation>Theip ar an scríobh: %1</translation>
+    </message>
+    <message>
+        <source>Customisations to apply:</source>
+        <translation>Saincheaptha le cur i bhfeidhm:</translation>
+    </message>
+    <message>
+        <source>Finalising...</source>
+        <translation>Ag críochnú...</translation>
+    </message>
+    <message>
+        <source>Write image</source>
+        <translation>Scríobh íomhá</translation>
+    </message>
+    <message>
+        <source>Operating system:</source>
+        <translation>Córas oibriúcháin:</translation>
+    </message>
+    <message>
+        <source>Cancel and return to the write summary without erasing the storage device</source>
+        <translation>Cealaigh agus fill ar an achoimre scríbhneoireachta gan an gléas stórála a scriosadh</translation>
+    </message>
+    <message>
+        <source>Confirm erasure and begin writing the image to the storage device</source>
+        <translation>Deimhnigh an scriosadh agus tosaigh ag scríobh na híomhá chuig an ngléas stórála</translation>
+    </message>
+    <message>
+        <source>Skip verification</source>
+        <translation>Seachain fíorú</translation>
+    </message>
+    <message>
+        <source>Cancel write</source>
+        <translation>Cealaigh an scríobh</translation>
+    </message>
+    <message>
+        <source>Skip verification and finish the write process</source>
+        <translation>Seachain an fíorú agus críochnaigh an próiseas scríbhneoireachta</translation>
+    </message>
+    <message>
+        <source>Cancel the write operation and return to the summary</source>
+        <translation>Cealaigh an oibríocht scríbhneoireachta agus fill ar ais chuig an achoimre</translation>
+    </message>
+    <message>
+        <source>Continue to the completion screen</source>
+        <translation>Lean ar aghaidh go dtí an scáileán críochnaithe</translation>
+    </message>
+    <message>
+        <source>Begin writing the image to the storage device. All existing data will be erased.</source>
+        <translation>Tosaigh ag scríobh an íomhá chuig an bhfeiste stórála. Scriosfar na sonraí go léir atá ann cheana.</translation>
+    </message>
+    <message>
+        <source>Return to previous customization step</source>
+        <translation>Fill ar ais go dtí an chéim saincheaptha roimhe seo</translation>
+    </message>
+    <message>
+        <source>Write progress</source>
+        <translation>Dul chun cinn a scríobh</translation>
+    </message>
+    <message>
+        <source>Finalising…</source>
+        <translation>Ag críochnú…</translation>
+    </message>
+    <message>
+        <source>Write complete</source>
+        <translation>Scríobh críochnaithe</translation>
+    </message>
+    <message>
+        <source>customization</source>
+        <translation>saincheapadh</translation>
+    </message>
+    <message>
+        <source>customizations</source>
+        <translation>saincheaptha</translation>
+    </message>
+    <message>
+        <source>Writing in progress — do not disconnect the storage device</source>
+        <translation>Scríbhneoireacht ar siúl — ná dícheangail an gléas stórála</translation>
+    </message>
+    <message>
+        <source>Please wait... %1</source>
+        <translation>Fan le do thoil... %1</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>Are you sure you want to quit?</source>
+        <translation>An bhfuil tú cinnte gur mian leat éirí as?</translation>
     </message>
     <message>
         <source>Error</source>
         <translation>Earráid</translation>
     </message>
     <message>
-        <source>Write Successful</source>
-        <translation>Scríobh go Rathúil</translation>
-    </message>
-    <message>
         <source>Erase</source>
         <translation>Scrios</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;%1&lt;/b&gt; has been erased&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>Scriosadh &lt;b&gt;%1&lt;/b&gt;&lt;br&gt;&lt;br&gt;Is féidir leat an cárta SD a bhaint as an léitheoir anois</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;%1&lt;/b&gt; has been written to &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;You can now remove the SD card from the reader</source>
-        <translation>Scríobhadh &lt;b&gt;%1&lt;/b&gt; chuig &lt;b&gt;%2&lt;/b&gt;&lt;br&gt;&lt;br&gt;Is féidir leat an cárta SD a bhaint as an léitheoir anois</translation>
     </message>
     <message>
         <source>Format card as FAT32</source>
@@ -664,24 +2316,76 @@ Sampla: ssh-rsa AAAAB3NzaC1yc2E... ainm úsáideora@óstach</translation>
         <translation>Roghnaigh .img saincheaptha ó do ríomhaire</translation>
     </message>
     <message>
-        <source>SKIP CACHE VERIFICATION</source>
-        <translation>SCIP FÍORÚ AN TAISCE</translation>
+        <source>Raspberry Pi Imager is still busy. Are you sure you want to quit?</source>
+        <translation>Tá Raspberry Pi Imager fós gnóthach. An bhfuil tú cinnte gur mhaith leat éirí as?</translation>
     </message>
     <message>
-        <source>Starting download...</source>
-        <translation>Ag tosú ag íoslódáil...</translation>
+        <source>Storage device removed</source>
+        <translation>Gléas stórála bainte</translation>
     </message>
     <message>
-        <source>Verifying cached file... %1%</source>
-        <translation>Ag fíorú comhad taisceáilte... %1%</translation>
+        <source>The storage device was removed while writing, so the operation was cancelled. Please reinsert the device or select a different one to continue.</source>
+        <translation>Baineadh an gléas stórála agus an scríobh ar siúl, mar sin cuireadh an oibríocht ar ceal. Cuir an gléas isteach arís nó roghnaigh ceann eile le leanúint ar aghaidh.</translation>
     </message>
     <message>
-        <source>Verifying cached file...</source>
-        <translation>Ag fíorú comhad taisceáilte...</translation>
+        <source>OK</source>
+        <translation>Ceart go leor</translation>
     </message>
     <message>
-        <source>Starting write...</source>
-        <translation>Ag tosú ag scríobh...</translation>
+        <source>Close the error dialog and continue</source>
+        <translation>Dún an dialóg earráide agus lean ar aghaidh</translation>
+    </message>
+    <message>
+        <source>Close the storage removed notification and return to storage selection</source>
+        <translation>Dún an fógra maidir leis an stóráil a baineadh agus fill ar ais chuig an rogha stórála</translation>
+    </message>
+    <message>
+        <source>Return to Raspberry Pi Imager and continue the current operation</source>
+        <translation>Fill ar ais chuig Íomháitheoir Raspberry Pi agus lean ar aghaidh leis an oibríocht reatha</translation>
+    </message>
+    <message>
+        <source>Force quit Raspberry Pi Imager and cancel the current write operation</source>
+        <translation>Éigeantach scor de Raspberry Pi Imager agus cealaigh an oibríocht scríbhneoireachta reatha</translation>
+    </message>
+    <message>
+        <source>Raspberry Pi Imager %1</source>
+        <translation>Íomháitheoir Raspberry Pi %1</translation>
+    </message>
+    <message>
+        <source>Insufficient Permissions</source>
+        <translation>Ceadanna Easpa</translation>
+    </message>
+    <message>
+        <source>Error message explaining why elevated privileges are required</source>
+        <translation>Teachtaireacht earráide ina mínítear cén fáth a bhfuil gá le ceadanna ardaithe</translation>
+    </message>
+    <message>
+        <source>Exit</source>
+        <translation>Scoir</translation>
+    </message>
+    <message>
+        <source>Exit Raspberry Pi Imager - you must restart with elevated privileges to write images</source>
+        <translation>Scoir Raspberry Pi Imager - ní mór duit atosú le pribhléidí ardaithe chun íomhánna a scríobh</translation>
+    </message>
+    <message>
+        <source>Install Authorization</source>
+        <translation>Údarú Suiteála</translation>
+    </message>
+    <message>
+        <source>Install system authorization to allow Raspberry Pi Imager to run with elevated privileges</source>
+        <translation>Suiteáil údarú córais chun ligean do Raspberry Pi Imager rith le pribhléidí ardaithe</translation>
+    </message>
+    <message>
+        <source>Save Performance Data</source>
+        <translation>Sábháil Sonraí Feidhmíochta</translation>
+    </message>
+    <message>
+        <source>JSON files (*.json)</source>
+        <translation>Comhaid JSON (*.json)</translation>
+    </message>
+    <message>
+        <source>All files (*)</source>
+        <translation>Gach comhad (*)</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
This PR updates the Irish (Gaeilge) translations for RPi Imager 2.0.3.

## Changes
- Updated existing Irish translations
- Added translations for new strings introduced in recent versions
- Current coverage: approximately ~556 translated strings

## Testing
- Checked the translations in Poedit to ensure proper display and context
- Verified formatting and special characters render correctly

This continues the ongoing effort to provide comprehensive Irish language support for Raspberry Pi Imager users.