### PR TITLE
Fix compile erorr in platformquirks_linux.cpp

### DIFF
--- a/src/linux/platformquirks_linux.cpp
+++ b/src/linux/platformquirks_linux.cpp
@@ -732,7 +732,8 @@ static QString xmlEscape(const QString& input) {
     result.reserve(input.size() + 16);  // Reserve a bit extra for escapes
     
     for (const QChar& c : input) {
-        switch (c.unicode()) {
+        uint16_t codepoint = c.unicode();
+        switch (codepoint) {
             case '&':  result += QStringLiteral("&amp;");  break;
             case '<':  result += QStringLiteral("&lt;");   break;
             case '>':  result += QStringLiteral("&gt;");   break;
@@ -740,8 +741,8 @@ static QString xmlEscape(const QString& input) {
             case '\'': result += QStringLiteral("&apos;"); break;
             default:
                 // Also escape control characters (except tab, newline, carriage return)
-                if (c.unicode() < 0x20 && c != '\t' && c != '\n' && c != '\r') {
-                    result += QString("&#x%1;").arg(c.unicode(), 0, 16);
+                if (codepoint < 0x20 && c != '\t' && c != '\n' && c != '\r') {
+                    result += QString("&#x%1;").arg(codepoint, 0, 16);
                 } else {
                     result += c;
                 }


### PR DESCRIPTION
I was getting a compile error when running the `create_appimage.sh` script on Ubuntu Linux:
```
/home/andrew/github/raspberrypi/rpi-imager2a/src/linux/platformquirks_linux.cpp: In function ‘QString PlatformQuirks::xmlEscape(const QString&)’:
/home/andrew/github/raspberrypi/rpi-imager2a/src/linux/platformquirks_linux.cpp:744:52: error: no matching function for call to ‘QString::arg(char16_t, int, int)’
  744 |                     result += QString("&#x%1;").arg(c.unicode(), 0, 16);
      |                               ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
In file included from /opt/Qt/6.9.3/gcc_64/include/QtCore/QString:1,
                 from /home/andrew/github/raspberrypi/rpi-imager2a/src/linux/../platformquirks.h:9,
                 from /home/andrew/github/raspberrypi/rpi-imager2a/src/linux/platformquirks_linux.cpp:14:
/opt/Qt/6.9.3/gcc_64/include/QtCore/qstring.h:317:27: note: candidate: ‘template<class T, typename std::enable_if<conjunction_v<std::disjunction<std::is_convertible<T, long long unsigned int>, std::is_convertible<T, long long int> >, std::negation<std::disjunction<std::is_same<typename std::remove_cvref<_Tp>::type, qfloat16>, std::is_floating_point<_Tp> > >, std::negation<std::conjunction<std::negation<QtPrivate::treat_as_integral_arg<typename std::remove_cv< <template-parameter-1-1> >::type> >, std::is_convertible<T, QAnyStringView> > > >, bool>::type <anonymous> > QString QString::arg(T, int, int, QChar) const’
  317 |     [[nodiscard]] QString arg(T a, int fieldWidth = 0, int base = 10,
      |                           ^~~
/opt/Qt/6.9.3/gcc_64/include/QtCore/qstring.h:317:27: note:   template argument deduction/substitution failed:
[snip]
```

This PR fixes that error.

Note that https://doc.qt.io/qt-6/qstring.html#arg-2 says "Note: In Qt versions prior to 6.9, this function was overloaded on various integral types and sometimes incorrectly accepted char and char16_t arguments." which implies that Qt 6.9 **doesn't** accept `char16_t` here. 