### PR TITLE
2nd attempt at fixing progress % >100 on local files with a more or less reasonable degree of accuracy

### DIFF
--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -450,7 +450,7 @@ protected:
     QTimer _osListRefreshTimer;
     SuspendInhibitor *_suspendInhibitor;
     DownloadThread *_thread;
-    bool _verifyEnabled, _multipleFilesInZip, _online, _extractSizeKnown;
+    bool _verifyEnabled, _multipleFilesInZip, _online, _extractSizeKnown, _needsDecompressScan;
     QSettings _settings;
     QMap<QString,QString> _translations;
     QTranslator *_trans;

--- a/src/localfileextractthread.h
+++ b/src/localfileextractthread.h
@@ -20,6 +20,7 @@ class LocalFileExtractThread : public DownloadExtractThread
 public:
     explicit LocalFileExtractThread(const QByteArray &url, const QByteArray &dst = "", const QByteArray &expectedHash = "", QObject *parent = nullptr);
     virtual ~LocalFileExtractThread();
+    void setNeedsDecompressScan(bool needs) { _needsDecompressScan = needs; }
 
 protected:
     virtual void _cancelExtract();
@@ -27,6 +28,7 @@ protected:
     virtual ssize_t _on_read(struct archive *a, const void **buff);
     virtual int _on_close(struct archive *a);
     void extractRawImageRun();
+    quint64 _estimateDecompressedSize();
     bool _testArchiveFormat();
     static ssize_t _archive_read_test(struct archive *, void *client_data, const void **buff);
     static int _archive_close_test(struct archive *, void *client_data);
@@ -36,6 +38,7 @@ protected:
 
 private:
     SuspendInhibitor *_suspendInhibitor;
+    bool _needsDecompressScan = false;
 };
 
 #endif // LOCALFILEEXTRACTTHREAD_H


### PR DESCRIPTION
  - For files <4GB, trust the ISIZE value directly.
  - For files >4GB, estimate the decompressed size by sampling ~50MB of compressed data and extrapolating the compression ratio, rather than fully decompressing the file upfront. This avoids the I/O cost of a full decompression pre-scan while still providing reasonable progress tracking. 
  - 50MB should be pretty fast to sample with but is big enough to be accurate. 
  - This still is not going to be perfect but should MOSTLY resolve user complaints (hopefully it just finishes fast enough if it goes over 100% that they wont even notice).