### PR TITLE
ISSUE-1373: Added wired ethernet only option

### DIFF
--- a/src/wizard/WifiCustomizationStep.qml
+++ b/src/wizard/WifiCustomizationStep.qml
@@ -25,6 +25,7 @@ WizardStepBase {
     function ssidUnchanged(ssid, prev) { return (ssid || "") === (prev || "") }
     
     title: qsTr("Customisation: Choose Wi‑Fi")
+    subtitle: qsTr("If you will use a network cable only, you can skip Wi‑Fi setup below.")
     showSkipButton: true
     nextButtonAccessibleDescription: qsTr("Save Wi-Fi settings and continue to next customisation step")
     backButtonAccessibleDescription: qsTr("Return to previous step")
@@ -35,9 +36,19 @@ WizardStepBase {
     // Track whether we've already auto-detected SSID/PSK to avoid re-prompting
     property bool ssidAutoDetected: false
 
+    function useWiredEthernetOnly() {
+        fieldWifiSSID.text = ""
+        fieldWifiPassword.text = ""
+        fieldWifiPasswordConfirm.text = ""
+        chkWifiHidden.checked = false
+        wifiMode = "secure"
+        updatePasswordFieldUI()
+        root.nextClicked()
+    }
+
     Component.onCompleted: {
         root.registerFocusGroup("wifi_modes", function() {
-            return [tabSecure, tabOpen]
+            return [btnUseEthernet, tabSecure, tabOpen]
         }, 0)
         // Labels are automatically skipped when screen reader is not active (via activeFocusOnTab)
         root.registerFocusGroup("wifi_fields", function(){
@@ -52,14 +63,10 @@ WizardStepBase {
         }, 1)
         root.registerFocusGroup("wifi_options", function(){ return [chkWifiHidden] }, 2)
 
-        // Set SSID placeholder before prefilling text content
         fieldWifiSSID.placeholderText = qsTr("Network name")
 
         // Prefill from conserved customization settings
         var settings = wizardContainer.customizationSettings
-
-        // Set SSID placeholder first (before setting any text)
-        fieldWifiSSID.placeholderText = qsTr("Network name")
 
         // Then set text values after, so they properly override the placeholder
         if (settings.wifiSSID) {
@@ -232,6 +239,20 @@ WizardStepBase {
             width: wifiScroll.availableWidth
 
             WizardSectionContainer {
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Style.spacingSmall
+
+                    ImButton {
+                        id: btnUseEthernet
+                        text: qsTr("Use wired Ethernet only")
+                        accessibleDescription: qsTr("Clear Wi-Fi settings and continue to the next step. Other customisation settings are kept.")
+                        onClicked: root.useWiredEthernetOnly()
+                    }
+
+                    Item { Layout.fillWidth: true }
+                }
+
                 RowLayout {
                     Layout.fillWidth: true
                     spacing: Style.spacingSmall


### PR DESCRIPTION
## Summary

Improves the Wi‑Fi customisation step so users who only need Ethernet can skip Wi‑Fi setup without clearing fields manually or confusing it with **Skip customisation** (which skips all OS customisation).

Closes https://github.com/raspberrypi/rpi-imager/issues/1373

## Changes

- Short **subtitle** explaining that a wired-only setup can skip Wi‑Fi on this screen.
- **Use wired Ethernet only** button that clears SSID/password/hidden-SSID state, resets secure/open mode appropriately, and continues with the same behaviour as **Next** with an empty SSID (no Wi‑Fi in the written image; other customisation unchanged).
- **Keyboard / screen reader**: new focus group so the control fits the existing wizard focus order.

## Testing

- [ ] Open OS customisation → Wi‑Fi step; use **Use wired Ethernet only** and confirm the write summary shows no Wi‑Fi when expected.
- [ ] Confirm **Skip customisation** still skips all customisation and jumps to writing as before.
