### PR TITLE
 Add "Clear saved customisation" button to App Options        

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -3203,6 +3203,14 @@ void ImageWriter::removePersistedCustomisationSetting(const QString &key)
     _settings.sync();
 }
 
+void ImageWriter::clearSavedCustomisationSettings()
+{
+    _settings.beginGroup("imagecustomization");
+    _settings.remove("");
+    _settings.endGroup();
+    _settings.sync();
+}
+
 bool ImageWriter::imageSupportsCustomization()
 {
     return !_initFormat.isEmpty();

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -283,6 +283,7 @@ public:
     Q_INVOKABLE QVariantMap getSavedCustomisationSettings();
     Q_INVOKABLE void setPersistedCustomisationSetting(const QString &key, const QVariant &value);
     Q_INVOKABLE void removePersistedCustomisationSetting(const QString &key);
+    Q_INVOKABLE void clearSavedCustomisationSettings();
     Q_INVOKABLE bool imageSupportsCustomization();
     Q_INVOKABLE bool imageSupportsCcRpi();
 


### PR DESCRIPTION
 - Adds a "Clear" button in App Options to bulk-delete all saved OS customisation settings (hostname, WiFi, user credentials, locale, SSH)                       
  - Includes a confirmation dialog before clearing                                                                                                                
  - Resolves the issue where users had no way to perform a clean fresh install without previously saved settings being silently reused                            
                                                                                                                                                                  
  Fixes #1498                                                                                                                                                     
                                                                                                                                                                  
  Changes                                                                                                                                                         
                                                                                                                                                                  
  - imagewriter.h / imagewriter.cpp — new clearSavedCustomisationSettings() method that removes all keys from the imagecustomization QSettings group              
  - AppOptionsDialog.qml — new ImOptionButton + BaseDialog confirmation, following the existing confirmDisableWarnings pattern (including screen reader and       
  keyboard navigation support)                                                                                                                                    
                             