### PR TITLE
Backport customization, font logging, and macOS DA fixes from dev/tdewey/2.1

### DIFF
--- a/src/customization_generator.cpp
+++ b/src/customization_generator.cpp
@@ -4,11 +4,17 @@
  */
 
 #include "customization_generator.h"
+#include "dependencies/sha256crypt/sha256crypt.h"
+#include "dependencies/yescrypt/yescrypt_wrapper.h"
 #include <QPasswordDigestor>
 #include <QCryptographicHash>
+#include <QDate>
+#include <QDateTime>
 #include <QRegularExpression>
 #include <QStringList>
 #include <QStringConverter>
+#include <QDebug>
+#include <random>
 
 namespace rpi_imager {
 
@@ -68,6 +74,92 @@ QString CustomisationGenerator::shellQuote(const QString& value) {
 
 QString CustomisationGenerator::pbkdf2(const QByteArray& password, const QByteArray& ssid) {
     return QPasswordDigestor::deriveKeyPbkdf2(QCryptographicHash::Sha1, password, ssid, 4096, 32).toHex();
+}
+
+QString CustomisationGenerator::cryptPassword(const QByteArray& passwordInput, const QString& osReleaseDate) {
+    // Strip CR/LF before hashing. Pasted clipboard content can carry a trailing
+    // newline (single-line text fields do not sanitise pasted text), and PAM
+    // always discards the line terminator when reading a password. Hashing the
+    // raw value would then produce a hash that can never be matched at login
+    // (see issue #1627). These characters can never form part of a usable
+    // password, so removing them everywhere is safe.
+    QByteArray password = passwordInput;
+    password.removeIf([](char c) { return c == '\r' || c == '\n'; });
+
+    const QByteArray saltchars =
+      "./0123456789ABCDEFGHIJKLMNOPQRST"
+      "UVWXYZabcdefghijklmnopqrstuvwxyz";
+    std::mt19937 gen(static_cast<unsigned>(QDateTime::currentMSecsSinceEpoch()));
+    std::uniform_int_distribution<> uid(0, saltchars.length() - 1);
+
+    if (osUsesYescrypt(osReleaseDate)) {
+        QByteArray salt;
+        for (int i = 0; i < 16; i++)  // yescrypt uses longer salts
+            salt += saltchars[uid(gen)];
+
+        char *result = yescrypt_crypt(password.constData(), salt.constData());
+        return result ? QString(result) : QString();
+    }
+
+    QByteArray salt = "$5$";
+    for (int i = 0; i < 10; i++)
+        salt += saltchars[uid(gen)];
+
+    return sha256_crypt(password.constData(), salt.constData());
+}
+
+bool CustomisationGenerator::osUsesYescrypt(const QString& osReleaseDate) {
+    if (osReleaseDate.isEmpty())
+        return false;
+    const QDate releaseDate = QDate::fromString(osReleaseDate, "yyyy-MM-dd");
+    const QDate cutoffDate(2023, 1, 1);
+    return releaseDate.isValid() && releaseDate >= cutoffDate;
+}
+
+bool CustomisationGenerator::isYescryptHash(const QString& cryptHash) {
+    // We only ever emit "$y$" (yescrypt) or "$5$" (sha256crypt). "$7$" is the
+    // other yescrypt/scrypt prefix the wrapper accepts, so treat it as yescrypt too.
+    return cryptHash.startsWith(QStringLiteral("$y$"))
+        || cryptHash.startsWith(QStringLiteral("$7$"));
+}
+
+QString CustomisationGenerator::resolveUserPasswordCrypt(const QVariantMap& settings) {
+    const QString plain = settings.value(QStringLiteral("sshUserPasswordPlain")).toString();
+    if (!plain.isEmpty()) {
+        const QString releaseDate = settings.value(QStringLiteral("osReleaseDate")).toString();
+        return cryptPassword(plain.toUtf8(), releaseDate);
+    }
+    // Already-crypted password reused from saved settings. The UI is expected to
+    // have invalidated any hash that is incompatible with the selected OS (a
+    // yescrypt hash cannot authenticate on a pre-2023 image); if one slips
+    // through here - e.g. the OS was changed after the user step was skipped -
+    // log it loudly, since we have no plaintext left to re-hash.
+    const QString crypted = settings.value(QStringLiteral("sshUserPassword")).toString();
+    if (!crypted.isEmpty() && isYescryptHash(crypted)
+        && !osUsesYescrypt(settings.value(QStringLiteral("osReleaseDate")).toString())) {
+        qWarning() << "Account password hash is yescrypt but the selected OS predates "
+                      "yescrypt support; login may fail. The password should have been "
+                      "re-entered for this OS.";
+    }
+    return crypted;
+}
+
+QString CustomisationGenerator::resolveWifiPskCrypt(const QVariantMap& settings, const QByteArray& ssidOctets, bool wifiConfigured) {
+    if (!wifiConfigured)
+        return {};
+
+    const QString crypted = settings.value(QStringLiteral("wifiPasswordCrypt")).toString();
+    if (!crypted.isEmpty())
+        return crypted;
+
+    const QString plain = settings.value(QStringLiteral("wifiPassword")).toString();
+    if (plain.isEmpty())
+        return {};
+
+    // Passphrase length per WPA spec is 8..63; anything else is taken to be a
+    // pre-computed 64-hex-digit PSK (or open-network sentinel) and passed through.
+    const bool isPassphrase = (plain.length() >= 8 && plain.length() < 64);
+    return isPassphrase ? pbkdf2(plain.toUtf8(), ssidOctets) : plain;
 }
 
 QByteArray CustomisationGenerator::yamlEscapeSsidOctets(const QByteArray& value)
@@ -146,26 +238,18 @@ QByteArray CustomisationGenerator::generateSystemdScript(const QVariantMap& s, c
     const bool sshEnabled = s.value("sshEnabled").toBool();
     const bool sshPasswordAuth = s.value("sshPasswordAuth").toBool();
     const QString userName = s.value("sshUserName").toString().trimmed();
-    const QString userPass = s.value("sshUserPassword").toString(); // crypted if present
+    const QString userPass = resolveUserPasswordCrypt(s); // crypted (hashes plaintext if present)
     const QString sshPublicKey = s.value("sshPublicKey").toString().trimmed();
     const QString sshAuthorizedKeys = s.value("sshAuthorizedKeys").toString().trimmed();
     const bool wifiConfigured = s.value("wifiConfigured", true).toBool();
     const QByteArray ssidOctets = ssidOctetsFromSettings(s, wifiConfigured);
-    const QString cryptedPskFromSettings = wifiConfigured ? s.value("wifiPasswordCrypt").toString() : QString();
     bool hidden = wifiConfigured ? s.value("wifiHidden").toBool() : false;
     if (!hidden)
         hidden = s.value("wifiSSIDHidden").toBool();
     const QString wifiCountry = s.value("recommendedWifiCountry").toString().trimmed();
-    
-    // Prefer persisted crypted PSK; fallback to deriving from legacy plaintext setting
-    QString cryptedPsk = cryptedPskFromSettings;
-    if (cryptedPsk.isEmpty()) {
-        const QString legacyPwd = s.value("wifiPassword").toString();
-        if (!legacyPwd.isEmpty()) {
-            const bool isPassphrase = (legacyPwd.length() >= 8 && legacyPwd.length() < 64);
-            cryptedPsk = isPassphrase ? pbkdf2(legacyPwd.toUtf8(), ssidOctets) : legacyPwd;
-        }
-    }
+
+    // Crypted PSK: prefer a pre-derived value, else derive from the plaintext passphrase.
+    const QString cryptedPsk = resolveWifiPskCrypt(s, ssidOctets, wifiConfigured);
     
     // Prepare SSH key arguments for imager_custom
     QStringList keyList;
@@ -451,7 +535,7 @@ QByteArray CustomisationGenerator::generateCloudInitUserData(const QVariantMap& 
     
     const bool sshPasswordAuth = settings.value("sshPasswordAuth").toBool();
     const QString userName = settings.value("sshUserName").toString().trimmed();
-    const QString userPass = settings.value("sshUserPassword").toString(); // expected crypted if present
+    const QString userPass = resolveUserPasswordCrypt(settings); // crypted (hashes plaintext if present)
     const QString sshPublicKey = settings.value("sshPublicKey").toString().trimmed();
     const QString sshAuthorizedKeys = settings.value("sshAuthorizedKeys").toString().trimmed();
     const bool passwordlessSudo = settings.value("passwordlessSudo").toBool();
@@ -681,7 +765,6 @@ QByteArray CustomisationGenerator::generateCloudInitNetworkConfig(const QVariant
     
     const bool wifiConfigured = settings.value("wifiConfigured", true).toBool();
     const QByteArray ssidOctets = ssidOctetsFromSettings(settings, wifiConfigured);
-    const QString cryptedPskFromSettings = wifiConfigured ? settings.value("wifiPasswordCrypt").toString() : QString();
     const bool hidden = wifiConfigured ? settings.value("wifiHidden").toBool() : false;
     const QString regDom = settings.value("recommendedWifiCountry").toString().trimmed().toUpper();
     
@@ -721,15 +804,8 @@ QByteArray CustomisationGenerator::generateCloudInitNetworkConfig(const QVariant
         if (hidden) {
             push(QStringLiteral("          hidden: true"), netcfg);
         }
-        // Prefer persisted crypted PSK; fallback to deriving from legacy plaintext setting
-        QString effectiveCryptedPsk = cryptedPskFromSettings;
-        if (effectiveCryptedPsk.isEmpty()) {
-            const QString legacyPwd = settings.value("wifiPassword").toString();
-            if (!legacyPwd.isEmpty()) {
-                const bool isPassphrase = (legacyPwd.length() >= 8 && legacyPwd.length() < 64);
-                effectiveCryptedPsk = isPassphrase ? pbkdf2(legacyPwd.toUtf8(), ssidOctets) : legacyPwd;
-            }
-        }
+        // Crypted PSK: prefer a pre-derived value, else derive from the plaintext passphrase.
+        QString effectiveCryptedPsk = resolveWifiPskCrypt(settings, ssidOctets, wifiConfigured);
         if (effectiveCryptedPsk.isEmpty()) {
             // Open network (no password) - use auth block with key-management: none
             // See: https://github.com/raspberrypi/rpi-imager/issues/1396

--- a/src/customization_generator.h
+++ b/src/customization_generator.h
@@ -72,6 +72,59 @@ public:
      */
     static QByteArray ssidOctetsFromSettings(const QVariantMap& settings, bool wifiConfigured);
 
+    // -------------------------------------------------------------------
+    // Credential derivation
+    //
+    // This class is the single home for turning a plaintext secret into the
+    // form that ends up in the generated artifacts. Keep all password/PSK
+    // hashing here so the UI layer never touches crypto and there is exactly
+    // one implementation of each algorithm.
+    // -------------------------------------------------------------------
+
+    /**
+     * @brief Hash a plaintext account password for /etc/shadow-style consumers.
+     *
+     * Picks yescrypt for OS images released on/after 2023-01-01 and sha256crypt
+     * otherwise. CR/LF are stripped first: pasted secrets can carry a trailing
+     * newline that PAM discards at login, which would otherwise yield a hash
+     * that never matches (issue #1627).
+     *
+     * @param password Plaintext password (UTF-8 bytes)
+     * @param osReleaseDate Target OS release date in "yyyy-MM-dd" form (may be empty)
+     * @return crypt(3)-style hash string, or empty on failure
+     */
+    static QString cryptPassword(const QByteArray& password, const QString& osReleaseDate);
+
+    /**
+     * @brief Derive a WPA PSK from a passphrase (PBKDF2-HMAC-SHA1, 4096 iters).
+     *
+     * @param password Plaintext Wi-Fi passphrase (UTF-8 bytes)
+     * @param ssid SSID octets used as the PBKDF2 salt
+     * @return Hex-encoded 32-byte PSK
+     */
+    static QString pbkdf2(const QByteArray& password, const QByteArray& ssid);
+
+    /**
+     * @brief Whether the OS image's release date selects yescrypt over sha256crypt.
+     *
+     * yescrypt is used for images released on/after 2023-01-01; older (or
+     * undated) images get sha256crypt, which every target understands. This is
+     * the single source of truth for the algorithm decision, shared by
+     * cryptPassword() and the hash-compatibility check.
+     */
+    static bool osUsesYescrypt(const QString& osReleaseDate);
+
+    /**
+     * @brief Whether a crypt() hash string is a yescrypt hash.
+     *
+     * crypt strings are self-describing via their "$id$" prefix, so the
+     * algorithm never needs to be stored separately: yescrypt hashes begin with
+     * "$y$" (we only ever emit "$y$" or sha256crypt's "$5$"). A yescrypt hash is
+     * unusable on images that predate yescrypt support, whereas sha256crypt is
+     * accepted everywhere - so only yescrypt hashes need a compatibility check.
+     */
+    static bool isYescryptHash(const QString& cryptHash);
+
 private:
     /**
      * @brief Shell-quote a string for safe use in bash scripts
@@ -80,16 +133,27 @@ private:
      * @return Quoted string safe for shell use
      */
     static QString shellQuote(const QString& value);
-    
+
     /**
-     * @brief Generate password hash using pbkdf2
-     * 
-     * @param password Plain text password
-     * @param ssid SSID for WiFi password hashing
-     * @return Hashed password
+     * @brief Resolve the crypted account password from settings.
+     *
+     * Prefers a freshly entered plaintext password ("sshUserPasswordPlain"),
+     * hashing it with cryptPassword() using "osReleaseDate"; otherwise falls
+     * back to an already-crypted value carried in "sshUserPassword" (e.g. a
+     * password reused from saved settings).
      */
-    static QString pbkdf2(const QByteArray& password, const QByteArray& ssid);
-    
+    static QString resolveUserPasswordCrypt(const QVariantMap& settings);
+
+    /**
+     * @brief Resolve the crypted Wi-Fi PSK from settings.
+     *
+     * Prefers an already-derived PSK ("wifiPasswordCrypt"); otherwise derives
+     * one from the plaintext "wifiPassword" using the SSID octets as salt. A
+     * value that is not a passphrase length (8..63) is treated as a raw PSK and
+     * passed through unchanged.
+     */
+    static QString resolveWifiPskCrypt(const QVariantMap& settings, const QByteArray& ssidOctets, bool wifiConfigured);
+
     static QString yamlEscapeString(const QString& value);
 };
 

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -13,8 +13,6 @@
 #include "drivelistitem.h"
 #include "customization_generator.h"
 #include "drivelist/drivelist.h"
-#include "dependencies/sha256crypt/sha256crypt.h"
-#include "dependencies/yescrypt/yescrypt_wrapper.h"
 #include "driveformatthread.h"
 #include "localfileextractthread.h"
 #include "systemmemorymanager.h"
@@ -69,7 +67,6 @@
 #include <QDebug>
 #include <QJsonObject>
 #include <QTranslator>
-#include <QPasswordDigestor>
 #include <QVersionNumber>
 #include <QCryptographicHash>
 #include <QRandomGenerator>
@@ -3882,11 +3879,17 @@ void ImageWriter::applyCustomisationFromSettings(const QVariantMap &settings)
         return;
     }
 
+    // Make the selected OS release date available to the generator so it can
+    // choose the right password hashing algorithm (yescrypt vs sha256crypt)
+    // when hashing a freshly entered plaintext password at generation time.
+    QVariantMap s = settings;
+    s.insert(QStringLiteral("osReleaseDate"), _osReleaseDate);
+
     if (_initFormat == "systemd") {
-        _applySystemdCustomisationFromSettings(settings);
+        _applySystemdCustomisationFromSettings(s);
     } else {
         // customisation for cloudinit and cloudinit-rpi
-        _applyCloudInitCustomisationFromSettings(settings);
+        _applyCloudInitCustomisationFromSettings(s);
     }
 }
 
@@ -3957,46 +3960,37 @@ void ImageWriter::_applyCloudInitCustomisationFromSettings(const QVariantMap &s)
     setImageCustomisation(QByteArray(), cmdlineAppend, QByteArray(), cloud, netcfg, advOpts);
 }
 
-QString ImageWriter::crypt(const QByteArray &password)
+QString ImageWriter::hashUserPassword(const QString &plaintext)
 {
-    QByteArray saltchars =
-      "./0123456789ABCDEFGHIJKLMNOPQRST"
-      "UVWXYZabcdefghijklmnopqrstuvwxyz";
-    std::mt19937 gen(static_cast<unsigned>(QDateTime::currentMSecsSinceEpoch()));
-    std::uniform_int_distribution<> uid(0, saltchars.length()-1);
-
-    // Determine whether to use yescrypt (for OS released after Jan 1, 2023) or sha256crypt
-    bool useYescrypt = false;
-    if (!_osReleaseDate.isEmpty()) {
-        // Parse release date in format "YYYY-MM-DD"
-        QDate releaseDate = QDate::fromString(_osReleaseDate, "yyyy-MM-dd");
-        QDate cutoffDate(2023, 1, 1);
-        if (releaseDate.isValid() && releaseDate >= cutoffDate) {
-            useYescrypt = true;
-        }
-    }
-
-    if (useYescrypt) {
-        // Use yescrypt for newer OS releases
-        QByteArray salt;
-        for (int i=0; i<16; i++)  // yescrypt uses longer salts
-            salt += saltchars[uid(gen)];
-        
-        char *result = yescrypt_crypt(password.constData(), salt.constData());
-        return result ? QString(result) : QString();
-    } else {
-        // Use sha256crypt for older OS releases
-        QByteArray salt = "$5$";
-        for (int i=0; i<10; i++)
-            salt += saltchars[uid(gen)];
-        
-        return sha256_crypt(password.constData(), salt.constData());
-    }
+    // Hash eagerly so the caller can discard the plaintext immediately and keep
+    // only the hash. The algorithm choice (yescrypt vs sha256crypt) follows the
+    // currently selected OS's release date. Crypto lives in CustomisationGenerator.
+    if (plaintext.isEmpty())
+        return QString();
+    return rpi_imager::CustomisationGenerator::cryptPassword(plaintext.toUtf8(), _osReleaseDate);
 }
 
-QString ImageWriter::pbkdf2(const QByteArray &psk, const QByteArray &ssid)
+bool ImageWriter::savedUserPasswordUsableWithCurrentOs(const QString &cryptHash) const
 {
-    return QPasswordDigestor::deriveKeyPbkdf2(QCryptographicHash::Sha1, psk, ssid, 4096, 32).toHex();
+    if (cryptHash.isEmpty())
+        return true;
+    // sha256crypt is accepted on every target; only a yescrypt hash can be
+    // incompatible, and only when the selected OS predates yescrypt support.
+    if (!rpi_imager::CustomisationGenerator::isYescryptHash(cryptHash))
+        return true;
+    return rpi_imager::CustomisationGenerator::osUsesYescrypt(_osReleaseDate);
+}
+
+QString ImageWriter::deriveWifiPsk(const QString &ssid, const QString &plaintext)
+{
+    if (plaintext.isEmpty())
+        return QString();
+    // Passphrase length per WPA spec is 8..63; anything else is taken to be a
+    // pre-computed PSK and returned verbatim.
+    const bool isPassphrase = (plaintext.length() >= 8 && plaintext.length() < 64);
+    return isPassphrase
+        ? rpi_imager::CustomisationGenerator::pbkdf2(plaintext.toUtf8(), ssid.toUtf8())
+        : plaintext;
 }
 
 QString ImageWriter::wifiSsidOctetsBase64(const QString &ssid) const

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -335,9 +335,24 @@ public:
     Q_INVOKABLE bool imageSupportsCustomization();
     Q_INVOKABLE bool imageSupportsCcRpi();
 
-    Q_INVOKABLE QString crypt(const QByteArray &password);
-    Q_INVOKABLE QString pbkdf2(const QByteArray &psk, const QByteArray &ssid);
+    // Derive account/Wi-Fi credentials from plaintext for the UI. Hashing is
+    // delegated to CustomisationGenerator (the single home for credential
+    // derivation); the UI hands over plaintext, gets back only the hashed/derived
+    // form, and never retains the plaintext in long-lived state. This keeps the
+    // plaintext's RAM lifetime bounded to the input field (needed for the
+    // show-password toggle) and guarantees only hashes reach disk or the
+    // generator. Both return an empty string for empty input.
+    Q_INVOKABLE QString hashUserPassword(const QString &plaintext);
+    Q_INVOKABLE QString deriveWifiPsk(const QString &ssid, const QString &plaintext);
     Q_INVOKABLE QString wifiSsidOctetsBase64(const QString &ssid) const;
+
+    // Whether a stored account-password hash can authenticate on the currently
+    // selected OS. The crypt string is self-describing, so we never store the
+    // algorithm separately: a yescrypt hash ("$y$") only works on images that
+    // support it (release date >= 2023-01-01), while sha256crypt works
+    // everywhere. The UI uses this to invalidate a restored/stale hash and force
+    // re-entry when the user targets an older OS. Empty input is "compatible".
+    Q_INVOKABLE bool savedUserPasswordUsableWithCurrentOs(const QString &cryptHash) const;
 
     Q_INVOKABLE QStringList getTranslations();
     Q_INVOKABLE QString getCurrentLanguage();

--- a/src/linux/platformquirks_linux.cpp
+++ b/src/linux/platformquirks_linux.cpp
@@ -1912,6 +1912,11 @@ qreal fontDpiCorrection()
     return 72.0 / 96.0;
 }
 
+void logFontEngine()
+{
+    qDebug() << "Font engine: freetype (fontconfig)";
+}
+
 namespace {
 
 // Connected display, as read from /sys/class/drm. Physical dimensions are

--- a/src/mac/platformquirks_macos.mm
+++ b/src/mac/platformquirks_macos.mm
@@ -491,4 +491,9 @@ qreal fontDpiCorrection()
     return 1.0;
 }
 
+void logFontEngine()
+{
+    qDebug() << "Font engine: Core Text";
+}
+
 } // namespace PlatformQuirks

--- a/src/mac/platformquirks_macos.mm
+++ b/src/mac/platformquirks_macos.mm
@@ -112,7 +112,6 @@ namespace {
         DiskOpContext* ctx = static_cast<DiskOpContext*>(context);
         ctx->result = translateDissenter(dissenter);
         ctx->completed = true;
-        CFRunLoopStop(CFRunLoopGetCurrent());
     }
     
     void ejectCallback(DADiskRef disk, DADissenterRef dissenter, void* context) {
@@ -120,7 +119,6 @@ namespace {
         DiskOpContext* ctx = static_cast<DiskOpContext*>(context);
         ctx->result = translateDissenter(dissenter);
         ctx->completed = true;
-        CFRunLoopStop(CFRunLoopGetCurrent());
     }
     
     void ejectUnmountCallback(DADiskRef disk, DADissenterRef dissenter, void* context) {
@@ -128,7 +126,6 @@ namespace {
         if (dissenter) {
             ctx->result = translateDissenter(dissenter);
             ctx->completed = true;
-            CFRunLoopStop(CFRunLoopGetCurrent());
         } else {
             // Unmount succeeded, now eject
             DADiskEject(disk, kDADiskEjectOptionDefault, ejectCallback, context);
@@ -137,11 +134,15 @@ namespace {
     
     // Default timeout: 60 seconds (maxRetries * 100 * 0.05s = 60s with maxRetries=12)
     // Slow USB drives with many files open may take significant time to unmount
-    PlatformQuirks::DiskResult runDiskOperation(const char* device, DADiskUnmountCallback callback, int maxRetries = 12) {
+    PlatformQuirks::DiskResult runDiskOperationOnMainRunLoop(const char* device,
+                                                                DADiskUnmountCallback callback,
+                                                                int maxRetries = 12) {
         DiskOpContext context;
         
         PLATFORM_LOG_INFO("runDiskOperation: starting operation on %{public}s", device);
         
+        CFRunLoopRef run_loop = [[NSRunLoop mainRunLoop] getCFRunLoop];
+
         // Create DiskArbitration session
         DASessionRef session = DASessionCreate(kCFAllocatorDefault);
         if (!session) {
@@ -157,24 +158,20 @@ namespace {
             return PlatformQuirks::DiskResult::InvalidDrive;
         }
         
-        // Initiate unmount with whole disk flag
-        DADiskUnmount(disk, kDADiskUnmountOptionWhole | kDADiskUnmountOptionForce, callback, &context);
+        // Schedule before initiating the operation (Apple requirement).
+        DASessionScheduleWithRunLoop(session, run_loop, kCFRunLoopDefaultMode);
+
+        DADiskUnmount(disk, kDADiskUnmountOptionWhole | kDADiskUnmountOptionForce,
+                      callback, &context);
         
-        // Schedule session on run loop
-        DASessionScheduleWithRunLoop(session, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-        
-        // Run loop with timeout
         int retries = 0;
         while (!context.completed && retries < maxRetries * 100) {
-            SInt32 status = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.05, false);
-            if (status == kCFRunLoopRunStopped || status == kCFRunLoopRunFinished) {
-                break;
-            }
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
             retries++;
         }
         
         // Clean up
-        DASessionUnscheduleFromRunLoop(session, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+        DASessionUnscheduleFromRunLoop(session, run_loop, kCFRunLoopDefaultMode);
         CFRelease(disk);
         CFRelease(session);
         
@@ -186,6 +183,20 @@ namespace {
         PLATFORM_LOG_INFO("runDiskOperation: completed on %{public}s with result %d", 
                           device, static_cast<int>(context.result));
         return context.result;
+    }
+
+    PlatformQuirks::DiskResult runDiskOperation(const char* device,
+                                                 DADiskUnmountCallback callback,
+                                                 int maxRetries = 12) {
+        if ([NSThread isMainThread]) {
+            return runDiskOperationOnMainRunLoop(device, callback, maxRetries);
+        }
+
+        __block PlatformQuirks::DiskResult result = PlatformQuirks::DiskResult::Error;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            result = runDiskOperationOnMainRunLoop(device, callback, maxRetries);
+        });
+        return result;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,6 +242,7 @@ int main(int argc, char *argv[])
 
     // Log text scaling factor for debugging (all modes)
     qDebug() << "Text scale factor:" << PlatformQuirks::detectTextScaleFactor();
+    PlatformQuirks::logFontEngine();
 
     // Log display scaling information for debugging (embedded mode only)
     if (::isEmbeddedMode()) {

--- a/src/platformquirks.h
+++ b/src/platformquirks.h
@@ -135,6 +135,14 @@ namespace PlatformQuirks {
     bool prefersReducedMotion();
 
     /**
+     * Log the configured font engine for the current platform.
+     *
+     * On Windows this reflects the fontengine= value in QT_QPA_PLATFORM
+     * (set by applyQuirks()). Must be called AFTER QGuiApplication is created.
+     */
+    void logFontEngine();
+
+    /**
      * Detect the platform's preferred text scaling factor.
      *
      * Returns a multiplier (1.0 = no scaling, 1.5 = 150%, etc.) reflecting

--- a/src/qmlcomponents/ImTextField.qml
+++ b/src/qmlcomponents/ImTextField.qml
@@ -102,12 +102,7 @@ TextField {
             enabled: !root.readOnly && ClipboardHelper.hasText
             Accessible.role: Accessible.MenuItem
             Accessible.name: text
-            onTriggered: {
-                var clipText = ClipboardHelper.getText()
-                if (clipText.length > 0) {
-                    root.insert(root.cursorPosition, clipText)
-                }
-            }
+            onTriggered: root.paste()
         }
         MenuSeparator {}
         MenuItem {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -18,17 +18,23 @@ list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(Catch)
 
 # Add the customization generator test executable
+# Includes the bundled crypto sources the generator now depends on for
+# credential derivation (yescrypt/sha256crypt password hashing).
 add_executable(customization_generator_test
     ${CMAKE_CURRENT_SOURCE_DIR}/../customization_generator.h
     ${CMAKE_CURRENT_SOURCE_DIR}/../customization_generator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../dependencies/sha256crypt/sha256crypt.c
     customization_generator_test.cpp
 )
 
-# Link against Catch2 and Qt
+# Link against Catch2, Qt and the bundled yescrypt static library
+# (yescrypt is defined in the parent scope via dependencies/yescrypt.cmake and
+# carries its include directory as a PUBLIC usage requirement).
 target_link_libraries(customization_generator_test PRIVATE 
     Catch2::Catch2WithMain
     Qt6::Core
     Qt6::Network
+    yescrypt
 )
 
 # Include parent directory for headers

--- a/src/test/customization_generator_test.cpp
+++ b/src/test/customization_generator_test.cpp
@@ -6,6 +6,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include "customization_generator.h"
+#include "dependencies/sha256crypt/sha256crypt.h"
 #include <QVariantMap>
 #include <QString>
 #include <QByteArray>
@@ -2011,5 +2012,140 @@ TEST_CASE("CustomisationGenerator cloud-init handles empty Pi Connect token", "[
     // Should not include write_files or runcmd for Pi Connect
     REQUIRE_FALSE(yaml.contains("write_files:"));
     REQUIRE_FALSE(yaml.contains(PI_CONNECT_CONFIG_PATH));
+}
+
+// ===========================================================================
+// Credential derivation (cryptPassword / pbkdf2) - moved here from the UI/
+// ImageWriter layer. See issue #1627 for the CR/LF stripping rationale.
+// ===========================================================================
+
+TEST_CASE("cryptPassword selects algorithm by OS release date", "[customization][password][crypt]") {
+    SECTION("OS released on/after 2023-01-01 uses yescrypt") {
+        const QString hash = CustomisationGenerator::cryptPassword("hunter2", "2023-06-01");
+        REQUIRE_THAT(hash.toStdString(), ContainsSubstring("$y$"));
+    }
+
+    SECTION("OS released before 2023-01-01 uses sha256crypt") {
+        const QString hash = CustomisationGenerator::cryptPassword("hunter2", "2022-12-31");
+        REQUIRE(hash.startsWith("$5$"));
+    }
+
+    SECTION("Missing release date defaults to sha256crypt") {
+        const QString hash = CustomisationGenerator::cryptPassword("hunter2", QString());
+        REQUIRE(hash.startsWith("$5$"));
+    }
+}
+
+TEST_CASE("cryptPassword strips CR/LF before hashing", "[customization][password][crypt]") {
+    // A pasted password may carry a trailing newline. PAM discards it at login,
+    // so the stored hash must correspond to the password WITHOUT the newline,
+    // otherwise sudo/login can never succeed (issue #1627).
+    // Verify via crypt(3) semantics: re-hashing against the produced hash's
+    // embedded salt reproduces it only for the stripped password.
+    const QString hash = CustomisationGenerator::cryptPassword(QByteArray("hunter2\n"), "2022-01-01");
+    REQUIRE(hash.startsWith("$5$"));
+
+    const QByteArray hashBytes = hash.toUtf8();
+    const QString rehashStripped = QString::fromUtf8(sha256_crypt("hunter2", hashBytes.constData()));
+    const QString rehashRaw = QString::fromUtf8(sha256_crypt("hunter2\n", hashBytes.constData()));
+
+    REQUIRE(rehashStripped == hash);   // stored hash matches the newline-free password
+    REQUIRE(rehashRaw != hash);        // and not the raw pasted value
+}
+
+TEST_CASE("osUsesYescrypt picks the algorithm by release date", "[customization][password][crypt]") {
+    REQUIRE(CustomisationGenerator::osUsesYescrypt("2023-01-01"));   // cutoff is inclusive
+    REQUIRE(CustomisationGenerator::osUsesYescrypt("2024-06-01"));
+    REQUIRE_FALSE(CustomisationGenerator::osUsesYescrypt("2022-12-31"));
+    REQUIRE_FALSE(CustomisationGenerator::osUsesYescrypt(QString()));   // unknown -> conservative
+    REQUIRE_FALSE(CustomisationGenerator::osUsesYescrypt("not-a-date"));
+}
+
+TEST_CASE("isYescryptHash detects the algorithm from the crypt prefix", "[customization][password][crypt]") {
+    // The crypt string is self-describing, so the algorithm is never stored
+    // separately. Only a yescrypt hash needs an OS-compatibility check; sha256crypt
+    // is accepted everywhere.
+    const QString yescrypt = CustomisationGenerator::cryptPassword("hunter2", "2024-03-01");
+    const QString sha256 = CustomisationGenerator::cryptPassword("hunter2", "2021-01-01");
+    REQUIRE(yescrypt.startsWith("$y$"));
+    REQUIRE(sha256.startsWith("$5$"));
+
+    REQUIRE(CustomisationGenerator::isYescryptHash(yescrypt));
+    REQUIRE(CustomisationGenerator::isYescryptHash("$7$abc$def"));
+    REQUIRE_FALSE(CustomisationGenerator::isYescryptHash(sha256));
+    REQUIRE_FALSE(CustomisationGenerator::isYescryptHash("$6$salt$hash"));
+    REQUIRE_FALSE(CustomisationGenerator::isYescryptHash(QString()));
+}
+
+TEST_CASE("Generator hashes plaintext account password at generation time", "[customization][password]") {
+    QVariantMap settings;
+    settings["sshUserName"] = "testuser";
+    settings["sshUserPasswordPlain"] = "s3cr3tpw";
+
+    SECTION("yescrypt for a recent OS") {
+        settings["osReleaseDate"] = "2024-03-01";
+        const QString script = QString::fromUtf8(CustomisationGenerator::generateSystemdScript(settings));
+
+        // The plaintext must never appear; only the derived hash is emitted.
+        REQUIRE_THAT(script.toStdString(), !ContainsSubstring("s3cr3tpw"));
+        REQUIRE_THAT(script.toStdString(), ContainsSubstring("/usr/lib/userconf-pi/userconf"));
+        REQUIRE_THAT(script.toStdString(), ContainsSubstring("'$y$"));
+    }
+
+    SECTION("sha256crypt for an older OS") {
+        settings["osReleaseDate"] = "2021-01-01";
+        const QString script = QString::fromUtf8(CustomisationGenerator::generateSystemdScript(settings));
+
+        REQUIRE_THAT(script.toStdString(), !ContainsSubstring("s3cr3tpw"));
+        REQUIRE_THAT(script.toStdString(), ContainsSubstring("'$5$"));
+    }
+}
+
+TEST_CASE("Generator prefers plaintext password over a stale crypted value", "[customization][password]") {
+    // When both a freshly entered plaintext and an old crypted value are present,
+    // the plaintext wins (the UI clears the crypted value, but be defensive).
+    QVariantMap settings;
+    settings["sshUserName"] = "testuser";
+    settings["sshUserPassword"] = "$5$stalesalt$stalehash";
+    settings["sshUserPasswordPlain"] = "freshpw1";
+    settings["osReleaseDate"] = "2021-01-01";
+
+    const QString script = QString::fromUtf8(CustomisationGenerator::generateSystemdScript(settings));
+
+    REQUIRE_THAT(script.toStdString(), !ContainsSubstring("$5$stalesalt$stalehash"));
+    REQUIRE_THAT(script.toStdString(), !ContainsSubstring("freshpw1"));
+    REQUIRE_THAT(script.toStdString(), ContainsSubstring("'$5$"));
+}
+
+TEST_CASE("Generator falls back to crypted password when no plaintext present", "[customization][password]") {
+    // Reused-from-saved-settings path: an already-crypted value passes through.
+    QVariantMap settings;
+    settings["sshUserName"] = "testuser";
+    settings["sshUserPassword"] = "$5$savedsalt$savedhash";
+
+    const QString script = QString::fromUtf8(CustomisationGenerator::generateSystemdScript(settings));
+    REQUIRE_THAT(script.toStdString(), ContainsSubstring("$5$savedsalt$savedhash"));
+}
+
+TEST_CASE("Generator derives Wi-Fi PSK from plaintext passphrase", "[customization][wifi][password]") {
+    QVariantMap settings;
+    settings["wifiSSID"] = "TestNet";
+    settings["wifiPassword"] = "supersecret"; // 11 chars -> passphrase
+
+    const QString expectedPsk = CustomisationGenerator::pbkdf2(
+        QByteArray("supersecret"), QByteArray("TestNet"));
+
+    const QString script = QString::fromUtf8(CustomisationGenerator::generateSystemdScript(settings));
+    REQUIRE_THAT(script.toStdString(), !ContainsSubstring("supersecret"));
+    REQUIRE_THAT(script.toStdString(), ContainsSubstring("psk=" + expectedPsk.toStdString()));
+}
+
+TEST_CASE("Generator passes through a pre-derived Wi-Fi PSK unchanged", "[customization][wifi][password]") {
+    QVariantMap settings;
+    settings["wifiSSID"] = "TestNet";
+    settings["wifiPasswordCrypt"] = "deadbeefcafef00d";
+
+    const QString script = QString::fromUtf8(CustomisationGenerator::generateSystemdScript(settings));
+    REQUIRE_THAT(script.toStdString(), ContainsSubstring("psk=deadbeefcafef00d"));
 }
 

--- a/src/windows/platformquirks_windows.cpp
+++ b/src/windows/platformquirks_windows.cpp
@@ -24,6 +24,7 @@
 #include <QDebug>
 #include <QFont>
 #include <QFontDatabase>
+#include <QString>
 
 namespace {
     // Network monitoring state
@@ -212,6 +213,66 @@ static bool hasNvidiaGraphicsCard() {
     return foundNvidia;
 }
 
+// Qt 6.11 defaults to DirectWrite on Windows, which corrupts uppercase button
+// text on some systems (https://github.com/raspberrypi/rpi-imager/issues/1648).
+// Force the cross-platform FreeType engine before QGuiApplication starts.
+static QByteArray ensureWindowsFreeTypeFontEngine()
+{
+    static constexpr char kFreeTypeArg[] = "fontengine=freetype";
+    QByteArray platform = qgetenv("QT_QPA_PLATFORM");
+
+    if (platform.isEmpty()) {
+        return QByteArrayLiteral("windows:") + kFreeTypeArg;
+    }
+
+    if (platform.contains(kFreeTypeArg)) {
+        return platform;
+    }
+
+    const int fontEngineIdx = platform.indexOf("fontengine=");
+    if (fontEngineIdx >= 0) {
+        const int commaIdx = platform.indexOf(',', fontEngineIdx);
+        platform.remove(fontEngineIdx,
+                        (commaIdx < 0 ? platform.size() : commaIdx) - fontEngineIdx);
+        if (platform.endsWith(',')) {
+            platform.chop(1);
+        }
+    }
+
+    if (!platform.contains(':')) {
+        if (platform == "windows") {
+            platform = QByteArrayLiteral("windows:");
+        } else {
+            platform = QByteArrayLiteral("windows:") + platform;
+        }
+    }
+
+    if (!platform.endsWith(':') && !platform.endsWith(',')) {
+        platform += ',';
+    }
+
+    return platform + kFreeTypeArg;
+}
+
+static QString windowsFontEngineFromPlatformArgs(const QByteArray &platformArgs)
+{
+    const QString args = QString::fromLatin1(platformArgs);
+    const int idx = args.indexOf(QStringLiteral("fontengine="), Qt::CaseInsensitive);
+    if (idx < 0) {
+        if (args.contains(QStringLiteral("nodirectwrite"), Qt::CaseInsensitive)) {
+            return QStringLiteral("gdi");
+        }
+        return QStringLiteral("directwrite (default)");
+    }
+
+    const int start = idx + QStringLiteral("fontengine=").size();
+    int end = args.indexOf(QLatin1Char(','), start);
+    if (end < 0) {
+        end = args.size();
+    }
+    return args.mid(start, end - start);
+}
+
 void applyQuirks() {
     // Suppress Windows "Insert a disk" / "not accessible" system error dialogs
     // for the main thread. This prevents Windows from showing modal dialogs
@@ -228,6 +289,9 @@ void applyQuirks() {
     if (hasNvidiaGraphicsCard()) {
         SetEnvironmentVariableA("QSG_RHI_PREFER_SOFTWARE_RENDERER", "1");
     }
+
+    const QByteArray fontPlatform = ensureWindowsFreeTypeFontEngine();
+    qputenv("QT_QPA_PLATFORM", fontPlatform);
 
     // make imager single instance because of rpi-connect callback server
     // will be automatically released once the process exits cleanly or crashes
@@ -809,6 +873,13 @@ qreal detectTextScaleFactor()
 qreal fontDpiCorrection()
 {
     return 72.0 / 96.0;
+}
+
+void logFontEngine()
+{
+    const QByteArray platform = qgetenv("QT_QPA_PLATFORM");
+    qDebug() << "Font engine:" << windowsFontEngineFromPlatformArgs(platform)
+             << "(QT_QPA_PLATFORM =" << platform << ")";
 }
 
 } // namespace PlatformQuirks

--- a/src/wizard/UserCustomizationStep.qml
+++ b/src/wizard/UserCustomizationStep.qml
@@ -18,6 +18,9 @@ WizardStepBase {
     id: root
     
     property bool hasSavedUserPassword: false
+    // Set when a previously saved password was discarded because its hashing
+    // algorithm is incompatible with the currently selected OS (drives a hint).
+    property bool savedPasswordInvalidated: false
     property string savedUsername: ""
     
     title: qsTr("Customisation: Choose username")
@@ -90,6 +93,13 @@ WizardStepBase {
             WizardDescriptionText {
                 id: helpText
                 text: qsTr("The username must be lowercase and contain only letters, numbers, underscores, and hyphens.")
+            }
+
+            WizardDescriptionText {
+                id: invalidatedPasswordHint
+                visible: root.savedPasswordInvalidated
+                color: Style.formLabelErrorColor
+                text: qsTr("Your saved password isn't compatible with the selected operating system, so please enter it again.")
             }
 
             RowLayout {
@@ -168,8 +178,23 @@ WizardStepBase {
             root.savedUsername = settings.sshUserName
         }
         if (settings.sshUserPassword) {
-            // Indicate a saved (crypted) password exists; do not prefill fields
-            root.hasSavedUserPassword = true
+            if (ImageWriterSingleton.savedUserPasswordUsableWithCurrentOs(settings.sshUserPassword)) {
+                // Indicate a saved (crypted) password exists; do not prefill fields.
+                // Because the field stays empty, the show-password toggle is
+                // unavailable for restored passwords (we only hold the hash) - it is
+                // only available for passwords typed in the current session.
+                root.hasSavedUserPassword = true
+            } else {
+                // The saved hash uses yescrypt but the selected OS predates
+                // yescrypt support, so it could never authenticate. We hold no
+                // plaintext to re-hash, so drop the stale hash and require
+                // re-entry; re-hashing under this OS yields sha256crypt, which is
+                // accepted everywhere.
+                delete wizardContainer.customizationSettings.sshUserPassword
+                ImageWriterSingleton.removePersistedCustomisationSetting("sshUserPassword")
+                root.hasSavedUserPassword = false
+                root.savedPasswordInvalidated = true
+            }
         }
         // Note: passwordlessSudo is intentionally NOT loaded from persisted settings.
         // It must be explicitly enabled each session due to security implications.
@@ -193,14 +218,18 @@ WizardStepBase {
         
         // Update conserved customization settings (runtime state)
         if (usernameText.length > 0 && hasPasswords) {
-            // User entered both username and new password
-            var cryptedPwd = ImageWriterSingleton.crypt(fieldPassword.text)
+            // User entered both username and a new password. Hash it now (in C++/
+            // generator) and keep ONLY the hash: the plaintext is never copied
+            // into the long-lived settings map. The plaintext stays solely in the
+            // password field, which is destroyed on navigation - this bounds its
+            // RAM lifetime and is what the show-password toggle relies on.
+            var hashedPwd = ImageWriterSingleton.hashUserPassword(fieldPassword.text)
             wizardContainer.customizationSettings.sshUserName = usernameText
-            wizardContainer.customizationSettings.sshUserPassword = cryptedPwd
+            wizardContainer.customizationSettings.sshUserPassword = hashedPwd
             wizardContainer.userConfigured = true
-            // Persist for future sessions
+            // Persist for future sessions (stored hashed, never as plaintext)
             ImageWriterSingleton.setPersistedCustomisationSetting("sshUserName", usernameText)
-            ImageWriterSingleton.setPersistedCustomisationSetting("sshUserPassword", cryptedPwd)
+            ImageWriterSingleton.setPersistedCustomisationSetting("sshUserPassword", hashedPwd)
             // Passwordless sudo (session-only, never persisted)
             if (checkPasswordlessSudo.checked) {
                 wizardContainer.customizationSettings.passwordlessSudo = true
@@ -224,6 +253,7 @@ WizardStepBase {
             // User cleared all fields -> remove from runtime settings
             delete wizardContainer.customizationSettings.sshUserName
             delete wizardContainer.customizationSettings.sshUserPassword
+            delete wizardContainer.customizationSettings.sshUserPasswordPlain
             delete wizardContainer.customizationSettings.passwordlessSudo
             wizardContainer.userConfigured = false
             // Remove from persistence

--- a/src/wizard/WifiCustomizationStep.qml
+++ b/src/wizard/WifiCustomizationStep.qml
@@ -80,7 +80,9 @@ WizardStepBase {
         }
 
         originalSavedSSID = settings.wifiSSID || ""
-        // Remember if a crypted PSK is already saved (affects placeholder/keep semantics)
+        // Remember if a derived PSK is already saved (affects placeholder/keep
+        // semantics and keychain auto-prefill). Only the derived PSK is ever
+        // stored; the plaintext passphrase is never kept in the settings map.
         hadSavedCrypt = !!settings.wifiPasswordCrypt
 
         // if no saved crypt, try to prefill a PSK from system
@@ -458,6 +460,20 @@ WizardStepBase {
         var hadCryptBefore = !!wizardContainer.customizationSettings.wifiPasswordCrypt
         var sameSSID = ssidUnchanged(ssid, prevSSID)
 
+        // Derive the PSK once, eagerly, in C++/generator if a new passphrase was
+        // entered. Only the derived PSK is ever stored; the plaintext passphrase
+        // is never copied into the settings map and stays solely in the password
+        // field (which the show-password toggle relies on and which is destroyed
+        // on navigation).
+        var newCrypt = ""
+        var haveNewCrypt = false
+        if (ssid.length > 0 && wifiMode !== "open" && pwd.length > 0) {
+            // extra safety; normally unreachable because nextButtonEnabled prevents this
+            if (pwd !== fieldWifiPasswordConfirm.text) return;
+            newCrypt = ImageWriterSingleton.deriveWifiPsk(ssid, pwd)
+            haveNewCrypt = true
+        }
+
         // Update conserved customization settings (runtime state)
         wizardContainer.customizationSettings.wifiMode = wifiMode
         
@@ -469,21 +485,14 @@ WizardStepBase {
             if (wifiMode === "open") {
                // always clear in open mode
                delete wizardContainer.customizationSettings.wifiPasswordCrypt
+            } else if (haveNewCrypt) {
+               // overwrite with the freshly derived PSK
+               wizardContainer.customizationSettings.wifiPasswordCrypt = newCrypt
+            } else if (hadCryptBefore && sameSSID) {
+               // keep the existing crypt (do nothing)
             } else {
-               // secure / closed mode
-               if (pwd.length > 0) {
-                   // extra safety; normally unreachable because nextButtonEnabled prevents this
-                   if (pwd !== fieldWifiPasswordConfirm.text) return;
-                   // overwrite with new password
-                   var isPassphrase = (pwd.length >= 8 && pwd.length < 64)
-                   wizardContainer.customizationSettings.wifiPasswordCrypt = isPassphrase ? ImageWriterSingleton.pbkdf2(pwd, ssid) : pwd
-               } else if (hadCryptBefore && sameSSID) {
-                   // keep the existing crypt
-                   // (do nothing)
-               } else {
-                   // no password provided and can't keep -> ensure cleared
-                   delete wizardContainer.customizationSettings.wifiPasswordCrypt
-               }
+               // no password provided and can't keep -> ensure cleared
+               delete wizardContainer.customizationSettings.wifiPasswordCrypt
             }
 
             wizardContainer.customizationSettings.wifiHidden = hidden
@@ -497,7 +506,8 @@ WizardStepBase {
             wizardContainer.wifiConfigured = false
         }
         
-        // Also persist for future sessions
+        // Also persist for future sessions. Only the derived PSK is ever written
+        // to disk - the plaintext passphrase is not.
         var saved = ImageWriterSingleton.getSavedCustomisationSettings()
         saved.wifiMode = wifiMode
         if (ssid.length > 0) {
@@ -505,15 +515,12 @@ WizardStepBase {
             saved.wifiSsidOctetsBase64 = ImageWriterSingleton.wifiSsidOctetsBase64(ssid)
             if (wifiMode === "open") {
                delete saved.wifiPasswordCrypt
+            } else if (haveNewCrypt) {
+               saved.wifiPasswordCrypt = newCrypt
+            } else if (hadCryptBefore && sameSSID) {
+               // keep existing persisted crypt
             } else {
-               if (pwd.length > 0) {
-                   var isPassphrase2 = (pwd.length >= 8 && pwd.length < 64)
-                   saved.wifiPasswordCrypt = isPassphrase2 ? ImageWriterSingleton.pbkdf2(pwd, ssid) : pwd
-               } else if (hadCryptBefore && sameSSID) {
-                   // keep existing
-               } else {
-                   delete saved.wifiPasswordCrypt
-               }
+               delete saved.wifiPasswordCrypt
             }
             saved.wifiHidden = hidden
         } else {


### PR DESCRIPTION
## Summary

Cherry-picks five commits from `dev/tdewey/2.1` that are unrelated to the privileged-helper work:

- **feat(platform-quirks):** add `logFontEngine()` on all platforms
- **chore:** call `logFontEngine()` at startup
- **feat(customization):** centralize credential derivation in `CustomisationGenerator` (yescrypt/sha256crypt, CR/LF stripping, tests)
- **refactor(customization):** hash credentials in C++ before persisting; wizard stores only derived values (fixes #1627)
- **fix(mac):** run DiskArbitration on the main run loop (`platformquirks_macos.mm` only — helper-server changes omitted)

## Test plan

- [ ] Build on macOS, Linux, and Windows
- [ ] Run `customization_generator_test`
- [ ] Customisation wizard: set username/password and Wi-Fi; confirm image customisation generates valid hashes
- [ ] Paste a password with a trailing newline; confirm login still works
- [ ] macOS: unmount/eject a removable drive during write prep