### PR TITLE
chore: add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ obj-**
 # IDE Configurations
 .vscode
 .zed
+.idea
 
 # Debian packaging
 debian/rpi-imager/**


### PR DESCRIPTION
.idea (JetBrains IDEs: CLion, IntelliJ, etc.) was missing from the 
IDE Configurations section of .gitignore. Added alongside .vscode and .zed.