### PR TITLE
fix(zstd): test the content-size sentinels by name

### DIFF
--- a/src/imagewriter.cpp
+++ b/src/imagewriter.cpp
@@ -2967,10 +2967,26 @@ void ImageWriter::_parseZstdFile()
 
     unsigned long long fcs = ZSTD_findDecompressedSize(data.constData(), data.size());
 
+    // The failure sentinels are (0ULL - 2) and (0ULL - 1), not 0, so they have to
+    // be tested by name: comparing against 0 alone lets ZSTD_CONTENTSIZE_UNKNOWN
+    // through as _extrLen = ULLONG_MAX, and startWrite() then rejects a perfectly
+    // good local image with "Storage capacity is not large enough".
+    if (fcs == ZSTD_CONTENTSIZE_ERROR)
+    {
+        qDebug() << "Unable to parse .zst file (invalid or truncated frames)";
+        return;
+    }
+
+    if (fcs == ZSTD_CONTENTSIZE_UNKNOWN)
+    {
+        // Size not recorded in the frame headers (streaming-compressed input).
+        // Leave _extrLen unknown and let progress fall back to the download size.
+        qDebug() << "Parsed .zst file. Uncompressed size: unknown (FCS not present)";
+        return;
+    }
+
     if (fcs == 0)
     {
-        // Could be ZSTD_CONTENTSIZE_ERROR or ZSTD_CONTENTSIZE_UNKNOWN,
-        // or a valid zero-size file. Fall back to unknown.
         qDebug() << "Unable to determine decompressed size of .zst file";
         return;
     }


### PR DESCRIPTION
`65269fa3` swapped `ZSTD_getFrameContentSize()` for `ZSTD_findDecompressedSize()` to support multi-frame `.img.zst`, and kept the `fcs == 0` guard that belonged to the old call. Both functions report failure the same way, and it is not with `0`:

- `ZSTD_CONTENTSIZE_ERROR` is `(0ULL - 1)`
- `ZSTD_CONTENTSIZE_UNKNOWN` is `(0ULL - 2)`

A stream-compressed image records no frame content size, so it returns `ZSTD_CONTENTSIZE_UNKNOWN`, passes the `fcs == 0` check, and sets `_extrLen = ULLONG_MAX`. `startWrite()` then compares that against the drive and rejects a perfectly good local image with "Storage capacity is not large enough".

This tests both sentinels by name. An unknown size returns without setting `_extrLen`, which leaves progress reporting on the download size — the behavior before `65269fa3`. The `fcs == 0` case stays for a genuinely empty payload.

Found while reviewing the 2.0.11-rc2 set against our fork. Not compiled here (no Qt toolchain on this machine); CI covers the build.
