### PR TITLE
fix(wifi): prevent stale WiFi settings from being applied after Skip

### DIFF
--- a/src/customization_generator.cpp
+++ b/src/customization_generator.cpp
@@ -72,9 +72,10 @@ QByteArray CustomisationGenerator::generateSystemdScript(const QVariantMap& s, c
     const QString userPass = s.value("sshUserPassword").toString(); // crypted if present
     const QString sshPublicKey = s.value("sshPublicKey").toString().trimmed();
     const QString sshAuthorizedKeys = s.value("sshAuthorizedKeys").toString().trimmed();
-    const QString ssid = s.value("wifiSSID").toString();
-    const QString cryptedPskFromSettings = s.value("wifiPasswordCrypt").toString();
-    bool hidden = s.value("wifiHidden").toBool();
+    const bool wifiConfigured = s.value("wifiConfigured", true).toBool();
+    const QString ssid = wifiConfigured ? s.value("wifiSSID").toString() : QString();
+    const QString cryptedPskFromSettings = wifiConfigured ? s.value("wifiPasswordCrypt").toString() : QString();
+    bool hidden = wifiConfigured ? s.value("wifiHidden").toBool() : false;
     if (!hidden)
         hidden = s.value("wifiSSIDHidden").toBool();
     const QString wifiCountry = s.value("recommendedWifiCountry").toString().trimmed();
@@ -482,7 +483,8 @@ QByteArray CustomisationGenerator::generateCloudInitUserData(const QVariantMap& 
     // Raspberry Pi Connect token provisioning via cloud-init write_files (store in user's home)
     const bool piConnectEnabled = settings.value("piConnectEnabled").toBool();
     QString cleanToken = piConnectToken.trimmed();
-    const QString ssid = settings.value("wifiSSID").toString();
+    const bool wifiConfigured = settings.value("wifiConfigured", true).toBool();
+    const QString ssid = wifiConfigured ? settings.value("wifiSSID").toString() : QString();
     const QString wifiCountry = settings.value("recommendedWifiCountry").toString().trimmed();
     
     // Determine if we need runcmd section
@@ -554,9 +556,10 @@ QByteArray CustomisationGenerator::generateCloudInitNetworkConfig(const QVariant
         }
     };
     
-    const QString ssid = settings.value("wifiSSID").toString();
-    const QString cryptedPskFromSettings = settings.value("wifiPasswordCrypt").toString();
-    const bool hidden = settings.value("wifiHidden").toBool();
+    const bool wifiConfigured = settings.value("wifiConfigured", true).toBool();
+    const QString ssid = wifiConfigured ? settings.value("wifiSSID").toString() : QString();
+    const QString cryptedPskFromSettings = wifiConfigured ? settings.value("wifiPasswordCrypt").toString() : QString();
+    const bool hidden = wifiConfigured ? settings.value("wifiHidden").toBool() : false;
     const QString regDom = settings.value("recommendedWifiCountry").toString().trimmed().toUpper();
     
     // Always generate network config with eth0 DHCP configuration

--- a/src/wizard/WizardContainer.qml
+++ b/src/wizard/WizardContainer.qml
@@ -777,6 +777,8 @@ Item {
             // Before entering the writing step, apply customization (when supported)
             if (nextIndex === stepWriting) {
                 if (customizationSupported && imageWriter) {
+                    // Pass session flags so the generator can skip unconfigured sections
+                    customizationSettings.wifiConfigured = wifiConfigured
                     // Pass the complete customizationSettings object directly to the generator
                     // This includes both persistent settings (hostname, wifi, etc.) and
                     // ephemeral settings (piConnectEnabled) from the current wizard session


### PR DESCRIPTION
When a user previously configured WiFi and later skips customization (e.g. for an ETH0-only headless build), the WiFi settings from the previous session were silently applied to the image

`customizationSettings` is loaded from persistent storage (QSettings) at app startup. When the user clicks "Skip" on any customization step, the runtime flags (`wifiConfigured = false`) are cleared but the WiFi keys (`wifiSSID`, `wifiPasswordCrypt`, `wifiHidden`) remain in `customizationSettings`. The customization generator checks `wifiSSID` directly - not the `wifiConfigured` flag - so it applies the stale WiFi config

This is the same class of bug as #1520 (USB Gadget Mode persistence)

## Fix

Before calling `applyCustomisationFromSettings()`, strip WiFi keys from `customizationSettings` when `wifiConfigured` is `false`. This is done centrally in `WizardContainer.qml` at the writing step entry point, covering all Skip paths

Closes #1326