### PR TITLE
fix: prefer kreadconfig6 with fallback to kreadconfig5

### DIFF
--- a/src/linux/platformquirks_linux.cpp
+++ b/src/linux/platformquirks_linux.cpp
@@ -1299,7 +1299,8 @@ bool prefersReducedMotion() {
 
     // KDE Plasma 5.67+: AnimationDurationFactor=0 disables animations
     {
-        const QString bin = QStringLiteral("/usr/bin/kreadconfig5");
+        const QString sessionVersion = qEnvironmentVariable("KDE_SESSION_VERSION");
+        const QString bin = QStringLiteral("/usr/bin/kreadconfig") + sessionVersion;
         if (QFileInfo::exists(bin)) {
             QProcess kreadconfig;
             kreadconfig.start(bin, {"--group", "KDE", "--key", "AnimationDurationFactor"});

--- a/src/linux/platformquirks_linux.cpp
+++ b/src/linux/platformquirks_linux.cpp
@@ -1298,9 +1298,12 @@ bool prefersReducedMotion() {
     }
 
     // KDE Plasma 5.67+: AnimationDurationFactor=0 disables animations
+    // Prefer kreadconfig6 (Plasma 6), fallback to kreadconfig5 (Plasma 5).
     {
-        const QString sessionVersion = qEnvironmentVariable("KDE_SESSION_VERSION");
-        const QString bin = QStringLiteral("/usr/bin/kreadconfig") + sessionVersion;
+        QString bin = QStringLiteral("/usr/bin/kreadconfig6");
+        if(!QFileInfo::exists(bin)) {
+            bin = QStringLiteral("/usr/bin/kreadconfig5");
+        }
         if (QFileInfo::exists(bin)) {
             QProcess kreadconfig;
             kreadconfig.start(bin, {"--group", "KDE", "--key", "AnimationDurationFactor"});


### PR DESCRIPTION
Previously hardcoded kreadconfig5, which fails on KDE Plasma 6.
Now tries kreadconfig6 first, falls back to kreadconfig5 if not found.