### PR TITLE
Don't show progress in percent if determining the extracted size failed.

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -521,6 +521,7 @@ void ImageWriter::setSrc(const QUrl &url, quint64 downloadLen, quint64 extrLen, 
     _downloadLen = downloadLen;
     _expectedHash = expectedHash;
     _extractSizeKnown = false;
+    _extrLen = extrLen;
     _multipleFilesInZip = multifilesinzip;
     _parentCategory = parentcategory;
     _osName = osname;

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -563,6 +563,11 @@ void ImageWriter::setSrc(const QUrl &url, quint64 downloadLen, quint64 extrLen, 
         else
             _parseCompressedFile();
     }
+
+    // If _extrLen is still not set we do not know the extracted size
+    // and cannot show progress as a percentage.
+    if (!_extrLen)
+        _extractSizeKnown = false;
 }
 
 /* Set device to write to */

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -519,18 +519,14 @@ void ImageWriter::setSrc(const QUrl &url, quint64 downloadLen, quint64 extrLen, 
 {
     _src = url;
     _downloadLen = downloadLen;
-    _extrLen = extrLen;
     _expectedHash = expectedHash;
+    _extractSizeKnown = false;
     _multipleFilesInZip = multifilesinzip;
     _parentCategory = parentcategory;
     _osName = osname;
     _initFormat = (initFormat == "none") ? "" : initFormat;
     _osReleaseDate = releaseDate;
     _bmapUrl = bmapUrl;
-    // Gzip ISIZE is 32-bit, so uncompressed size is unreliable for files >4GB.
-    // When no trusted extract size is provided by the manifest, mark it so the
-    // UI can show indeterminate progress instead of a misleading percentage.
-    _extractSizeKnown = !(!_extrLen && url.toString().toLower().endsWith(".gz"));
 
     qDebug() << "setSrc: initFormat parameter:" << initFormat << "-> _initFormat set to:" << _initFormat;
 
@@ -541,7 +537,7 @@ void ImageWriter::setSrc(const QUrl &url, quint64 downloadLen, quint64 extrLen, 
     }
 
     // Parse local compressed files to estimate _extrLen for capacity checks.
-    if (!_extrLen && _src.isLocalFile())
+    if (!extrLen && _src.isLocalFile())
     {
         QString lowercaseurl = _src.toLocalFile().toLower();
         bool compressed = lowercaseurl.endsWith(".zip") ||
@@ -564,10 +560,12 @@ void ImageWriter::setSrc(const QUrl &url, quint64 downloadLen, quint64 extrLen, 
             _parseCompressedFile();
     }
 
-    // If _extrLen is still not set we do not know the extracted size
-    // and cannot show progress as a percentage.
-    if (!_extrLen)
-        _extractSizeKnown = false;
+    // Gzip ISIZE is 32-bit, so uncompressed size is unreliable for files >4GB.
+    // The only extract size we can trust when calculating progress for gzipped
+    // images is the size provided by the manifest.
+    if (extrLen
+        || (_extrLen && !url.toString().toLower().endsWith(".gz")))
+        _extractSizeKnown = true;
 }
 
 /* Set device to write to */


### PR DESCRIPTION
I have an xz compressed archive that flashes fine, but determining the extracted size failed for some reason so I got 150% progress reported in flashing. The reason for the failed size extraction is also interesting, but nevertheless the progress display should be more robust. With this fix, the absolute size written is displayed instead of a false percentage. Also tested that the percentage is still displayed when the size extraction was successful.
