### PR TITLE
fix(macos): actually wait for the DiskArbitration unmount callback

### DIFF
--- a/src/mac/platformquirks_macos.mm
+++ b/src/mac/platformquirks_macos.mm
@@ -112,20 +112,23 @@ namespace {
         DiskOpContext* ctx = static_cast<DiskOpContext*>(context);
         ctx->result = translateDissenter(dissenter);
         ctx->completed = true;
+        CFRunLoopStop(CFRunLoopGetCurrent());
     }
-    
+
     void ejectCallback(DADiskRef disk, DADissenterRef dissenter, void* context) {
         (void)disk;
         DiskOpContext* ctx = static_cast<DiskOpContext*>(context);
         ctx->result = translateDissenter(dissenter);
         ctx->completed = true;
+        CFRunLoopStop(CFRunLoopGetCurrent());
     }
-    
+
     void ejectUnmountCallback(DADiskRef disk, DADissenterRef dissenter, void* context) {
         DiskOpContext* ctx = static_cast<DiskOpContext*>(context);
         if (dissenter) {
             ctx->result = translateDissenter(dissenter);
             ctx->completed = true;
+            CFRunLoopStop(CFRunLoopGetCurrent());
         } else {
             // Unmount succeeded, now eject
             DADiskEject(disk, kDADiskEjectOptionDefault, ejectCallback, context);
@@ -134,14 +137,16 @@ namespace {
     
     // Default timeout: 60 seconds (maxRetries * 100 * 0.05s = 60s with maxRetries=12)
     // Slow USB drives with many files open may take significant time to unmount
-    PlatformQuirks::DiskResult runDiskOperationOnMainRunLoop(const char* device,
-                                                                DADiskUnmountCallback callback,
-                                                                int maxRetries = 12) {
+    PlatformQuirks::DiskResult runDiskOperation(const char* device,
+                                                DADiskUnmountCallback callback,
+                                                int maxRetries = 12) {
         DiskOpContext context;
-        
+
         PLATFORM_LOG_INFO("runDiskOperation: starting operation on %{public}s", device);
-        
-        CFRunLoopRef run_loop = [[NSRunLoop mainRunLoop] getCFRunLoop];
+
+        // Run the session on the calling thread's own run loop. The caller is a
+        // worker thread (write/format), so blocking here never stalls the GUI.
+        CFRunLoopRef run_loop = CFRunLoopGetCurrent();
 
         // Create DiskArbitration session
         DASessionRef session = DASessionCreate(kCFAllocatorDefault);
@@ -164,12 +169,19 @@ namespace {
         DADiskUnmount(disk, kDADiskUnmountOptionWhole | kDADiskUnmountOptionForce,
                       callback, &context);
         
+        // Wait for the callback, sleeping 50ms per iteration. A zero-second
+        // CFRunLoopRunInMode() only drains sources that are *already* pending,
+        // so polling with it burns through the retry budget in microseconds and
+        // reports a timeout on every real disk.
         int retries = 0;
         while (!context.completed && retries < maxRetries * 100) {
-            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
+            SInt32 status = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.05, false);
+            if (status == kCFRunLoopRunStopped || status == kCFRunLoopRunFinished) {
+                break;
+            }
             retries++;
         }
-        
+
         // Clean up
         DASessionUnscheduleFromRunLoop(session, run_loop, kCFRunLoopDefaultMode);
         CFRelease(disk);
@@ -183,20 +195,6 @@ namespace {
         PLATFORM_LOG_INFO("runDiskOperation: completed on %{public}s with result %d", 
                           device, static_cast<int>(context.result));
         return context.result;
-    }
-
-    PlatformQuirks::DiskResult runDiskOperation(const char* device,
-                                                 DADiskUnmountCallback callback,
-                                                 int maxRetries = 12) {
-        if ([NSThread isMainThread]) {
-            return runDiskOperationOnMainRunLoop(device, callback, maxRetries);
-        }
-
-        __block PlatformQuirks::DiskResult result = PlatformQuirks::DiskResult::Error;
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            result = runDiskOperationOnMainRunLoop(device, callback, maxRetries);
-        });
-        return result;
     }
 }
 


### PR DESCRIPTION
On current `main`, every write on macOS begins with an error dialog:

> Failed to unmount disk '/dev/diskN'. Please close any applications using the disk and try again.

The disk is not busy. Dismissing the dialog and writing again succeeds, because the unmount we stopped waiting for had already completed. Reproduced on macOS with two different USB flash drives.

## Cause

8b8695ae ("fix(mac): run DiskArbitration on the main run loop") replaced the blocking wait in `runDiskOperation()` with:

```c
CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.0, true);
```

A zero-second `CFRunLoopRunInMode()` only drains sources that are *already* pending and returns immediately. The loop is bounded by `maxRetries * 100` = 1200 iterations, so the timeout documented just above it as 60 seconds now elapses in microseconds — far too soon for `diskarbitrationd` to answer. `context.completed` is still false, `runDiskOperation()` returns `DiskResult::Busy`, and `DownloadThread::_openAndPrepareDevice()` surfaces that as the dialog above.

The same commit also wrapped the call in `dispatch_sync(dispatch_get_main_queue(), ...)`. That is invisible today only because the wait returns instantly; restoring a real wait underneath it would freeze the GUI for the duration of every unmount.

## Fix

- Restore the blocking `CFRunLoopRunInMode(..., 0.05, false)` wait, and the `CFRunLoopStop()` calls in the three DiskArbitration callbacks that wake it early, so the retry budget really is the 60 seconds it claims.
- Run the session on the calling thread's run loop rather than dispatching to the main queue. The callers are the write and format worker threads, so blocking there cannot stall the UI.
- Keep the correct half of 8b8695ae: schedule the session before initiating the operation.

Net effect is the pre-8b8695ae wait behaviour, with that commit's scheduling-order fix retained.

## Testing

Syntax-checked the DiskArbitration path with clang. I have not been able to run a full Qt build locally — a macOS write test on CI or by a maintainer would confirm the dialog is gone.

Found while rebasing a downstream fork onto 2.0.11; the affected file is identical to upstream, so the change applies here unmodified.
