### PR TITLE
chore(release): v2.0.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -24,7 +24,8 @@ body:
       label: Version
       description: What version of our software are you running?
       options:
-        - 2.0.5 (Default)
+        - 2.0.6 (Default)
+        - 2.0.5
         - 2.0.4
         - 2.0.3
         - 2.0.2 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -47,7 +47,8 @@ body:
       label: Version
       description: What version of our software did you last run?
       options:
-        - 2.0.5 (Default)
+        - 2.0.6 (Default)
+        - 2.0.5
         - 2.0.4
         - 2.0.3
         - 2.0.2

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+rpi-imager (2.0.6) unstable; urgency=medium
+
+  * UI: Improve ImButton width calculation for better content fitting
+  * i18n: Updated German translation
+
+ -- Tom Dewey <tom.dewey@raspberrypi.com>  Thu, 22 Jan 2026 14:30:00 +0000
+
 rpi-imager (2.0.5) unstable; urgency=medium
 
   * all platforms: CLI option added to help on GUI builds


### PR DESCRIPTION
- Changed the default version option from 2.0.5 to 2.0.6 in both the bug report and feature request issue templates.
- Updated Debian changelog for 2.0.6