### PR TITLE
fix(ImComboBox): scroll the dropdown in the direction of the wheel

### DIFF
--- a/src/qmlcomponents/ImComboBox.qml
+++ b/src/qmlcomponents/ImComboBox.qml
@@ -391,8 +391,9 @@ ComboBox {
                     if (PlatformHelper.isScrollInverted(event.inverted)) {
                         dy = -dy
                     }
-                    
-                    var newY = dropdownList.contentY + dy
+
+                    // dy is now positive for an "up" gesture, and up means earlier in the list, so contentY decreases.
+                    var newY = dropdownList.contentY - dy
                     var maxY = Math.max(0, dropdownList.contentHeight - dropdownList.height)
                     newY = Math.max(0, Math.min(newY, maxY))
                     


### PR DESCRIPTION
The popup's `WheelHandler` does `contentY + dy`. By that point `dy` has already been through the inversion handling, so a positive value means an "up" gesture, meaning a lower `contentY`. Adding it scrolled the popup backwards unless your desktop is set to natural scrolling. Subtracting fixes it.

The closed-state handler already gets this right, so the same gesture moved the selection opposite ways with the popup open and closed. #1534 fixed the closed half for #1532; this is the other one.

I left `isScrollInverted()` alone, so the popup follows the gesture rather than the OS content direction, same as the closed state. On a natural-scrolling desktop the dropdown now moves with the wheel, not the content. If you'd rather it track the OS direction, drop the inversion here instead and I'll send that version.

Fixes #1589
