### PR TITLE
Fix progress bar exceeding 100% for compressed images

### DIFF
--- a/src/wizard/WritingStep.qml
+++ b/src/wizard/WritingStep.qml
@@ -590,8 +590,10 @@ WizardStepBase {
                 progressText.text = qsTr("Writing... %1 MB written").arg(bytesWrittenMB)
             } else {
                 var progress = total > 0 ? (now / total) * 100 : 0
-                progressBar.value = progress
-                progressText.text = qsTr("Writing... %1%").arg(Math.round(progress))
+                // Clamp progress to avoid exceeding 100% due to extra writes
+                var clamped = Math.min(100, Math.max(0, progress))
+                progressBar.value = clamped
+                progressText.text = qsTr("Writing... %1%").arg(Math.round(clamped))
             }
         }
     }
@@ -602,8 +604,10 @@ WizardStepBase {
             root.bottleneckStatus = ""  // Clear write bottleneck during verification
             root.operationWarning = ""  // Clear write warnings during verification
             var progress = total > 0 ? (now / total) * 100 : 0
-            progressBar.value = progress
-            progressText.text = qsTr("Verifying... %1%").arg(Math.round(progress))
+            // Clamp verification progress to 0..100
+            var clamped = Math.min(100, Math.max(0, progress))
+            progressBar.value = clamped
+            progressText.text = qsTr("Verifying... %1%").arg(Math.round(clamped))
         }
     }
 


### PR DESCRIPTION
<img width="549" height="387" alt="image" src="https://github.com/user-attachments/assets/67981647-185c-4ac5-bb83-3872df1be83e" />

When writing a compressed custom image (e.g. .img.gz), the progress indicator can exceed 100% (I observed values like ~131%+).
This change clamps the UI progress value to a maximum of 100% in WritingStep.qml (UI-only; imaging/verification logic is unchanged).

Tested: Built locally on Debian (Qt via ./qt/build-qt.sh, AppImage via ./create-appimage.sh). Flashed a .img.gz image to microSD with verification enabled — write + verify completed successfully and the progress no longer exceeds 100%.

Fixes #1491 