### PR TITLE
QML: fix property name mismatch in ImFileDialog

### DIFF
--- a/src/qmlcomponents/ImFileDialog.qml
+++ b/src/qmlcomponents/ImFileDialog.qml
@@ -475,7 +475,7 @@ BaseDialog {
                     delegate: ItemDelegate {
                         required property int index
                         required property string fileName
-                        required property string fileURL
+                        required property url fileUrl
                         
                         width: (ListView.view ? ListView.view.width : 0)
                         text: "📁 " + fileName
@@ -496,7 +496,7 @@ BaseDialog {
                         }
                         onClicked: {
                             subfoldersList.currentIndex = index
-                            dialog.currentFolder = fileURL
+                            dialog.currentFolder = fileUrl
                         }
                     }
                     ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded; width: Style.scrollBarWidth }
@@ -512,12 +512,12 @@ BaseDialog {
                     }
                     Keys.onEnterPressed: {
                         if (currentIndex >= 0) {
-                            dialog.currentFolder = model.get(currentIndex, "fileURL")
+                            dialog.currentFolder = model.get(currentIndex, "fileUrl")
                         }
                     }
                     Keys.onReturnPressed: {
                         if (currentIndex >= 0) {
-                            dialog.currentFolder = model.get(currentIndex, "fileURL")
+                            dialog.currentFolder = model.get(currentIndex, "fileUrl")
                         }
                     }
                 }
@@ -552,8 +552,8 @@ BaseDialog {
                         currentFileIndex--
                         // Update selection
                         var fileItem = fileColumn.children[currentFileIndex + 1] // +1 because of up entry
-                        if (fileItem && fileItem.fileURL) {
-                            dialog.selectedFile = fileItem.fileURL
+                        if (fileItem && fileItem.fileUrl) {
+                            dialog.selectedFile = fileItem.fileUrl
                         }
                     }
                 }
@@ -562,8 +562,8 @@ BaseDialog {
                         currentFileIndex++
                         // Update selection
                         var fileItem = fileColumn.children[currentFileIndex + 1] // +1 because of up entry
-                        if (fileItem && fileItem.fileURL) {
-                            dialog.selectedFile = fileItem.fileURL
+                        if (fileItem && fileItem.fileUrl) {
+                            dialog.selectedFile = fileItem.fileUrl
                         }
                     }
                 }
@@ -648,7 +648,7 @@ BaseDialog {
                                 currentIndex = 0
                                 // Set the selected file to the first file
                                 if (count > 0) {
-                                    dialog.selectedFile = model.get(0, "fileURL")
+                                    dialog.selectedFile = model.get(0, "fileUrl")
                                 }
                             }
                         }
@@ -657,20 +657,20 @@ BaseDialog {
                         Keys.onUpPressed: {
                             if (currentIndex > 0) {
                                 currentIndex--
-                                dialog.selectedFile = model.get(currentIndex, "fileURL")
+                                dialog.selectedFile = model.get(currentIndex, "fileUrl")
                             }
                         }
                         Keys.onDownPressed: {
                             if (currentIndex < count - 1) {
                                 currentIndex++
-                                dialog.selectedFile = model.get(currentIndex, "fileURL")
+                                dialog.selectedFile = model.get(currentIndex, "fileUrl")
                             }
                         }
                         
                         delegate: ItemDelegate {
                             required property int index
                             required property string fileName
-                            required property string fileURL
+                            required property url fileUrl
                             
                             width: fileColumn.width
                             text: "📄 " + fileName
@@ -679,7 +679,7 @@ BaseDialog {
                             Accessible.name: qsTr("File: %1").arg(fileName)
                             background: Rectangle {
                                 color: {
-                                    if (dialog.selectedFile === fileURL)
+                                    if (dialog.selectedFile === fileUrl)
                                         return Style.listViewHighlightColor
                                     else if (ListView.isCurrentItem && filesList.activeFocus)
                                         return Style.listViewHighlightColor
@@ -693,7 +693,7 @@ BaseDialog {
                             }
                             onClicked: {
                                 filesList.currentIndex = index
-                                dialog.selectedFile = fileURL
+                                dialog.selectedFile = fileUrl
                             }
                         }
                         


### PR DESCRIPTION
### Problem: QML-based file dialog fails due to deprecated model role usage

This change addresses issues reported in:

- https://github.com/raspberrypi/rpi-imager/issues/1422
- https://github.com/raspberrypi/rpi-imager/issues/1433
- https://github.com/raspberrypi/rpi-imager/issues/1446
- https://github.com/raspberrypi/rpi-imager/issues/1502 
  And maybe a few others.

The native XDG Desktop Portal file dialog requires an active user D-Bus session (at least on Arch-based distros). When no session bus is available, `rpi-imager` correctly falls back to its internal QML-based file picker (`ImFileDialog.qml`). This fallback path is expected and intentional.

However, the fallback file dialog was entirely non-functional due to incorrect use of a Qt model role. As a result, the file list rendered empty and the application emitted repeated QML errors such as:

```
NativeFileDialog: No D-Bus session bus available
qml: OSSelectionListView: Restoring scroll - contentY: 0 savedContentY: 138 contentHeight: 999
qml: OSSelectionListView: Restored to 138
qrc:/qt/qml/RpiImager/qmlcomponents/ImFileDialog.qml:670:35: QML Component: Cannot create delegate
qrc:/qt/qml/RpiImager/qmlcomponents/ImFileDialog.qml:673:29: Required property fileURL was not initialized
qrc:/qt/qml/RpiImager/qmlcomponents/ImFileDialog.qml:475:31: QML Component: Cannot create delegate
qrc:/qt/qml/RpiImager/qmlcomponents/ImFileDialog.qml:478:25: Required property fileURL was not initialized
```

### Root cause

~~The failure was caused by a property name mismatch between the data model and the QML delegates:~~

- ~~`FolderListModel` exposes a role named `fileUrl`~~\
  \~\~[~~https://doc.qt.io/qt-6/qml-qt-labs-folderlistmodel-folderlistmodel.html#details~~](https://doc.qt.io/qt-6/qml-qt-labs-folderlistmodel-folderlistmodel.html#details)
- ~~The delegates in `ImFileDialog.qml` defined a required property named `fileURL`~~

~~Because the property was marked as \`\`, this mismatch caused delegate instantiation to fail for every item, resulting in the errors shown above and a completely empty file picker.~~

To be more precise: the `fileURL` role (uppercase) was actually valid in older Qt versions but has been deprecated since Qt 5.15 and appears to have been removed in Qt 6.10.

\* [Qt 6.9 Docs:](https://doc.qt.io/qt-6.9/qml-qt-labs-folderlistmodel-folderlistmodel.html) List both `fileUrl` and `fileURL (deprecated)`.

\* [Qt 6.10 Docs](https://doc.qt.io/qt-6/qml-qt-labs-folderlistmodel-folderlistmodel.html): List only `fileUrl`.

This explains why the AppImage (built with Qt 6.9) still works despite using the old name, while native builds on newer systems (like Arch with Qt 6.10) fail completely. My fix updates the code to use the modern, supported `fileUrl` role, which ensures compatibility with Qt ≥ 5.15 and future Qt versions.

### Fix

Renamed all occurrences of `fileURL` to `fileUrl` in `src/qmlcomponents/ImFileDialog.qml` to match the roles provided by `FolderListModel`.

### Verification

Built and tested locally. The internal QML file picker now functions correctly when the native file dialog is unavailable.
