### PR TITLE
WritingStep.qml: add missing import

### DIFF
--- a/src/wizard/WritingStep.qml
+++ b/src/wizard/WritingStep.qml
@@ -5,6 +5,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Material
 import QtQuick.Layouts
 import "../qmlcomponents"
 


### PR DESCRIPTION
While I can successfully build from source on Arch Linux, I get
```
QQmlApplicationEngine failed to load component
qrc:/qt/qml/RpiImager/main.qml:107:9: Type WizardContainer unavailable
qrc:/qt/qml/RpiImager/wizard/WizardContainer.qml:1143:9: Type WritingStep unavailable
qrc:/qt/qml/RpiImager/wizard/WritingStep.qml:332:17: Non-existent attached object
```
when running the compiled program. Clearly this is not a problem in your/other build environments, but adding this import fixes it on mine.