### PR TITLE
fix(io): let the direct-I/O reopen degrade to a shared handle

### DIFF
--- a/src/devicewrapper.cpp
+++ b/src/devicewrapper.cpp
@@ -17,7 +17,16 @@ DeviceWrapper::DeviceWrapper(rpi_imager::FileOperations *file_ops, QObject *pare
 
 DeviceWrapper::~DeviceWrapper()
 {
-    sync();
+    /* sync() throws on a write or flush failure, and a destructor is implicitly
+       noexcept — letting that escape calls std::terminate(). A card reader that
+       disappeared mid-write is exactly the case that makes the final flush fail,
+       so kill the process there and the user loses the error dialog too. Callers
+       that need to know a flush failed call sync() explicitly. */
+    try {
+        sync();
+    } catch (const std::exception &err) {
+        qDebug() << "DeviceWrapper: sync() failed during destruction:" << err.what();
+    }
 }
 
 void DeviceWrapper::_seekToBlock(quint64 blockNr)

--- a/src/linux/file_operations_linux.cpp
+++ b/src/linux/file_operations_linux.cpp
@@ -261,18 +261,25 @@ FileError LinuxFileOperations::OpenDevice(const std::string& path) {
   // is rejected. extraFlags (e.g. O_EXCL) are preserved across that fallback.
   auto tryOpenWithFlags = [&](int extraFlags) -> FileError {
     int flags = O_RDWR | extraFlags;
-    if (isBlockDevice) {
+    // Track the O_DIRECT attempt locally: OpenInternal() starts with Close(),
+    // and Close() resets using_direct_io_, so the member is always false by the
+    // time the call returns. Branching on it here would make the buffered
+    // fallback below unreachable, and would also leave using_direct_io_ false
+    // after a *successful* O_DIRECT open.
+    const bool triedDirectIo = isBlockDevice;
+    if (triedDirectIo) {
       flags |= O_DIRECT;
-      using_direct_io_ = true;
       direct_io_attempted_ = true;
     }
 
     FileError r = OpenInternal(path.c_str(), flags);
 
     // If O_DIRECT fails, fall back to regular (buffered) I/O, keeping extraFlags.
-    if (r != FileError::kSuccess && isBlockDevice && using_direct_io_) {
-      using_direct_io_ = false;
+    if (r != FileError::kSuccess && triedDirectIo) {
       r = OpenInternal(path.c_str(), O_RDWR | extraFlags);
+      using_direct_io_ = false;
+    } else {
+      using_direct_io_ = (r == FileError::kSuccess && triedDirectIo);
     }
     return r;
   };
@@ -434,6 +441,18 @@ FileError LinuxFileOperations::SetDirectIOEnabled(bool enabled) {
       result = OpenInternal(savedPath.c_str(), O_RDWR | exclFlag);
       using_direct_io_ = false;
       Log("Failed to enable O_DIRECT, reopened without it");
+    }
+    if (result != FileError::kSuccess && exclFlag != 0) {
+      // The handle was closed above, so anything racing us can claim the device
+      // in that window and every exclusive reopen then fails — which aborts a
+      // write that was already in flight. OpenDevice() degrades to a shared open
+      // in the same situation; do the same here rather than lose the write.
+      result = OpenInternal(savedPath.c_str(), O_RDWR);
+      if (result == FileError::kSuccess) {
+        opened_exclusive_ = false;
+        using_direct_io_ = false;
+        Log("Exclusive reopen failed; continuing with a shared handle");
+      }
     }
     if (result != FileError::kSuccess) {
       return result;

--- a/src/windows/file_operations_windows.cpp
+++ b/src/windows/file_operations_windows.cpp
@@ -740,6 +740,19 @@ FileError WindowsFileOperations::SetDirectIOEnabled(bool enabled) {
   if (result != FileError::kSuccess) {
     result = OpenInternal(savedPath, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, shareMode);
     using_direct_io_ = false;
+    if (result != FileError::kSuccess &&
+        shareMode != (FILE_SHARE_READ | FILE_SHARE_WRITE)) {
+      // The handle is already closed, so another process can claim the drive in
+      // that window and every exclusive reopen then fails, aborting a write that
+      // was already in flight. OpenDevice() degrades to a shared open in the same
+      // situation; do the same here rather than lose the write.
+      result = OpenInternal(savedPath, GENERIC_READ | GENERIC_WRITE, OPEN_EXISTING,
+                            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
+                            FILE_SHARE_READ | FILE_SHARE_WRITE);
+      if (result == FileError::kSuccess) {
+        Log("Exclusive reopen failed; continuing with a shared handle");
+      }
+    }
     if (result != FileError::kSuccess) {
       return result;
     }


### PR DESCRIPTION
Two fixes around the exclusive-open work in `b70f9083` / `87b62f85`, plus one long-standing crash. Found reviewing #1674 against our fork.

### The direct-I/O reopen cannot degrade, so it aborts writes

`SetDirectIOEnabled()` closes the device and reopens it. `b70f9083` and `87b62f85` made that reopen preserve the exclusive flag (`O_EXCL` on Linux, a restrictive share mode on Windows) — right in principle, but the handle is already gone when the reopen runs. Anything that claims the device in that window makes every attempt fail, and the call sites treat the failure as fatal, aborting a write that was already in flight.

`OpenDevice()` has always degraded to a shared open in exactly this situation. Before those commits the reopen path did too, implicitly, because its fallback was a plain `O_RDWR` / default share mode. This restores that explicitly: after the exclusive reopen fails, try once more shared and record that the handle is no longer exclusive.

### O_DIRECT bookkeeping in `OpenDevice()` (Linux)

The lambda set `using_direct_io_` before calling `OpenInternal()`, and `OpenInternal()` begins with `Close()`, which resets it — so the flag was always `false` on return. Two consequences:

- the buffered fallback is gated on that flag and therefore never ran;
- a **successful** `O_DIRECT` open also left the flag `false`, which matters because the new customisation read-back consults it to decide whether it is reading the medium or the page cache.

The correct local is `triedDirectIo`. `direct_io_attempted_` was already there and is untouched.

### A failed final flush calls `std::terminate()`

Separate commit, pre-existing. `~DeviceWrapper()` calls `sync()`, which throws on a write or flush failure. A destructor is implicitly `noexcept`, so that exception terminates the process rather than propagating.

The case that makes the final flush fail is the one where the user most needs the error — a card reader unplugged mid-write — and instead of an error dialog they get a vanished application. `473bf483` made it more reachable by adding a `Flush()` on the pre-MBR path. Now caught and logged; callers that need to act on a flush failure already call `sync()` explicitly, where it still propagates.

Not compiled here (no Qt toolchain on this machine); CI covers the build.
