### PR TITLE
feat(gui): run the post-write eject in the background with live status

### DIFF
--- a/src/downloadextractthread.cpp
+++ b/src/downloadextractthread.cpp
@@ -321,7 +321,9 @@ void DownloadExtractThread::_onDownloadSuccess()
         return;
     }
 
-    // Extraction thread already called _writeComplete(), so just emit success to signal thread completion
+    // Extraction thread already called _writeComplete() (image mode) or
+    // performed the eject itself (multi-file mode), so just emit success to
+    // signal thread completion.
     emit success();
 }
 
@@ -793,6 +795,11 @@ void DownloadExtractThread::extractMultiFileRun()
             }
         }
 
+        // Announce the eject before success() so the done screen never claims
+        // the drive is safe to remove while the flush is still running; the
+        // eject itself runs in the cleanup section below, after this signal.
+        if (_ejectEnabled)
+            emit ejectStarted();
         emit success();
     }
     catch (exception &e)
@@ -864,15 +871,14 @@ void DownloadExtractThread::extractMultiFileRun()
     }
 #endif
 
-    // Give the filesystem a moment to settle after sync before ejecting
-    QThread::msleep(500);
-
+    // The eject is announced before success() and performed here afterwards,
+    // so the done screen appears immediately and shows a live "ejecting"
+    // status instead of the write screen freezing on "Finalising…". On macOS
+    // the unmount inside ejectDisk() is what flushes the freshly extracted
+    // files out of the page cache, which can take tens of seconds on a slow
+    // stick.
     if (_ejectEnabled)
-    {
-        // Use canonical device path for eject (e.g., /dev/disk on macOS, not rdisk)
-        QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
-        PlatformQuirks::ejectDisk(ejectPath);
-    }
+        _performEject();
 }
 
 ssize_t DownloadExtractThread::_on_read(struct archive *, const void **buff)

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -1928,13 +1928,7 @@ void DownloadThread::_performEject()
     QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
     PlatformQuirks::DiskResult result = PlatformQuirks::ejectDisk(ejectPath);
 
-    bool succeeded = (result == PlatformQuirks::DiskResult::Success);
-#ifdef Q_OS_WIN
-    // The legacy Windows implementation walks every drive letter, so its
-    // result can carry an unrelated volume's failure even when the target
-    // drive ejected fine. Only report a definite miss.
-    succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
-#endif
+    const bool succeeded = (result == PlatformQuirks::DiskResult::Success);
 
     qDebug() << "Background eject finished for" << ejectPath << "succeeded:" << succeeded;
     emit ejectFinished(succeeded);

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -1908,14 +1908,36 @@ void DownloadThread::_writeComplete()
     QThread::sleep(1);
 #endif
 
+    // Announce the eject before success() so the done screen never shows a
+    // stale "safe to remove" while the background eject is still running.
+    if (_ejectEnabled)
+        emit ejectStarted();
+
     emit success();
 
     if (_ejectEnabled)
-    {
-        // Use canonical device path for eject (e.g., /dev/disk on macOS, not rdisk)
-        QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
-        PlatformQuirks::ejectDisk(ejectPath);
-    }
+        _performEject();
+}
+
+void DownloadThread::_performEject()
+{
+    // Give the filesystem a moment to settle before ejecting
+    QThread::msleep(500);
+
+    // Use canonical device path for eject (e.g., /dev/disk on macOS, not rdisk)
+    QString ejectPath = PlatformQuirks::getEjectDevicePath(_filename);
+    PlatformQuirks::DiskResult result = PlatformQuirks::ejectDisk(ejectPath);
+
+    bool succeeded = (result == PlatformQuirks::DiskResult::Success);
+#ifdef Q_OS_WIN
+    // The legacy Windows implementation walks every drive letter, so its
+    // result can carry an unrelated volume's failure even when the target
+    // drive ejected fine. Only report a definite miss.
+    succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
+#endif
+
+    qDebug() << "Background eject finished for" << ejectPath << "succeeded:" << succeeded;
+    emit ejectFinished(succeeded);
 }
 
 namespace {

--- a/src/downloadthread.h
+++ b/src/downloadthread.h
@@ -192,6 +192,12 @@ signals:
     void cacheFileHashUpdated(QByteArray cacheFileHash, QByteArray imageHash);
     void finalizing();
     void preparationStatusUpdate(QString msg);
+    // Background eject progress after a successful write. ejectStarted() is
+    // emitted before success() so the UI already shows "ejecting" when the
+    // done screen appears; ejectFinished() follows when the drive is safe to
+    // remove (or the eject gave up).
+    void ejectStarted();
+    void ejectFinished(bool succeeded);
     
     // Performance event signals (connected by ImageWriter to PerformanceStats)
     void eventDriveUnmount(quint32 durationMs, bool success);
@@ -245,6 +251,7 @@ protected:
 
     void _hashData(const char *buf, size_t len);
     void _writeComplete();
+    void _performEject();
     virtual bool _verify();
     virtual void _onVerifyProgress() {}  // Called during verify loop for progress updates
     int _authopen(const QByteArray &filename);

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -2696,12 +2696,7 @@ void ImageWriter::ejectDrive()
     QThread *thread = QThread::create([self, device]() {
         PlatformQuirks::DiskResult result =
             PlatformQuirks::ejectDisk(PlatformQuirks::getEjectDevicePath(device));
-        bool succeeded = (result == PlatformQuirks::DiskResult::Success);
-#ifdef Q_OS_WIN
-        // The legacy Windows result can carry an unrelated volume's failure
-        // even when the target drive ejected fine; only report a definite miss.
-        succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
-#endif
+        const bool succeeded = (result == PlatformQuirks::DiskResult::Success);
         QMetaObject::invokeMethod(QCoreApplication::instance(), [self, succeeded]() {
             if (self)
                 self->onEjectFinished(succeeded);

--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -46,6 +46,7 @@
 #include <QTimeZone>
 #include <QNetworkInterface>
 #include <QCoreApplication>
+#include <QPointer>
 #ifndef CLI_ONLY_BUILD
 #include <QQmlContext>
 #include <QWindow>
@@ -509,6 +510,22 @@ ImageWriter::~ImageWriter()
         qDebug() << "Cleaning up CacheManager";
         delete _cacheManager;
         _cacheManager = nullptr;
+    }
+
+    // Give a user-triggered eject a chance to finish before teardown. Never
+    // terminate() it: killing the thread mid-DiskArbitration call is unsafe,
+    // and deleting a QThread that survived terminate() is a qFatal. If it is
+    // still flushing after the grace period, leave it to finish detached — the
+    // worker only reaches this object through a guarded QPointer, so it cannot
+    // touch a destroyed ImageWriter.
+    if (_manualEjectThread) {
+        qDebug() << "Waiting for manual eject thread to finish";
+        if (_manualEjectThread->wait(10000)) {
+            delete _manualEjectThread;
+        } else {
+            qWarning() << "Manual eject still running at teardown; leaving it to finish detached";
+        }
+        _manualEjectThread = nullptr;
     }
 
     // Ensure any running thread is properly cleaned up
@@ -1028,6 +1045,7 @@ void ImageWriter::startWrite()
     }
 
     setWriteState(WriteState::Preparing);
+    setEjectState(EjectState::EjectIdle);
 
     if (_isFastbootDevice)
     {
@@ -1403,6 +1421,8 @@ void ImageWriter::startWrite()
     connect(_thread, SIGNAL(error(QString)), SLOT(onError(QString)));
     connect(_thread, SIGNAL(finalizing()), SLOT(onFinalizing()));
     connect(_thread, SIGNAL(preparationStatusUpdate(QString)), SLOT(onPreparationStatusUpdate(QString)));
+    connect(_thread, &DownloadThread::ejectStarted, this, &ImageWriter::onEjectStarted);
+    connect(_thread, &DownloadThread::ejectFinished, this, &ImageWriter::onEjectFinished);
     // Ensure cleanup of thread pointer on finish in all paths
     connect(_thread, &QThread::finished, this, [this]() {
         if (_thread)
@@ -2629,6 +2649,72 @@ void ImageWriter::restartWrite(QString reason)
         }
         startWrite();
     }
+}
+
+void ImageWriter::setEjectState(EjectState state)
+{
+    if (_ejectState == state)
+        return;
+
+    _ejectState = state;
+    emit ejectStateChanged();
+}
+
+void ImageWriter::onEjectStarted()
+{
+    setEjectState(EjectState::EjectInProgress);
+}
+
+void ImageWriter::onEjectFinished(bool succeeded)
+{
+    // Ignore a stale result if a new write has already reset the state
+    if (_ejectState != EjectState::EjectInProgress)
+        return;
+
+    setEjectState(succeeded ? EjectState::EjectSucceeded : EjectState::EjectFailed);
+}
+
+void ImageWriter::ejectDrive()
+{
+    // The eject result (queued onEjectFinished) can arrive before the worker's
+    // finished() signal, so ejectState alone would let a retry overwrite a
+    // thread that is still winding down — check the thread pointer too.
+    if (_ejectState == EjectState::EjectInProgress || _manualEjectThread)
+        return;
+
+    // Only regular block devices can be ejected (not fastboot targets)
+    if (_dst.isEmpty() || _dst.startsWith("fastboot://"))
+        return;
+
+    setEjectState(EjectState::EjectInProgress);
+
+    const QString device = _dst;
+    // Guard `this` with a QPointer and deliver via the application object: the
+    // destructor does not join a slow eject, so the worker must never touch a
+    // destroyed ImageWriter.
+    QPointer<ImageWriter> self(this);
+    QThread *thread = QThread::create([self, device]() {
+        PlatformQuirks::DiskResult result =
+            PlatformQuirks::ejectDisk(PlatformQuirks::getEjectDevicePath(device));
+        bool succeeded = (result == PlatformQuirks::DiskResult::Success);
+#ifdef Q_OS_WIN
+        // The legacy Windows result can carry an unrelated volume's failure
+        // even when the target drive ejected fine; only report a definite miss.
+        succeeded = (result != PlatformQuirks::DiskResult::InvalidDrive);
+#endif
+        QMetaObject::invokeMethod(QCoreApplication::instance(), [self, succeeded]() {
+            if (self)
+                self->onEjectFinished(succeeded);
+        }, Qt::QueuedConnection);
+    });
+    _manualEjectThread = thread;
+    connect(thread, &QThread::finished, this, [this, thread]() {
+        thread->deleteLater();
+        // A retry may already own the member; only clear our own pointer.
+        if (_manualEjectThread == thread)
+            _manualEjectThread = nullptr;
+    });
+    thread->start();
 }
 
 void ImageWriter::setWriteState(WriteState state)
@@ -4535,6 +4621,8 @@ void ImageWriter::_continueStartWriteAfterCacheVerification(bool cacheIsValid)
     connect(_thread, SIGNAL(error(QString)), SLOT(onError(QString)));
     connect(_thread, SIGNAL(finalizing()), SLOT(onFinalizing()));
     connect(_thread, SIGNAL(preparationStatusUpdate(QString)), SLOT(onPreparationStatusUpdate(QString)));
+    connect(_thread, &DownloadThread::ejectStarted, this, &ImageWriter::onEjectStarted);
+    connect(_thread, &DownloadThread::ejectFinished, this, &ImageWriter::onEjectFinished);
     // Ensure cleanup of thread pointer on finish in all paths
     connect(_thread, &QThread::finished, this, [this]() {
         if (_thread)

--- a/src/imagewriter.h
+++ b/src/imagewriter.h
@@ -66,6 +66,18 @@ public:
     };
     Q_ENUM(WriteState)
 
+    // Progress of the post-write eject, which runs in the background after
+    // success() so the done screen can show a live status instead of the
+    // write blocking on a slow flush. EjectIdle also covers writes where no
+    // eject was requested (auto-eject disabled, fastboot flash).
+    enum class EjectState {
+        EjectIdle,
+        EjectInProgress,
+        EjectSucceeded,
+        EjectFailed
+    };
+    Q_ENUM(EjectState)
+
     // NB: the parent argument is deliberately mandatory (no `= nullptr`).
     // ImageWriter is a QML_SINGLETON whose instance is supplied by main() via
     // setQmlInstance()/create(). Qt's qmlRegisterTypesAndRevisions only honours a
@@ -88,6 +100,7 @@ public:
 #endif
 
     Q_PROPERTY(WriteState writeState READ writeState NOTIFY writeStateChanged)
+    Q_PROPERTY(EjectState ejectState READ ejectState NOTIFY ejectStateChanged)
     Q_PROPERTY(bool isOsListUnavailable READ isOsListUnavailable NOTIFY osListUnavailableChanged)
     Q_PROPERTY(bool screenReaderActive READ isScreenReaderActive NOTIFY screenReaderActiveChanged)
 
@@ -125,6 +138,11 @@ public:
 
     /* Cancel write */
     Q_INVOKABLE void cancelWrite();
+
+    /* Manually eject the written drive (retry after a failed background
+       eject, or first eject when auto-eject is disabled). Runs on a
+       background thread; progress is reported via ejectState. */
+    Q_INVOKABLE void ejectDrive();
 
     /* Skip cache verification and proceed with download */
     Q_INVOKABLE void skipCacheVerification();
@@ -477,6 +495,7 @@ signals:
     void keychainPermissionRequested();
     void keychainPermissionResponseReceived();
     void writeStateChanged();
+    void ejectStateChanged();
     void connectTokenReceived(const QString &token);
     void connectTokenConflictDetected(const QString &token);
     void connectTokenCleared();
@@ -498,6 +517,8 @@ protected slots:
     
     void onSuccess();
     void onError(QString msg);
+    void onEjectStarted();
+    void onEjectFinished(bool succeeded);
     void onFileSelected(QString filename);
     void onCancelled();
     void onFinalizing();
@@ -524,6 +545,8 @@ private:
 #endif
     void setWriteState(WriteState state);
     WriteState writeState() const { return _writeState; }
+    void setEjectState(EjectState state);
+    EjectState ejectState() const { return _ejectState; }
     // Cache management
     CacheManager* _cacheManager;
     bool _waitingForCacheVerification;
@@ -554,6 +577,8 @@ protected:
     DriveListModel _drivelist;
     bool _selectedDeviceValid;
     WriteState _writeState;
+    EjectState _ejectState = EjectState::EjectIdle;
+    QThread *_manualEjectThread = nullptr;
     bool _cancelledDueToDeviceRemoval;
     HWListModel _hwlist;
     OSListModel _oslist;

--- a/src/mac/platformquirks_macos.mm
+++ b/src/mac/platformquirks_macos.mm
@@ -141,7 +141,7 @@ namespace {
         }
     }
     
-    // Default timeout: 60 seconds (maxRetries * 100 * 0.05s = 60s with maxRetries=12)
+    // Timeout: maxRetries * 100 iterations * 0.05s, so maxRetries=12 -> 60s.
     // Slow USB drives with many files open may take significant time to unmount
     PlatformQuirks::DiskResult runDiskOperationOnMainRunLoop(const char* device,
                                                                 DADiskUnmountCallback callback,
@@ -568,9 +568,14 @@ DiskResult ejectDisk(const QString& device) {
     
     QByteArray bsdNameBytes = bsdName.toUtf8();
     qDebug() << "ejectDisk: ejecting" << bsdNameBytes.constData();
-    
-    // Use the combined unmount+eject callback
-    return runDiskOperation(bsdNameBytes.constData(), ejectUnmountCallback);
+
+    // Use the combined unmount+eject callback. The unmount is what flushes
+    // everything the extract path just wrote out of the page cache, and on a
+    // slow stick that alone can exceed the 60-second default. Give the flush
+    // five minutes; the callers treat the result as best-effort, but timing
+    // out early would let the UI claim the drive is safe to remove while the
+    // kernel is still writing to it.
+    return runDiskOperation(bsdNameBytes.constData(), ejectUnmountCallback, 60);
 }
 
 qreal detectTextScaleFactor()

--- a/src/wizard/DoneStep.qml
+++ b/src/wizard/DoneStep.qml
@@ -18,7 +18,10 @@ WizardStepBase {
     title: qsTr("Write complete!")
     showBackButton: false
     showNextButton: false
-    readonly property bool autoEjectEnabled: ImageWriterSingleton.getBoolSetting("eject")
+    readonly property var ejectState: ImageWriterSingleton.ejectState
+    readonly property bool ejectInProgress: ejectState === ImageWriterSingleton.EjectInProgress
+    // Fastboot targets have no removable medium to eject
+    readonly property bool ejectApplicable: !ImageWriterSingleton.isFastbootDevice()
     // Use snapshot of customization flags captured when write completed
     // This preserves the state even after token/flags are cleared for security
     readonly property bool anyCustomizationsApplied: (
@@ -234,10 +237,22 @@ WizardStepBase {
             }
             FocusableText {
                 id: ejectInstruction
-                text: root.autoEjectEnabled ? qsTr("The storage device was ejected automatically. You can now remove it safely.") : qsTr("Please eject the storage device before removing it from your computer.")
+                visible: root.ejectApplicable
+                text: {
+                    if (root.ejectState === ImageWriterSingleton.EjectInProgress)
+                        return qsTr("Ejecting the storage device — do not remove it yet…")
+                    if (root.ejectState === ImageWriterSingleton.EjectSucceeded)
+                        return qsTr("The storage device was ejected. You can now remove it safely.")
+                    if (root.ejectState === ImageWriterSingleton.EjectFailed)
+                        return qsTr("The storage device could not be ejected. Close any application still using it, then press Eject.")
+                    // EjectIdle: no eject ran for this write, so never claim one
+                    // did — instruct the user to eject before removal instead.
+                    return qsTr("Please eject the storage device before removing it from your computer.")
+                }
                 font.pointSize: Style.fontSizeDescription
                 font.family: Style.fontFamily
-                color: Style.textDescriptionColor
+                color: root.ejectInProgress || root.ejectState === ImageWriterSingleton.EjectFailed ? Style.formLabelColor : Style.textDescriptionColor
+                font.bold: root.ejectInProgress || root.ejectState === ImageWriterSingleton.EjectFailed
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
@@ -253,10 +268,24 @@ WizardStepBase {
         },
         
         ImButton {
+            id: ejectButton
+            text: qsTr("Eject")
+            accessibleDescription: qsTr("Eject the storage device so it can be removed safely")
+            visible: root.ejectApplicable &&
+                     (root.ejectState === ImageWriterSingleton.EjectFailed ||
+                      root.ejectState === ImageWriterSingleton.EjectIdle)
+            activeFocusOnTab: true
+            Layout.minimumWidth: Style.buttonWidthMinimum
+            Layout.preferredHeight: Style.buttonHeightStandard
+            onVisibleChanged: root.rebuildFocusOrder()
+            onClicked: ImageWriterSingleton.ejectDrive()
+        },
+
+        ImButton {
             id: writeAnotherButton
             text: qsTr("Write Another")
             accessibleDescription: qsTr("Return to storage selection to write the same image to another storage device")
-            enabled: true
+            enabled: !root.ejectInProgress
             activeFocusOnTab: true
             Layout.minimumWidth: Style.buttonWidthMinimum
             Layout.preferredHeight: Style.buttonHeightStandard
@@ -270,8 +299,8 @@ WizardStepBase {
         ImButtonRed {
             id: finishButton
             text: ImageWriterSingleton.isEmbeddedMode() ? qsTr("Reboot") : CommonStrings.finish
-            accessibleDescription: ImageWriterSingleton.isEmbeddedMode() ? qsTr("Reboot the system to apply changes") : qsTr("Close Raspberry Pi Imager and exit the application")
-            enabled: true
+            accessibleDescription: root.ejectInProgress ? qsTr("Available once the storage device has been ejected") : (ImageWriterSingleton.isEmbeddedMode() ? qsTr("Reboot the system to apply changes") : qsTr("Close Raspberry Pi Imager and exit the application"))
+            enabled: !root.ejectInProgress
             activeFocusOnTab: true
             Layout.minimumWidth: Style.buttonWidthMinimum
             Layout.preferredHeight: Style.buttonHeightStandard
@@ -308,12 +337,17 @@ WizardStepBase {
         
         // Register eject instruction as third focus group
         registerFocusGroup("eject", function() {
-            return [ejectInstruction]
+            return ejectInstruction.visible ? [ejectInstruction] : []
         }, 2)
         
         // Register custom buttons as fourth focus group
         registerFocusGroup("buttons", function() {
-            return [writeAnotherButton, finishButton]
+            var buttons = []
+            if (ejectButton.visible)
+                buttons.push(ejectButton)
+            buttons.push(writeAnotherButton)
+            buttons.push(finishButton)
+            return buttons
         }, 3)
         
         // Ensure focus order is built after custom buttons are fully instantiated

--- a/src/wizard/DoneStep.qml
+++ b/src/wizard/DoneStep.qml
@@ -242,7 +242,7 @@ WizardStepBase {
                     if (root.ejectState === ImageWriterSingleton.EjectInProgress)
                         return qsTr("Ejecting the storage device — do not remove it yet…")
                     if (root.ejectState === ImageWriterSingleton.EjectSucceeded)
-                        return qsTr("The storage device was ejected. You can now remove it safely.")
+                        return qsTr("The storage device was ejected automatically. You can now remove it safely.")
                     if (root.ejectState === ImageWriterSingleton.EjectFailed)
                         return qsTr("The storage device could not be ejected. Close any application still using it, then press Eject.")
                     // EjectIdle: no eject ran for this write, so never claim one


### PR DESCRIPTION
## Problem

After a write finishes, the eject runs synchronously inside the write/extract threads. On macOS the unmount inside `ejectDisk()` is what flushes the freshly written data out of the page cache, so it can run for tens of seconds on a slow stick — measured with the DiskArbitration code against hdiutil FAT32 volumes: **6.5 s** to eject an empty 64 MB volume, **10.1 s** after writing 250 MB across 1000 files. A slow physical stick with a large multi-file payload can exceed the 60-second timeout entirely.

During that window the UI either freezes on "Finalising…" or shows the done screen already claiming *"The storage device was ejected automatically. You can now remove it safely."* — while the kernel is still writing to the drive. Users who trust that text can pull a stick mid-flush and corrupt it; users who don't get what looks like a hung app.

Today this is partially masked on `main` because the zero-second `CFRunLoopRunInMode()` polling loop (from 8b8695ae) makes the eject return in microseconds without waiting — but that also means the "safe to remove" text has never actually been true. Once DiskArbitration callbacks are delivered again (#1674 fixes this), the synchronous eject genuinely blocks and the freeze becomes user-visible. We shipped this exact sequence in our downstream fork (unraid/usb-creator-next): fixing the DA wait immediately produced "app hangs after write, force-quit needed" reports, which this restructure fixed.

## Change

Two commits:

**`fix(macos)`** — raise the eject's DiskArbitration timeout to five minutes (unmount keeps 60 s). The callers treat the result as best-effort, but timing out early lets the UI claim safety mid-flush. This composes with either DA wait implementation, including #1674's.

**`feat(gui)`** — never let user-visible state get ahead of the hardware:

- `DownloadThread` gains `ejectStarted()` / `ejectFinished(bool)` and a shared `_performEject()`; every write path announces the eject, emits `success()` immediately, then ejects on its worker thread — the done screen appears the moment the write finishes.
- `ImageWriter` exposes an `EjectState` property (`Idle / InProgress / Succeeded / Failed`) plus `Q_INVOKABLE ejectDrive()` for a manual eject/retry on a disposable thread. The thread is never `terminate()`d (a thread blocked in a DA `mach_msg` may never receive the deferred cancellation, after which deleting the still-running `QThread` is a qFatal); teardown waits briefly and otherwise leaves it to finish detached behind a `QPointer` guard. Retry is protected against the queued result arriving before `QThread::finished` (pointer-match cleanup).
- The done screen shows the live status — *"Ejecting the storage device — do not remove it yet…"* → *"…ejected. You can now remove it safely."*, or a failure message with an **Eject** button — and disables Finish / Write Another while an eject is in flight. The safe-removal text now only appears after an eject actually succeeded, and the eject text/button are hidden for fastboot targets, which have no removable medium.

## Testing

- All touched C++ TUs syntax-checked against Qt 6; QML linted.
- The equivalent change shipped downstream in unraid/usb-creator-next v2.0.11-unraid.2-rc.2 (PR unraid/usb-creator-next#121, CodeRabbit-reviewed) and is in QA on real hardware there now.
- Needs a maintainer-side macOS write to see the full effect once #1674 restores real DA waits; on current `main` the UI changes are visible but the eject still returns instantly.

## Relationship to #1674

Complementary, not conflicting: #1674 fixes *how* the DA callbacks are delivered; this PR fixes *when* the eject runs relative to `success()` and what the UI claims meanwhile. The only shared file is `platformquirks_macos.mm`, where this PR's change is the one-line eject timeout (plus comment) — trivial to rebase whichever lands second.