### PR TITLE
fix(repository): validate custom repo URL extension against path only

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -4347,11 +4347,21 @@ QString ImageWriter::customRepoHost()
 
 bool ImageWriter::isValidRepoUrl(const QString &url) const
 {
-    // Validate: must be http/https URL ending with .json or manifest extension
-    static const QRegularExpression repoUrlRe(
-        QStringLiteral("^https?://[^ \\t\\r\\n]+\\.(json|" MANIFEST_EXTENSION ")$"), 
+    QUrl u(url, QUrl::StrictMode);
+    if (!u.isValid()) return false;
+
+    const QString scheme = u.scheme();
+    if (scheme.compare(QLatin1String("http"), Qt::CaseInsensitive) != 0 &&
+        scheme.compare(QLatin1String("https"), Qt::CaseInsensitive) != 0)
+    return false;
+
+    // Validate URL path (ignoring query string/fragment) ends with .json
+    // or the manifest extension, so authenticated URLs with query params
+    // (e.g. Azure SAS tokens, S3 presigned URLs) are accepted.    
+    static const QRegularExpression extRe(
+        QStringLiteral("\\.(json|" MANIFEST_EXTENSION ")$"),
         QRegularExpression::CaseInsensitiveOption);
-    return repoUrlRe.match(url).hasMatch();
+    return extRe.match(u.path()).hasMatch();
 }
 
 // Cache-related methods removed - now handled by CacheManager


### PR DESCRIPTION
## Problem

`isValidRepoUrl()` requires the URL to end with `.json` or the manifest
extension, but matches this against the full URL string, including the
query string. This breaks authenticated manifest URLs such as Azure Blob
SAS links or S3 presigned URLs. 


Fixes #1667

## Fix

Match the extension regex against `QUrl::path()` instead of the raw URL
string, so query parameters and fragments no longer break the check.

## Why keep the extension check

`isValidRepoUrl()` is used in two places:
- the custom repository URL field (QML)
- `handleIncomingUrl()`, validating `repo=` in `rpi-imager://open?repo=...`
  deep links (added in 86c3e20)

The deep link can be triggered by an external site without direct user
input, so the extension check acts as a first-pass filter before the
confirmation dialog. This PR keeps that check and only fixes how it's
matched, rather than removing it.