### PR TITLE
fix(DiskFormatter): Large drive handling (>8GB)

### DIFF
--- a/src/disk_formatter.h
+++ b/src/disk_formatter.h
@@ -182,7 +182,8 @@ class DiskFormatter {
       const Fat32Config& config) const;
 
   Result<void> WriteRootDirectory(
-      std::uint32_t root_cluster_sector) const;
+      std::uint32_t root_cluster_sector,
+      const Fat32Config& config) const;
 
   // Utility functions
   Fat32Config CalculateFat32Config(std::uint32_t partition_size_sectors) const;


### PR DESCRIPTION
- Updated WriteFat32 to specify the backup boot sector location using a constant for clarity.
- Modified WriteRootDirectory to accept the Fat32Config parameter, allowing for dynamic root cluster size calculation based on sectors per cluster.
- Enhanced comments for better understanding of the backup boot sector and root directory handling.