### PR TITLE
Ignore drives with .rpiignore

### DIFF
--- a/src/drivelistmodel.cpp
+++ b/src/drivelistmodel.cpp
@@ -8,6 +8,7 @@
 #include "drivelist/drivelist.h"
 #include <QSet>
 #include <QDebug>
+#include <QFile>
 
 DriveListModel::DriveListModel(QObject *parent)
     : QAbstractListModel(parent)
@@ -116,6 +117,17 @@ void DriveListModel::processDriveList(std::vector<Drivelist::DeviceDescriptor> l
 
         // Should already be caught by isSystem variable, but just in case...
         if (mountpoints.contains("/") || mountpoints.contains("C://"))
+            continue;
+
+        // Hide drives that have an .rpiignore file on any mountpoint
+        bool hasRpiIgnore = false;
+        for (const auto &mountpoint : mountpoints) {
+            if (QFile::exists(mountpoint + "/.rpiignore")) {
+                hasRpiIgnore = true;
+                break;
+            }
+        }
+        if (hasRpiIgnore)
             continue;
 
         bool isRpibootDevice = i.isRpiboot;


### PR DESCRIPTION
Really simple request; I'd like the Imager to never show me external drives which have an `.rpiignore` file at the root.

The reason is that I have an external drive permanently attached to my Mac, and every time I use the Imager I'm paranoid I'll zap this drive by mistake. It hasn't happened yet! But a simple check for this empty file on the root would make me a lot happier, and I think others may find it helpful too.