### PR TITLE
fix(capital-cities): Update capital city entries and handling for Hong Kong

### DIFF
--- a/src/capital-cities.txt
+++ b/src/capital-cities.txt
@@ -55,7 +55,6 @@ Cayenne|French Guiana|GF|America/Cayenne|English|us
 Charlotte Amalie|United States Virgin Islands|VI|America/Virgin|English|us
 Chișinău|Moldova|MD|Europe/Chisinau|Romanian|us
 City of San Marino|San Marino|SM|Europe/San_Marino|Italian|it
-City of Victoria|Hong Kong|HK|Asia/Hong_Kong|English|us
 Cockburn Town|Turks and Caicos Islands|TC|America/Grand_Turk|English|us
 Conakry|Guinea|GN|Africa/Conakry|French|fr
 Copenhagen|Denmark|DK|Europe/Copenhagen|Danish|dk
@@ -89,6 +88,7 @@ Hanoi|Vietnam|VN|Asia/Ho_Chi_Minh|Vietnamese|vn
 Harare|Zimbabwe|ZW|Africa/Harare|English|gb
 Havana|Cuba|CU|America/Havana|Spanish|us
 Helsinki|Finland|FI|Europe/Helsinki|Finnish|fi
+Hong Kong|Hong Kong|HK|Asia/Hong_Kong|English|us
 Honiara|Solomon Islands|SB|Pacific/Guadalcanal|English|us
 Islamabad|Pakistan|PK|Asia/Karachi|English|pk
 Jakarta|Indonesia|ID|Asia/Jakarta|Indonesian|id

--- a/src/cmake/GenerateCapitalCities.cmake
+++ b/src/cmake/GenerateCapitalCities.cmake
@@ -371,16 +371,21 @@ foreach(country_obj ${country_objects})
         continue()
     endif()
     
-    # Capital city (first capital if multiple, inside array)
+    # Capital city (first capital if multiple, inside array).
+    # When the API returns an empty capital array (e.g. Macau), fall back to
+    # the territory's common name so it still appears in the list.
     if(country_obj MATCHES "\"capital\" *: *\\[ *\"([^\"]+)\"")
         set(capital "${CMAKE_MATCH_1}")
+    elseif(country_name)
+        set(capital "${country_name}")
     else()
-        # Territories/SARs where the API returns no capital -- use the territory name
-        if(country_code STREQUAL "MO")
-            set(capital "Macau")
-        else()
-            continue()
-        endif()
+        continue()
+    endif()
+
+    # REST Countries API returns "City of Victoria" for Hong Kong, which users
+    # won't recognise. Use "Hong Kong" instead (matches the territory name).
+    if(country_code STREQUAL "HK")
+        set(capital "Hong Kong")
     endif()
     
     # Get keyboard and language using helper functions


### PR DESCRIPTION
- Removed "City of Victoria" from the capital cities list for Hong Kong.
- Added "Hong Kong" as the recognized capital city to improve user familiarity.
- Enhanced CMake logic to handle cases where the API returns empty capital arrays, defaulting to the territory's common name when necessary.