### PR TITLE
fastboot: tell a transport failure apart from a device denial

### DIFF
--- a/src/drivelistmodelpollthread.cpp
+++ b/src/drivelistmodelpollthread.cpp
@@ -161,18 +161,30 @@ void DriveListModelPollThread::run()
                         // before exposing it as a flashable target. The gadget
                         // borrows Google's 18d1:4e40 VID/PID, so a non-Pi
                         // device (e.g. an Android phone in a colliding fastboot
-                        // mode) could enumerate identically. isRpiFastboot()
+                        // mode) could enumerate identically. identifyRpiFastboot()
                         // checks the authoritative USB interface descriptor
                         // ("fastbootd-provisioner") and falls back to the
-                        // RPi-specific block-devices getvar. If neither
-                        // confirms a Pi, cache a storage-less entry so the
-                        // device is neither listed as a target nor re-probed on
-                        // every tick, and skip it.
-                        if (!fb.isRpiFastboot(*transport)) {
+                        // RPi-specific block-devices getvar. Only a device that
+                        // actually answered and denied it is cached as a
+                        // storage-less entry, so it is neither listed as a
+                        // target nor re-probed on every tick; a probe that got
+                        // no answer is retried instead of being banked.
+                        const auto identity = fb.identifyRpiFastboot(*transport);
+                        if (identity == fastboot::RpiIdentity::ConfirmedNotPi) {
                             qDebug() << "Fastboot: ignoring non-RPi device at"
                                      << QString::fromStdString(ppKey)
                                      << "(did not identify as rpi-fastbootd)";
                             _fastbootCache[ppKey] = std::move(cache);
+                            continue;
+                        }
+                        if (identity == fastboot::RpiIdentity::Inconclusive) {
+                            // The probe got no answer — which is also what a Pi
+                            // still starting its gadget looks like. Caching this
+                            // would strand a genuine device until it is
+                            // unplugged, so skip the tick and re-probe next one.
+                            qDebug() << "Fastboot: identity probe inconclusive at"
+                                     << QString::fromStdString(ppKey)
+                                     << "- will retry on the next scan";
                             continue;
                         }
 

--- a/src/fastboot/fastboot_protocol.cpp
+++ b/src/fastboot/fastboot_protocol.cpp
@@ -26,7 +26,9 @@ Response FastbootProtocol::readResponse(rpiboot::IUsbTransport& transport, int t
 
     int bytesRead = transport.bulkRead(EP_IN, span, timeoutMs);
     if (bytesRead < 4) {
-        return {Response::Fail, "Short or failed read from device", 0};
+        // No usable answer came back. This is not the device saying "no" — it
+        // is the device saying nothing — so report it distinctly.
+        return {Response::TransportError, "Short or failed read from device", 0};
     }
 
     std::string raw(reinterpret_cast<const char*>(buf), static_cast<size_t>(bytesRead));
@@ -78,9 +80,13 @@ FastbootProtocol::CaptureResult FastbootProtocol::sendCommandCapture(
     auto data = std::span<const uint8_t>(
         reinterpret_cast<const uint8_t*>(command.data()), command.size());
 
+    // A command is one small ASCII write with no continuation, so a short write
+    // is not something to resume — it means the device received a truncated
+    // command, and any response we then read is answering something we did not
+    // ask. Treat it exactly like a failed write.
     int written = transport.bulkWrite(EP_OUT, data, timeoutMs);
-    if (written < 0) {
-        result.terminal = {Response::Fail, "Failed to send command", 0};
+    if (written < 0 || static_cast<size_t>(written) != data.size()) {
+        result.terminal = {Response::TransportError, "Failed to send complete command", 0};
         return result;
     }
 
@@ -123,9 +129,12 @@ bool FastbootProtocol::sendData(rpiboot::IUsbTransport& transport,
 
     auto cmdSpan = std::span<const uint8_t>(
         reinterpret_cast<const uint8_t*>(cmd), static_cast<size_t>(cmdLen));
+    // Short write means a truncated command header — see sendCommandCapture().
+    // Here it would be read back as a bad size, so fail rather than stream a
+    // payload the device is not expecting.
     int written = transport.bulkWrite(EP_OUT, cmdSpan, 3000);
-    if (written < 0) {
-        _lastError = std::string("Failed to send ") + std::string(commandPrefix) + " command";
+    if (written < 0 || static_cast<size_t>(written) != cmdSpan.size()) {
+        _lastError = std::string("Failed to send complete ") + std::string(commandPrefix) + " command";
         return false;
     }
 
@@ -204,9 +213,10 @@ std::vector<uint8_t> FastbootProtocol::upload(rpiboot::IUsbTransport& transport,
     const char* cmd = "upload";
     auto cmdSpan = std::span<const uint8_t>(
         reinterpret_cast<const uint8_t*>(cmd), std::strlen(cmd));
+    // Short write means a truncated command — see sendCommandCapture().
     int written = transport.bulkWrite(EP_OUT, cmdSpan, 3000);
-    if (written < 0) {
-        _lastError = "Failed to send upload command";
+    if (written < 0 || static_cast<size_t>(written) != cmdSpan.size()) {
+        _lastError = "Failed to send complete upload command";
         return {};
     }
 
@@ -433,22 +443,34 @@ std::optional<std::string> FastbootProtocol::getVar(rpiboot::IUsbTransport& tran
 
 // ── Device identification ──────────────────────────────────────────────
 
-bool FastbootProtocol::isRpiFastboot(rpiboot::IUsbTransport& transport)
+RpiIdentity FastbootProtocol::identifyRpiFastboot(rpiboot::IUsbTransport& transport)
 {
     // Prefer the authoritative signal: the USB interface string descriptor
     // the RPi gadget advertises ("fastbootd-provisioner").  It is available
     // at open time, before any fastboot command, and stock Android
     // fastboot/fastbootd advertises "fastbootd" / "Android Fastboot" instead.
     if (transport.interfaceString() == rpiboot::FASTBOOT_INTERFACE_DESCRIPTOR)
-        return true;
+        return RpiIdentity::ConfirmedPi;
 
     // Fall back to a protocol-level probe: rpi-fastbootd implements the
     // RPi-specific "block-devices" getvar to enumerate flashable storage,
-    // which stock Android fastboot does not (→ getVar yields nullopt).  This
-    // covers transports that cannot read the descriptor (e.g. non-USB) and
-    // gadgets built with a customised interface string, while still rejecting
-    // a non-Pi device that merely matches the borrowed 18d1:4e40 VID/PID.
-    return getVar(transport, "block-devices").has_value();
+    // which stock Android fastboot does not (→ FAIL).  This covers transports
+    // that cannot read the descriptor (e.g. non-USB) and gadgets built with a
+    // customised interface string, while still rejecting a non-Pi device that
+    // merely matches the borrowed 18d1:4e40 VID/PID.
+    auto resp = sendCommand(transport, "getvar:block-devices", 3000);
+    switch (resp.type) {
+    case Response::Okay:
+        // Implementing the getvar at all is the positive signal; an empty list
+        // just means a Pi with no attached storage.
+        return RpiIdentity::ConfirmedPi;
+    case Response::TransportError:
+        // Nothing answered. A Pi whose gadget is still coming up looks exactly
+        // like this, so leave the question open rather than banking a "no".
+        return RpiIdentity::Inconclusive;
+    default:
+        return RpiIdentity::ConfirmedNotPi;
+    }
 }
 
 // ── Combined flash ─────────────────────────────────────────────────────

--- a/src/fastboot/fastboot_protocol.h
+++ b/src/fastboot/fastboot_protocol.h
@@ -25,10 +25,22 @@
 namespace fastboot {
 
 struct Response {
-    enum Type { Okay, Fail, Data, Info, Text };
+    // TransportError means we never heard from the device at all (the bulk
+    // write or read failed), as opposed to Fail, which is the device answering
+    // and refusing. Callers that only ask "did this succeed?" can keep testing
+    // against Okay; callers that must not confuse "no" with "no answer" —
+    // device identification, above all — have to tell the two apart.
+    enum Type { Okay, Fail, Data, Info, Text, TransportError };
     Type type = Fail;
     std::string message;
     uint32_t dataSize = 0;  // Only valid for Data type
+};
+
+// Outcome of identifying a device as a genuine rpi-fastbootd gadget.
+enum class RpiIdentity {
+    ConfirmedPi,     // the descriptor or the block-devices getvar confirms it
+    ConfirmedNotPi,  // the device answered the probe and denied it
+    Inconclusive,    // the probe never got an answer; identity still unknown
 };
 
 class FastbootProtocol {
@@ -103,8 +115,13 @@ public:
     //   2. a fallback probe of the RPi-specific "block-devices" getvar, which
     //      stock Android fastboot/fastbootd does not implement (FAILs), for
     //      transports that cannot read the descriptor or customised gadgets.
-    // Returns true only when one of these confirms a Pi; false otherwise.
-    bool isRpiFastboot(rpiboot::IUsbTransport& transport);
+    //
+    // A transport failure is reported as Inconclusive rather than as a denial:
+    // a genuine Pi that is still bringing its gadget up answers nothing for a
+    // moment, and treating that as ConfirmedNotPi would strand it. Callers
+    // deciding whether to *write* must require ConfirmedPi; callers deciding
+    // whether to *remember* a rejection must accept only ConfirmedNotPi.
+    RpiIdentity identifyRpiFastboot(rpiboot::IUsbTransport& transport);
 
     // Combined download + flash in one call.
     bool flashImage(rpiboot::IUsbTransport& transport,

--- a/src/fastbootflashthread.cpp
+++ b/src/fastbootflashthread.cpp
@@ -658,6 +658,19 @@ bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
     // targets it directly and mounts "<dev>p1", so no partition suffix here.
     const std::string dev = _blockDevice.toStdString();
 
+    // Every step below is destructive, so cancellation is checked before and
+    // after each one: a cancel landing between two commands must not let the
+    // next one run, and must never reach emit success().
+    auto stopIfCancelled = [this]() {
+        if (!_cancelled.load())
+            return false;
+        emit error(tr("Cancelled"));
+        return true;
+    };
+
+    if (stopIfCancelled())
+        return false;
+
     // 1. Bare wipe of the whole device. The daemon's erase handler calls
     //    wipe_block_device(), which issues BLKDISCARD (near-instant on eMMC
     //    that supports it) or falls back to zeroing the device — which can
@@ -665,8 +678,7 @@ bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
     emit preparationStatusUpdate(tr("Erasing storage device..."));
     qDebug() << "FastbootFlashThread: erase:" << QString::fromStdString(dev);
     auto resp = fb.sendCommand(transport, "erase:" + dev, 600000);
-    if (_cancelled.load()) {
-        emit error(tr("Cancelled"));
+    if (stopIfCancelled()) {
         return false;
     }
     if (resp.type != fastboot::Response::Okay) {
@@ -679,6 +691,9 @@ bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
     emit preparationStatusUpdate(tr("Writing partition table..."));
     qDebug() << "FastbootFlashThread: oem partinit" << QString::fromStdString(dev) << "dos";
     resp = fb.sendCommand(transport, "oem partinit " + dev + " dos", 60000);
+    if (stopIfCancelled()) {
+        return false;
+    }
     if (resp.type != fastboot::Response::Okay) {
         emit error(tr("Failed to write partition table: %1")
                    .arg(QString::fromStdString(resp.message)));
@@ -694,6 +709,9 @@ bool FastbootFlashThread::performErase(fastboot::FastbootProtocol& fb,
     emit preparationStatusUpdate(tr("Creating FAT32 partition..."));
     qDebug() << "FastbootFlashThread: oem partapp" << QString::fromStdString(dev) << "c";
     resp = fb.sendCommand(transport, "oem partapp " + dev + " c", 60000);
+    if (stopIfCancelled()) {
+        return false;
+    }
     if (resp.type != fastboot::Response::Okay) {
         emit error(tr("Failed to create partition: %1")
                    .arg(QString::fromStdString(resp.message)));
@@ -748,12 +766,16 @@ void FastbootFlashThread::runImpl()
     // Safety gate: refuse to touch anything that is not a genuine
     // rpi-fastbootd gadget. The device matched only on the 18d1:4e40 VID/PID
     // the gadget borrows from Google, so verify its identity before issuing
-    // any destructive command (erase / partition / flash). isRpiFastboot()
+    // any destructive command (erase / partition / flash). identifyRpiFastboot()
     // checks the authoritative USB interface descriptor ("fastbootd-provisioner")
     // and falls back to the RPi-specific block-devices getvar. This ensures a
     // non-Pi device in a colliding fastboot mode can never be written to,
     // even if it somehow reached this point.
-    if (!fb.isRpiFastboot(*transport)) {
+    //
+    // Only a positive confirmation is good enough here: an inconclusive probe
+    // means we do not know what this device is, and "unknown" must never be
+    // enough to start erasing it.
+    if (fb.identifyRpiFastboot(*transport) != fastboot::RpiIdentity::ConfirmedPi) {
         emit error(tr("Refusing to flash %1: the device did not identify as a "
                       "Raspberry Pi fastboot device.").arg(_fastbootId));
         return;

--- a/src/rpiboot/test/mock_usb_transport.h
+++ b/src/rpiboot/test/mock_usb_transport.h
@@ -48,6 +48,10 @@ public:
     // Configure a simulated failure on the next N bulk writes
     void failNextBulkWrites(int count) { _failBulkWriteCount = count; }
 
+    // Make the next bulk write report a short (but non-negative) transfer of
+    // `bytes`, as a real USB stack may. Applies once.
+    void shortNextBulkWrite(int bytes) { _shortBulkWriteBytes = bytes; }
+
     // Configure a simulated failure on the next N control transfers
     void failNextControlTransfers(int count) { _failControlCount = count; }
 
@@ -112,6 +116,13 @@ public:
         }
 
         _capturedBulkWrites.emplace_back(data.begin(), data.end());
+
+        if (_shortBulkWriteBytes >= 0) {
+            int n = _shortBulkWriteBytes;
+            _shortBulkWriteBytes = -1;
+            return n;
+        }
+
         return static_cast<int>(data.size());
     }
 
@@ -137,6 +148,7 @@ private:
     bool _isOpen = true;
     std::string _interfaceString;
     int _failBulkWriteCount = 0;
+    int _shortBulkWriteBytes = -1;  // -1 = write everything
     int _failControlCount = 0;
     std::deque<std::vector<uint8_t>> _bulkReadQueue;
     std::vector<std::vector<uint8_t>> _capturedBulkWrites;

--- a/src/test/fastboot_protocol_test.cpp
+++ b/src/test/fastboot_protocol_test.cpp
@@ -183,26 +183,26 @@ TEST_CASE("FastbootProtocol getVar returns nullopt on FAIL", "[fastboot][protoco
 }
 
 // ────────────────────────────────────────────────────────────────────────
-// Device identification (isRpiFastboot) — guards against a non-Pi device
+// Device identification (identifyRpiFastboot) — guards against a non-Pi device
 // that happens to enumerate as the borrowed 18d1:4e40 VID/PID.
 //
 // Primary signal: the USB interface descriptor "fastbootd-provisioner".
 // Fallback: the RPi-specific "block-devices" getvar.
 // ────────────────────────────────────────────────────────────────────────
 
-TEST_CASE("FastbootProtocol isRpiFastboot true on the fastbootd-provisioner interface descriptor", "[fastboot][protocol][identity]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot confirms on the fastbootd-provisioner interface descriptor", "[fastboot][protocol][identity]")
 {
     MockUsbTransport mock;
     mock.setInterfaceString("fastbootd-provisioner");
 
     FastbootProtocol fb;
-    CHECK(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedPi);
 
     // The descriptor is authoritative — no getvar probe should be sent.
     CHECK(mock.capturedBulkWrites().empty());
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot false for a non-Pi interface descriptor with no block-devices", "[fastboot][protocol][identity][negative]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot denies a non-Pi interface descriptor with no block-devices", "[fastboot][protocol][identity][negative]")
 {
     // e.g. a stock Android device that matched the borrowed VID/PID.
     MockUsbTransport mock;
@@ -210,17 +210,17 @@ TEST_CASE("FastbootProtocol isRpiFastboot false for a non-Pi interface descripto
     mock.queueBulkReadResponse(makeResponse("FAIL", "unknown variable"));
 
     FastbootProtocol fb;
-    CHECK_FALSE(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedNotPi);
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot falls back to block-devices when the descriptor is unavailable", "[fastboot][protocol][identity]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot falls back to block-devices when the descriptor is unavailable", "[fastboot][protocol][identity]")
 {
     // No interface descriptor (default empty) → protocol-level fallback.
     MockUsbTransport mock;
     mock.queueBulkReadResponse(makeResponse("OKAY", "mmcblk0,nvme0n1"));
 
     FastbootProtocol fb;
-    CHECK(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedPi);
 
     // Verify it probed the RPi-specific getvar
     REQUIRE(!mock.capturedBulkWrites().empty());
@@ -228,7 +228,7 @@ TEST_CASE("FastbootProtocol isRpiFastboot falls back to block-devices when the d
     CHECK(sent == "getvar:block-devices");
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot true for a Pi with an empty block-devices list", "[fastboot][protocol][identity]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot confirms a Pi with an empty block-devices list", "[fastboot][protocol][identity]")
 {
     // A genuine Pi with no attached storage still OKAYs the getvar (empty
     // value). Implementing the getvar at all is the positive signal.
@@ -236,27 +236,72 @@ TEST_CASE("FastbootProtocol isRpiFastboot true for a Pi with an empty block-devi
     mock.queueBulkReadResponse(makeResponse("OKAY", ""));
 
     FastbootProtocol fb;
-    CHECK(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedPi);
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot false when block-devices FAILs", "[fastboot][protocol][identity][negative]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot denies when block-devices FAILs", "[fastboot][protocol][identity][negative]")
 {
     // Stock Android fastboot/fastbootd does not implement block-devices and
-    // returns FAIL — the device must be rejected.
+    // returns FAIL — the device answered, and the answer was no.
     MockUsbTransport mock;
     mock.queueBulkReadResponse(makeResponse("FAIL", "unknown variable"));
 
     FastbootProtocol fb;
-    CHECK_FALSE(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::ConfirmedNotPi);
 }
 
-TEST_CASE("FastbootProtocol isRpiFastboot false when the transport is dead", "[fastboot][protocol][identity][negative]")
+TEST_CASE("FastbootProtocol identifyRpiFastboot is inconclusive when the transport is dead", "[fastboot][protocol][identity][negative]")
 {
-    // No queued response → bulkRead fails → not identified as a Pi.
+    // No queued response → bulkRead fails → we never heard from the device.
+    // This must NOT be recorded as a denial: a genuine Pi that is still
+    // bringing its gadget up is indistinguishable from this, and caching a
+    // "not a Pi" verdict here would strand it until it is unplugged.
     MockUsbTransport mock;
 
     FastbootProtocol fb;
-    CHECK_FALSE(fb.isRpiFastboot(mock));
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::Inconclusive);
+}
+
+TEST_CASE("FastbootProtocol rejects a short command write", "[fastboot][protocol][negative]")
+{
+    // A command is a single small ASCII write with no continuation. A positive
+    // but short transfer means the device got a truncated command, so any
+    // response read afterwards is answering something we never sent — even a
+    // queued OKAY must not be accepted.
+    MockUsbTransport mock;
+    mock.shortNextBulkWrite(3);
+    mock.queueBulkReadResponse(makeResponse("OKAY", "mmcblk0"));
+
+    FastbootProtocol fb;
+    CHECK(fb.sendCommand(mock, "getvar:block-devices", 100).type
+          == Response::TransportError);
+}
+
+TEST_CASE("FastbootProtocol short command write is not read as a device denial", "[fastboot][protocol][identity][negative]")
+{
+    // The identity probe must not downgrade a truncated command to
+    // ConfirmedNotPi — that would be cached and strand a genuine Pi.
+    MockUsbTransport mock;
+    mock.shortNextBulkWrite(3);
+
+    FastbootProtocol fb;
+    CHECK(fb.identifyRpiFastboot(mock) == RpiIdentity::Inconclusive);
+}
+
+TEST_CASE("FastbootProtocol reports a dead transport as TransportError, not Fail", "[fastboot][protocol][identity][negative]")
+{
+    // The distinction the tri-state identity rests on: a device that refuses
+    // answers Fail, a device that is not talking yields TransportError.
+    MockUsbTransport mock;
+
+    FastbootProtocol fb;
+    CHECK(fb.sendCommand(mock, "getvar:block-devices", 100).type
+          == Response::TransportError);
+
+    MockUsbTransport refusing;
+    refusing.queueBulkReadResponse(makeResponse("FAIL", "unknown variable"));
+    CHECK(fb.sendCommand(refusing, "getvar:block-devices", 100).type
+          == Response::Fail);
 }
 
 // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Two related fixes in the fastboot path, both found reviewing #1674 against our fork.

### A Pi that is still starting its gadget can be stranded

`isRpiFastboot()` returns a `bool`, so "the device said no" and "the device said nothing" collapse into the same `false`. `DriveListModelPollThread` caches that as a permanent storage-less entry — and a Pi whose fastboot gadget is still coming up answers nothing for the first moment after it enumerates. The device is then never offered as a target until it is unplugged and replugged.

`Response` gains `TransportError`, and `identifyRpiFastboot()` replaces the bool with `ConfirmedPi` / `ConfirmedNotPi` / `Inconclusive`. A write requires `ConfirmedPi`; only `ConfirmedNotPi` is cached, so an inconclusive probe is retried on the next scan instead of banked.

### Short command writes were read as responses

`bulkWrite()` returns the transfer count, but the three raw command writes only checked for a negative result. A positive short write was accepted as success, so `sendCommandCapture()`, `sendData()` and `upload()` went on to read a response to a command the device had only partly received.

A command is one small ASCII write with no continuation, so a short write is not something to resume — unlike the payload loop in `sendData()`, which correctly advances by the transferred count and is left alone.

This compounds the first bug: a truncated command must not read as a device denial, or the poll thread caches `ConfirmedNotPi` and strands a real Pi. It now surfaces as `TransportError`, and therefore as `Inconclusive`.

`MockUsbTransport` gains `shortNextBulkWrite()` so the truncated-write path is covered by a test.

### Cancellation between erase stages

Separate commit. `performErase()` checked `_cancelled` only after the `erase:` command, leaving `oem partinit` and `oem partapp` unguarded. A cancel arriving during the erase — which can run for minutes on a large eMMC — still rewrote the partition table and appended a partition afterwards, then reached `success()`. Every stage is destructive, so each is now guarded before and after through one `stopIfCancelled()` helper.

Not compiled here (no Qt toolchain on this machine); CI covers the build.
