### PR TITLE
wizard: Reject "root" as the account username

### DIFF
--- a/src/wizard/UserCustomizationStep.qml
+++ b/src/wizard/UserCustomizationStep.qml
@@ -22,6 +22,13 @@ WizardStepBase {
     // algorithm is incompatible with the currently selected OS (drives a hint).
     property bool savedPasswordInvalidated: false
     property string savedUsername: ""
+
+    // "root" already exists in every image, so first-boot user creation fails
+    // and the device is left with no usable login. Kept as a named property so
+    // further system account names can be added without touching the callers.
+    // Compare ImageWriter::getCurrentUser(), which substitutes "pi" for the
+    // same reason when pre-filling this field.
+    readonly property bool usernameIsReserved: fieldUsername.text.trim() === "root"
     
     title: qsTr("Customisation: Choose username")
     subtitle: qsTr("Create a user account for your Raspberry Pi")
@@ -93,6 +100,13 @@ WizardStepBase {
             WizardDescriptionText {
                 id: helpText
                 text: qsTr("The username must be lowercase and contain only letters, numbers, underscores, and hyphens.")
+            }
+
+            WizardDescriptionText {
+                id: reservedUsernameHint
+                visible: root.usernameIsReserved
+                color: Style.formLabelErrorColor
+                text: qsTr("This username is already used by the operating system. Please choose a different one, for example \"pi\".")
             }
 
             WizardDescriptionText {
@@ -205,7 +219,8 @@ WizardStepBase {
     // - all fields are empty (no customization), or
     // - a new password is entered and matches confirm, or
     // - a saved (crypted) password exists and user leaves password fields blank (with or without username)
-    nextButtonEnabled: (
+    // In every case the username must not collide with an existing system account.
+    nextButtonEnabled: !root.usernameIsReserved && (
         (fieldUsername.text.length === 0 && fieldPassword.text.length === 0 && fieldPasswordConfirm.text.length === 0)
         || (fieldPassword.text.length > 0 && fieldPasswordConfirm.text.length > 0 && fieldPassword.text === fieldPasswordConfirm.text)
         || (root.hasSavedUserPassword && fieldPassword.text.length === 0 && fieldPasswordConfirm.text.length === 0)


### PR DESCRIPTION
## Problem

The username field in the customisation wizard validates character shape only:

https://github.com/raspberrypi/rpi-imager/blob/main/src/wizard/UserCustomizationStep.qml#L60

```qml
validator: RegularExpressionValidator {
    regularExpression: /^[a-z_][a-z0-9_-]*$/
}
```

`root` matches this pattern, so the wizard accepts it and writes it into the
customisation config. On first boot, user creation fails because the account already
exists, and the setup step aborts without creating anything.

The result is a device that cannot be logged into at all:

- password authentication rejects every attempt, because no such user account exists
- public-key authentication has nothing to check against, because no `authorized_keys`
  file was ever written

For a headless install the only visible symptom is `Permission denied`, which is
indistinguishable from a mistyped password. The natural response is to re-enter the
password, then reflash with the same username, and reproduce the failure exactly.
Recovery requires mounting the boot partition on another machine, and diagnosing it
first requires knowing that `root` is special.

Previously reported in #759, which asked for the name to be blocked or at least
flagged, and in #1624, which asked for it to be documented.

## Rationale

The rule is already established in the codebase — `ImageWriter::getCurrentUser()`
substitutes `pi` when the host account is root, precisely so that this value never
reaches the field as a pre-fill:

https://github.com/raspberrypi/rpi-imager/blob/main/src/imagewriter.cpp#L4281

```cpp
if (user.isEmpty() || user == "root")
    user = "pi";
```

This PR applies the same rule to names the user types in.

## Change

- A `usernameIsReserved` property on the step.
- An inline error message while the name is entered, following the existing
  `invalidatedPasswordHint` pattern (`Style.formLabelErrorColor`).
- `nextButtonEnabled` gated on the check, so the step cannot be completed with a name
  that is known to fail.

Confined to `src/wizard/UserCustomizationStep.qml`; no behaviour change for any other
username. One new translatable string.

## Scope

Deliberately limited to `root`, which is the name users actually enter and the one
named in #759.

The same failure applies to every account already present in the image — the
`base-passwd` set (`daemon`, `bin`, `sys`, `www-data`, `nobody`, …) plus package-created
accounts such as `sshd` and `messagebus`. I left those out rather than hard-code a
snapshot of another project's data that nothing here would keep in sync, and because
the first group is fixed by Debian policy while the second varies by image variant.
The check is a named property specifically so that list can be added later if you want
it — happy to include it in this PR if you would prefer.

Reading the actual account list out of the image is not available at this point: the
customisation is entered before the image is written, and the source is compressed.

## Testing

`qmllint` shows no syntax errors. Not verified at runtime — the documented macOS build
path requires building Qt from source, which I have not set up. The change follows the
existing `invalidatedPasswordHint` pattern in the same file and touches no C++.
