### PR TITLE
fix(windows): classify UASP storage as USB

### DIFF
--- a/src/drivelist/drivelist_windows.cpp
+++ b/src/drivelist/drivelist_windows.cpp
@@ -981,6 +981,14 @@ std::vector<DeviceDescriptor> ListStorageDevices()
             // Refine classification based on bus type (these are our constants, case-sensitive OK)
             device.isCard = (device.busType == "SD" || device.busType == "MMC" || device.busType == "UFS");
 
+            // UASP bridges are driven through the SCSI enumerator, even though
+            // the adapter descriptor identifies their bus type as USB. Classify
+            // them before the system-drive heuristic below so removable USB
+            // storage is not hidden as a generic non-removable SCSI disk.
+            if (equalsIgnoreCase(device.enumerator, "SCSI") && device.busType == "USB") {
+                device.isUSB = true;
+            }
+
             // SD/MMC/UFS cards and USB devices should never be system drives
             if (!device.isCard && !device.isUSB) {
                 device.isSystem = device.isSystem || isSystemDevice(device.mountpoints);


### PR DESCRIPTION
## Summary
Windows UASP storage can be hidden as a system SCSI disk; this classifies SCSI-enumerated devices with an authoritative USB bus type as USB before applying the system-drive heuristic.

## Why This Exists
Windows exposes many USB 3 storage bridges through the SCSI enumerator when they use UASP. Enumerator-only classification therefore leaves `isUSB` false, and a non-removable UASP target can be guessed to be a system drive and hidden from the storage list.

## Resolution
Use the adapter descriptor bus type already collected by the device scan. When the enumerator is SCSI and `busType` is USB, mark the device as USB before the existing system-drive classification. The later authoritative system-disk override remains unchanged.

## Reviewer Considerations
- The change only affects devices whose adapter descriptor explicitly reports USB.
- A UASP device that is actually a system disk remains protected by the authoritative system-disk override.
- The observed failure involved an ASMedia ASM2115 enclosure enumerating as `SCSI\DISK`.

## Behavior Changes
UASP-attached removable storage appears in the Windows storage list instead of being hidden by the generic SCSI system-drive heuristic.

## Implementation Summary
- Refine `isUSB` from the SCSI enumerator plus USB adapter bus type before system-drive classification.

## Verification
- `git diff --check`: passed.
- The fix is isolated to the Windows device-enumeration path and reproduces the classification used successfully with an ASMedia ASM2115 UASP enclosure.

## Risk
Low. The adapter bus type is authoritative, and the existing final system-disk override is preserved.