### PR TITLE
fix(debian): Add missing GUI library dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,9 @@ Homepage: https://www.raspberrypi.com/software
 Package: rpi-imager
 Build-Profiles: <desktop>
 Architecture: amd64 arm64
-Depends: ${shlibs:Depends}, ${misc:Depends}, dosfstools, fdisk, fuse, libfuse2, util-linux (>= 2.37), pkexec
+Depends: ${shlibs:Depends}, ${misc:Depends}, dosfstools, fdisk, fuse, libfuse2,
+         util-linux (>= 2.37), pkexec,
+         libfontconfig1, libx11-6, libegl1, libgl1
 Recommends: udisks2
 Conflicts: rpi-imager-embedded
 Description: Raspberry Pi Imaging utility


### PR DESCRIPTION
## Summary
- Adds explicit dependencies on `libfontconfig1`, `libx11-6`, `libegl1`, and `libgl1` to the `rpi-imager` desktop deb package
- These libraries are required at runtime by Qt6 GUI applications but are not present on headless systems like Raspberry Pi OS Lite
- Without these, `rpi-imager` fails at launch with `libfontconfig.so.1: cannot open shared object file`

## Test plan
- [ ] Install the built `rpi-imager` deb on Raspberry Pi OS Lite (Trixie) and verify `apt` pulls in the GUI library dependencies
- [ ] Verify `rpi-imager --help` no longer fails with missing shared library errors on a headless system
- [ ] Verify no duplicate dependencies with `${shlibs:Depends}` on a full desktop install

Fixes https://github.com/raspberrypi/rpi-imager/issues/1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)