### PR TITLE
Fix Windows device size truncation and backup boot sector mismatch

### DIFF
--- a/src/disk_formatter.cpp
+++ b/src/disk_formatter.cpp
@@ -231,7 +231,7 @@ Result<void> DiskFormatter::WriteFat32(
   config.total_sectors = partition_size_sectors;
 
   // Write boot sector
-  if (auto result = WriteBootSector(partition_start_sector, config); !result) {
+  if (auto result = WriteBootSector(partition_start_sector, partition_start_sector, config); !result) {
     return result;
   }
 
@@ -242,7 +242,8 @@ Result<void> DiskFormatter::WriteFat32(
 
   // Write backup boot sector at sector 6 (as specified in the boot sector's backup_boot_sector field)
   constexpr std::uint32_t kBackupBootSector = 6;
-  if (auto result = WriteBootSector(partition_start_sector + kBackupBootSector, config); !result) {
+  if (auto result = WriteBootSector(partition_start_sector + kBackupBootSector,
+                                    partition_start_sector, config); !result) {
     return result;
   }
 
@@ -260,6 +261,7 @@ Result<void> DiskFormatter::WriteFat32(
 
 Result<void> DiskFormatter::WriteBootSector(
     std::uint32_t offset_sectors,
+    std::uint32_t partition_start_sectors,
     const Fat32Config& config) const {
   
   Fat32BootSector boot_sector{};
@@ -284,7 +286,11 @@ Result<void> DiskFormatter::WriteBootSector(
   boot_sector.sectors_per_fat_16 = 0;  // FAT32
   boot_sector.sectors_per_track = ToLittleEndian(static_cast<std::uint16_t>(63));
   boot_sector.num_heads = ToLittleEndian(static_cast<std::uint16_t>(255));
-  boot_sector.hidden_sectors = ToLittleEndian(static_cast<std::uint32_t>(offset_sectors));
+  // BPB_HiddSec is the number of sectors preceding the FAT32 volume, not the
+  // location of this particular copy of the boot sector. Using offset_sectors gave
+  // the backup copy at +6 a value 6 higher than the primary, which fsck.fat reports
+  // as "There are differences between boot sector and its backup" at offset 28.
+  boot_sector.hidden_sectors = ToLittleEndian(partition_start_sectors);
   boot_sector.total_sectors_32 = ToLittleEndian(config.total_sectors);
 
   // FAT32 specific fields

--- a/src/disk_formatter.h
+++ b/src/disk_formatter.h
@@ -169,8 +169,11 @@ class DiskFormatter {
       std::uint32_t partition_size_sectors) const;
 
   // Helper functions
+  // offset_sectors is where this copy of the boot sector is written; the primary
+  // and the backup at +6 differ there but must record the same partition start.
   Result<void> WriteBootSector(
       std::uint32_t offset_sectors,
+      std::uint32_t partition_start_sectors,
       const Fat32Config& config) const;
 
   Result<void> WriteFsInfo(

--- a/src/windows/file_operations_windows.cpp
+++ b/src/windows/file_operations_windows.cpp
@@ -562,21 +562,39 @@ FileError WindowsFileOperations::GetSize(std::uint64_t& size) {
 
   LARGE_INTEGER file_size;
   if (!GetFileSizeEx(handle_, &file_size)) {
-    // For devices, try to get geometry information
-    DISK_GEOMETRY geometry;
     DWORD bytes_returned;
-    
+
+    // For devices, ask for the exact length. IOCTL_DISK_GET_DRIVE_GEOMETRY below
+    // reports a synthetic CHS geometry whose product is rounded down to a whole
+    // cylinder, so it under-reports the device: a 28.7 GB USB stick of 60125184
+    // sectors is reported as 3742 * 255 * 63 = 60115230 sectors, 9954 sectors
+    // (4.86 MiB) short. Anything positioned relative to the end of the device is
+    // then placed inside that gap rather than at the true end.
+    GET_LENGTH_INFORMATION length_info;
+    if (DeviceIoControl(handle_, IOCTL_DISK_GET_LENGTH_INFO,
+                        nullptr, 0, &length_info, sizeof(length_info),
+                        &bytes_returned, nullptr)) {
+      size = static_cast<std::uint64_t>(length_info.Length.QuadPart);
+      return FileError::kSuccess;
+    }
+
+    // Fall back to geometry information
+    DISK_GEOMETRY geometry;
+
     if (DeviceIoControl(handle_, IOCTL_DISK_GET_DRIVE_GEOMETRY,
                         nullptr, 0, &geometry, sizeof(geometry),
                         &bytes_returned, nullptr)) {
-      
+
       size = static_cast<std::uint64_t>(geometry.Cylinders.QuadPart) *
              geometry.TracksPerCylinder *
              geometry.SectorsPerTrack *
              geometry.BytesPerSector;
+      FileOperationsLog("GetSize: IOCTL_DISK_GET_LENGTH_INFO unavailable; using "
+                        "cylinder-rounded geometry size " + std::to_string(size) +
+                        " which may under-report the device");
       return FileError::kSuccess;
     }
-    
+
     return FileError::kSizeError;
   }
 


### PR DESCRIPTION
Two independent bugs in the format path, both found while investigating why a USB stick carrying residue from another OS could still be seen by Windows as GPT after a fresh MBR had been written. They are unrelated to each other and can be split into separate PRs if you would prefer — happy to do that.

## 1. `GetSize()` under-reports devices on Windows

`WindowsFileOperations::GetSize()` falls back to `IOCTL_DISK_GET_DRIVE_GEOMETRY` for devices and multiplies out the reported CHS geometry. That geometry is synthetic, and its product is rounded down to a whole cylinder, so the size comes back short.

Measured on a 28.7 GB SanDisk USB stick:

| | sectors | bytes |
|---|---|---|
| actual device | 60,125,184 | 30,784,094,208 |
| reported by geometry | 60,115,230 | 30,778,997,760 |
| short by | 9,954 | 5,096,448 (4.86 MiB) |

The reported figure is exactly `3742 cylinders × 255 heads × 63 sectors`, i.e. the true size truncated to the last whole cylinder.

The failure mode is quiet: the size is returned as a success, so callers have no way to know it is wrong. Anything positioned relative to the end of the device lands ~5 MiB early, inside the gap, rather than at the true end — which is what led me here, since a structure in the device's final sector was never being overwritten.

`IOCTL_DISK_GET_LENGTH_INFO` returns the exact byte length and is the documented call for this. This PR tries it first and keeps the geometry path as a fallback, which now logs when it is used.

**Worth flagging for review:** this changes the device size used for MBR and FAT32 sizing on every Windows write, not only for end-relative work. On affected devices the partition will now extend to the true end rather than stopping at a cylinder boundary. I believe that is the intended behaviour, but it is a real change to the format path and you may want to weigh it.

## 2. Backup boot sector records a different `BPB_HiddSec` than the primary

`WriteBootSector()` derives `hidden_sectors` from `offset_sectors`, which is where that copy is being written rather than where the volume starts. The backup copy at `partition_start + 6` therefore records a value 6 higher than the primary.

`fsck.fat` reports it on every check of a card formatted by the tool:

```
There are differences between boot sector and its backup.
This is mostly harmless. Differences: (offset:original/backup)
  28:00/06
```

Offset 28 is `BPB_HiddSec`; `00`/`06` is the low byte of 8192 vs 8198 for a partition starting at sector 8192.

It is cosmetic — `fsck` repairs it in place — but it prompts the user on each boot of a system that fsck's its boot partition. Fixed by passing the partition start separately from the write offset so both copies agree.

## Testing

Both changes compile and the resulting builds run. Fix 2 was observed directly: the `fsck.fat` output above came from booting a stick written by the tool, and the arithmetic matches the two values exactly. Fix 1 was diagnosed from instrumented logging on a real device, with the numbers in the table above.

To be straightforward about the limits of my testing: I verified that the bugs are real and precisely measured, but I have not demonstrated a user-visible symptom being cured end-to-end by fix 1 — the drive I measured it on wrote successfully despite the truncated size. So I would treat the size correction as fixing a demonstrated defect rather than as a confirmed fix for any particular report.
