### PR TITLE
Fix GenerateTimezones.cmake FALLBACK_FILE path.

### DIFF
--- a/src/cmake/GenerateTimezones.cmake
+++ b/src/cmake/GenerateTimezones.cmake
@@ -42,7 +42,7 @@ if(download_error)
     message(STATUS "Attempting to use fallback timezone list...")
     
     # Try to find a fallback timezone file
-    set(FALLBACK_FILE "${SOURCE_DIR}/timezones.txt.fallback")
+    set(FALLBACK_FILE "${SOURCE_DIR}/timezones.txt")
     if(EXISTS "${FALLBACK_FILE}")
         message(STATUS "Using fallback timezone file: ${FALLBACK_FILE}")
         file(READ "${FALLBACK_FILE}" fallback_content)
@@ -141,7 +141,7 @@ list(LENGTH timezone_list num_timezones)
 message(STATUS "Generated ${num_timezones} timezone entries in ${OUTPUT_FILE}")
 
 # Compare with fallback file if it exists
-set(FALLBACK_FILE "${SOURCE_DIR}/timezones.txt.fallback")
+set(FALLBACK_FILE "${SOURCE_DIR}/timezones.txt")
 if(EXISTS "${FALLBACK_FILE}")
     message(STATUS "Comparing with existing timezone list...")
     


### PR DESCRIPTION
This fixes the build when built in isolation with no access to the internet.

Prior to this patch `rpi-imager` would fail to find its actual FALLBACK_FILE `timezones.txt` in the source as it was seeking `timezones.txt.fallback`.

This results in builds where users are unable to select nor set their timezone within the `rpi-imager` application and being left with a blank dropdown gui element.