### PR TITLE
fix(ImComboBox): use PlatformHelper for scroll direction in closed ComboBox

### DIFF
--- a/src/qmlcomponents/ImComboBox.qml
+++ b/src/qmlcomponents/ImComboBox.qml
@@ -129,13 +129,13 @@ ComboBox {
             if (!root.popup.visible) {
                 var dy = event.pixelDelta && Math.abs(event.pixelDelta.y) > 0 ? event.pixelDelta.y : event.angleDelta.y
                 
-                // Qt provides deltas that match the system scroll direction (natural vs traditional).
-                // However, for combo boxes (discrete item selection), users expect consistent behavior:
-                // "scroll down gesture" should always mean "next item" regardless of scroll preferences.
+                // Use PlatformHelper.isScrollInverted() instead of event.inverted directly,
+                // because Qt doesn't reliably report the scroll direction on all platforms.
+                // PlatformHelper reads the actual OS setting for accuracy.
                 //
-                // When event.inverted is true (natural scrolling), Qt's deltas are content-oriented,
+                // When natural scrolling is active, Qt's deltas are content-oriented,
                 // which feels backwards for discrete selection. We invert to match user expectations.
-                if (event.inverted) {
+                if (PlatformHelper.isScrollInverted(event.inverted)) {
                     dy = -dy
                 }
                 


### PR DESCRIPTION
- Fix inverted scroll direction for ComboBox dropdowns (timezone, keyboard layout, capital city) on Windows
- Align the closed-state WheelHandler with the popup WheelHandler by using `PlatformHelper.isScrollInverted()` instead of `event.inverted` directly

## Root Cause

`ImComboBox.qml` has two `WheelHandler` blocks:

1. **Closed ComboBox** (line 138) — was using `event.inverted` directly
2. **Open popup list** (line 399) — correctly uses `PlatformHelper.isScrollInverted(event.inverted)`

On Windows, Qt's `event.inverted` flag doesn't reliably reflect the OS scroll direction setting. `PlatformHelper.isScrollInverted()` works around this by reading the actual value from the Windows registry (`PrecisionTouchPad\ScrollDirection`). On macOS/Linux, it passes through `event.inverted` unchanged — so this fix has no behavioral change on those platforms.

Closes #1532