### PR TITLE
fix(linux): wait for the partition node before the post-format mount

### DIFF
--- a/src/downloadextractthread.cpp
+++ b/src/downloadextractthread.cpp
@@ -29,6 +29,13 @@
 #include <unistd.h>
 #endif
 
+#ifdef Q_OS_LINUX
+#include <sys/ioctl.h>
+#include <linux/fs.h>   // BLKRRPART
+#include <cerrno>
+#include <QFile>
+#endif
+
 using namespace std;
 
 // Ring buffer slot count is now determined dynamically by SystemMemoryManager
@@ -617,6 +624,50 @@ void DownloadExtractThread::extractMultiFileRun()
             fatpartition += "p1";
         else
             fatpartition += "1";
+
+        // The partition node for the freshly written table may not
+        // exist yet. The kernel re-reads the table when the last writer
+        // closes the whole-disk device, but the exclusive (O_EXCL) open used
+        // during formatting means that re-read can fail with EBUSY and only
+        // happen later — mounting immediately then dies with "special device
+        // does not exist". Wait for the node, and after a grace period ask
+        // the kernel for a re-read ourselves.
+        if (!QFile::exists(fatpartition))
+        {
+            QElapsedTimer nodeWait;
+            nodeWait.start();
+            bool rereadRequested = false;
+            while (!_cancelled && !QFile::exists(fatpartition) && nodeWait.elapsed() < 10000)
+            {
+                if (!rereadRequested && nodeWait.elapsed() >= 2000)
+                {
+                    rereadRequested = true;
+                    int fd = open(_filename.constData(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+                    if (fd >= 0)
+                    {
+                        if (ioctl(fd, BLKRRPART) != 0)
+                            qDebug() << "BLKRRPART on" << _filename << "failed:" << strerror(errno);
+                        else
+                            qDebug() << "Requested partition table re-read on" << _filename;
+                        close(fd);
+                    }
+                    else
+                    {
+                        qDebug() << "Could not open" << _filename << "for partition re-read:" << strerror(errno);
+                    }
+                }
+                QThread::msleep(100);
+            }
+            qDebug() << "Waited" << nodeWait.elapsed() << "ms for partition node" << fatpartition
+                     << "- exists:" << QFile::exists(fatpartition);
+
+            // A cancel during that wait must not fall through to mount: the
+            // cancel path has already torn the write down, and _joinExtractThread()
+            // is blocked on this function returning.
+            if (_cancelled)
+                return;
+        }
+
         args << "-t" << "vfat" << fatpartition << folder;
 
         if (QProcess::execute("mount", args) != 0)


### PR DESCRIPTION
The multi-file flow formats the target and then mounts the first partition to extract into. The manual-mount fallback ran `mount(8)` immediately, but the node for a freshly written partition table appears asynchronously: the kernel re-reads the table when the last writer closes the whole-disk device, and the exclusive open added in `b70f9083` can make that re-read fail with `EBUSY` and happen later still.

We hit this in CI as:

```
Cross-platform disk formatter succeeded in 25 ms
mount: /dev/sda1: special device does not exist
```

passing on rerun — so it is a race, not a hard failure.

This waits up to ten seconds for the node, and asks the kernel for a `BLKRRPART` re-read if it has not appeared after two. When the node is already present the wait costs one `stat`. A cancel during the wait returns instead of falling through to mount.

The automount poll above needs no equivalent: it discovers mountpoints the OS created, and its Linux fallback is this path. Customisation reaches the FAT filesystem through whole-disk offsets and never touches the partition node.

Not compiled here (no Qt toolchain on this machine); CI covers the build.
