### PR TITLE
fix(progress): clamp write and verify progress to 100%

### DIFF
--- a/src/wizard/WritingStep.qml
+++ b/src/wizard/WritingStep.qml
@@ -589,7 +589,7 @@ WizardStepBase {
                 var bytesWrittenMB = Math.round(now / (1024 * 1024))
                 progressText.text = qsTr("Writing... %1 MB written").arg(bytesWrittenMB)
             } else {
-                var progress = total > 0 ? (now / total) * 100 : 0
+                var progress = total > 0 ? Math.min((now / total) * 100, 100) : 0
                 progressBar.value = progress
                 progressText.text = qsTr("Writing... %1%").arg(Math.round(progress))
             }
@@ -601,7 +601,7 @@ WizardStepBase {
             root.isVerifying = true
             root.bottleneckStatus = ""  // Clear write bottleneck during verification
             root.operationWarning = ""  // Clear write warnings during verification
-            var progress = total > 0 ? (now / total) * 100 : 0
+            var progress = total > 0 ? Math.min((now / total) * 100, 100) : 0
             progressBar.value = progress
             progressText.text = qsTr("Verifying... %1%").arg(Math.round(progress))
         }


### PR DESCRIPTION
Clamp the calculated write and verify progress percentage to [0, 100] so the progress bar never exceeds 100%

The async write callback in `DownloadThread` captures `_extractTotal` at the moment each write is queued. If the total is stale or underestimated (e.g. for custom OS images like Batocera), `bytesWritten` can exceed the total, producing percentages like 248%

For `.gz` files >4GB this is already handled via indeterminate progress mode, but other formats with inaccurate size estimates were not covered

## Fix

Add `Math.min(..., 100)` to the progress calculation in both `onWriteProgress` and `onVerifyProgress` handlers in `WritingStep.qml`

Closes #1491