### PR TITLE
Fixup 'long' translations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -495,6 +495,7 @@ if(NOT BUILD_CLI_ONLY)
         wizard/DoneStep.qml
         wizard/components/WizardSectionContainer.qml
         wizard/components/WizardFormLabel.qml
+        wizard/components/WizardFormGrid.qml
         wizard/components/WizardDescriptionText.qml
         wizard/components/SshKeyManager.qml
     )

--- a/src/Style.qml
+++ b/src/Style.qml
@@ -141,7 +141,9 @@ Item {
     readonly property int buttonWidthMinimum: scaled(120)
     readonly property int buttonWidthSkip: scaled(150)
 
-    readonly property int sectionMaxWidth: scaled(500)
+    // Wide enough that a resized window gives the form room rather than margins,
+    // capped so a maximised window doesn't stretch a single field across the screen.
+    readonly property int sectionMaxWidth: scaled(720)
     readonly property int sectionMargins: scaled(24)
     readonly property int sectionPadding: scaled(16)
     readonly property int sectionBorderWidth: 1          // not scaled — visual decoration

--- a/src/qmlcomponents/ImComboBox.qml
+++ b/src/qmlcomponents/ImComboBox.qml
@@ -7,6 +7,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Material
 import QtQuick.Window
 
 import RpiImager
@@ -43,7 +44,37 @@ ComboBox {
     // Configuration
     selectTextByMouse: true
     editable: false
-    
+
+    // The Material style's content item is a read-only TextField, which cannot
+    // elide, so a field squeezed below its content width clips mid-character. A
+    // plain Text can elide, so use one and mirror the style's own metrics. Only
+    // the rendering is shortened - displayText, currentText and the accessible
+    // name all keep the full string. Every box in the app is non-editable; an
+    // editable one would need the style's TextField content item back.
+    contentItem: Text {
+        leftPadding: root.Material.textFieldHorizontalPadding
+        topPadding: root.Material.textFieldVerticalPadding
+        bottomPadding: root.Material.textFieldVerticalPadding
+
+        text: root.editable ? root.editText : root.displayText
+        font: root.font
+        color: root.enabled ? root.Material.foreground : root.Material.hintTextColor
+        elide: Text.ElideRight
+        verticalAlignment: Text.AlignVCenter
+    }
+
+    // ComboBox mirrors editText from its content item only while that item is a
+    // TextInput, and ours no longer is. Call sites read editText on these
+    // (always non-editable) boxes to persist the selection, so keep the mirror
+    // explicit rather than leaving them reading an empty string.
+    function syncEditText() {
+        if (!editable)
+            editText = displayText
+    }
+
+    onDisplayTextChanged: root.syncEditText()
+    Component.onCompleted: root.syncEditText()
+
     ListModel {
         id: filteredModel
     }
@@ -276,6 +307,7 @@ ComboBox {
                 contentItem: Text {
                     text: filterDelegate.displayText
                     font: root.font
+                    elide: Text.ElideRight
                     verticalAlignment: Text.AlignVCenter
                     color: root.indicateError ? Style.formLabelErrorColor : Style.textDescriptionColor
                 }

--- a/src/wizard/LocaleCustomizationStep.qml
+++ b/src/wizard/LocaleCustomizationStep.qml
@@ -114,11 +114,8 @@ WizardStepBase {
         spacing: Style.stepContentSpacing
         
         WizardSectionContainer {
-            GridLayout {
+            WizardFormGrid {
                 Layout.fillWidth: true
-                columns: 2
-                columnSpacing: Style.formColumnSpacing
-                rowSpacing: Style.formRowSpacing
 
                 WizardFormLabel {
                     id: labelCapitalCity

--- a/src/wizard/PiConnectCustomizationStep.qml
+++ b/src/wizard/PiConnectCustomizationStep.qml
@@ -70,11 +70,8 @@ WizardStepBase {
                 Accessible.name: text
             }
 
-            GridLayout {
+            WizardFormGrid {
                 Layout.fillWidth: true
-                columns: 2
-                columnSpacing: Style.formColumnSpacing
-                rowSpacing: Style.formRowSpacing
 
                 WizardFormLabel {
                     id: labelOrgKey

--- a/src/wizard/UserCustomizationStep.qml
+++ b/src/wizard/UserCustomizationStep.qml
@@ -40,11 +40,8 @@ WizardStepBase {
         spacing: Style.stepContentSpacing
         
         WizardSectionContainer {
-            GridLayout {
+            WizardFormGrid {
                 Layout.fillWidth: true
-                columns: 2
-                columnSpacing: Style.formColumnSpacing
-                rowSpacing: Style.formRowSpacing
                 
                 WizardFormLabel {
                     id: labelUsername

--- a/src/wizard/WifiCustomizationStep.qml
+++ b/src/wizard/WifiCustomizationStep.qml
@@ -282,11 +282,8 @@ WizardStepBase {
                 }
 
                 // No explicit enable checkbox; intent is inferred from inputs
-                GridLayout {
+                WizardFormGrid {
                     Layout.fillWidth: true
-                    columns: 2
-                    columnSpacing: Style.formColumnSpacing
-                    rowSpacing: Style.formRowSpacing
 
                     WizardFormLabel {
                         id: labelSSID

--- a/src/wizard/WizardStepBase.qml
+++ b/src/wizard/WizardStepBase.qml
@@ -165,8 +165,14 @@ FocusScope {
                 visible: customButtonArea.children.length === 0 && root.showSkipButton
                 enabled: root.skipButtonEnabled
                 accessibleDescription: root.skipButtonAccessibleDescription
+                // Without fillWidth a layout pins the button at its preferred width,
+                // which makes these hints inert and pushes the row's minimum past
+                // the window in wordy translations. Cap growth at the natural width
+                // rounded up, so a fractional content width can't cost the label an
+                // ellipsis it doesn't need.
+                Layout.fillWidth: true
                 Layout.minimumWidth: Style.buttonWidthSkip
-                Layout.maximumWidth: Style.buttonWidthSkip * 1.5  // Allow some growth but cap it
+                Layout.maximumWidth: Math.ceil(implicitWidth)
                 Layout.preferredHeight: Style.buttonHeightStandard
                 onClicked: root.skipClicked()
                 // Tab order among action buttons: next -> back -> skip -> wrap to first field
@@ -185,8 +191,9 @@ FocusScope {
                 visible: customButtonArea.children.length === 0 && root.showBackButton
                 enabled: root.backButtonEnabled
                 accessibleDescription: root.backButtonAccessibleDescription
+                Layout.fillWidth: true
                 Layout.minimumWidth: Style.buttonWidthMinimum
-                Layout.maximumWidth: Style.buttonWidthMinimum * 1.5  // Allow some growth but cap it
+                Layout.maximumWidth: Math.ceil(implicitWidth)
                 Layout.preferredHeight: Style.buttonHeightStandard
                 onClicked: root.backClicked()
                 // After back, Tab goes to skip; Shift+Tab goes to next
@@ -200,8 +207,9 @@ FocusScope {
                 visible: customButtonArea.children.length === 0 && root.showNextButton
                 enabled: root.nextButtonEnabled
                 accessibleDescription: root.nextButtonAccessibleDescription
+                Layout.fillWidth: true
                 Layout.minimumWidth: Style.buttonWidthMinimum
-                Layout.maximumWidth: Style.buttonWidthMinimum * 1.5  // Allow some growth but cap it
+                Layout.maximumWidth: Math.ceil(implicitWidth)
                 Layout.preferredHeight: Style.buttonHeightStandard
                 onClicked: root.nextClicked()
                 // After next, Tab goes to back; Shift+Tab goes to skip

--- a/src/wizard/components/WizardFormGrid.qml
+++ b/src/wizard/components/WizardFormGrid.qml
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026 Raspberry Pi Ltd
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import RpiImager
+
+/*
+ * Two-column label/field grid shared by the customisation steps.
+ *
+ * The label column is only as wide as the widest label, and long translations
+ * can push that far enough to leave the fields with almost nothing to work
+ * with - Russian is the worst case. The window's 680px minimum is deliberate
+ * for low-resolution displays, so the room has to come out of the layout
+ * instead: once the labels would take more than `stackRatio` of the row, the
+ * grid drops to a single column and each label sits above its own field, which
+ * hands the full width back to the fields.
+ *
+ * The switch is driven by the measured label widths rather than by a list of
+ * languages, so it holds for translations added or reworded later.
+ */
+GridLayout {
+    id: root
+
+    // Share of the available width the label column may take before the labels
+    // move above their fields.
+    property real stackRatio: 0.45
+
+    // What the label column actually costs: the widest label in the grid.
+    readonly property real labelColumnWidth: {
+        var widest = 0
+        for (var i = 0; i < root.children.length; ++i) {
+            var child = root.children[i]
+            if (child && child.visible && child.isWizardFormLabel === true)
+                widest = Math.max(widest, child.implicitWidth)
+        }
+        return widest
+    }
+
+    readonly property bool stacked: root.width > 0
+                                    && root.labelColumnWidth > root.width * root.stackRatio
+
+    columns: stacked ? 1 : 2
+    columnSpacing: Style.formColumnSpacing
+    rowSpacing: stacked ? Style.spacingSmall : Style.formRowSpacing
+}

--- a/src/wizard/components/WizardFormLabel.qml
+++ b/src/wizard/components/WizardFormLabel.qml
@@ -14,6 +14,10 @@ FocusableText {
     
     property bool isError: false
     property bool isDisabled: false
+
+    // Lets WizardFormGrid pick the labels out of its children when it measures
+    // how much width the label column is asking for.
+    readonly property bool isWizardFormLabel: true
     
     // When set, label becomes independently focusable for screen readers with this description
     property string accessibleDescription: ""


### PR DESCRIPTION
...by changing how we calculate lengths, when to reflow, and how much space to allocate.

Tested on macOS, where it transforms the experience in Russian - but also helps the experience in every language when you resize the window.