### PR TITLE
packaging: bundle the xcb helper libraries in AppImages

### DIFF
--- a/create-appimage.sh
+++ b/create-appimage.sh
@@ -348,9 +348,10 @@ fi
 # plugins/wayland-shell-integration; without libxdg-shell.so the "wayland" QPA
 # plugin loads, connects to the compositor, then aborts with "Loading shell
 # integration failed." Qt then falls back to "xcb", so every session -- Wayland
-# included -- ends up on XWayland and needs libxcb-cursor0. On a target without
-# that library (Raspberry Pi OS bookworm) both plugins fail and the app does not
-# start at all.
+# included -- ends up on XWayland and needs libxcb-cursor. That library is now
+# bundled (see appimage_lib_excluded() in debian/lib.sh, #1719), so the fallback
+# no longer depends on the host shipping it; deploying these plugins is still
+# what keeps a Wayland session off XWayland in the first place.
 #
 # These are Qt's own plugins and belong with the bundled Qt, unlike the wayland
 # *system* libraries: libwayland-client/-cursor stay host-provided via

--- a/debian/control
+++ b/debian/control
@@ -27,10 +27,13 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, dosfstools, fdisk, fuse,
          util-linux (>= 2.37), pkexec,
          libstdc++6, libatomic1,
          libfontconfig1, libfreetype6,
-         libx11-6, libx11-xcb1, libxcb1, libxcb-cursor0, libxcb-glx0,
-         libxcb-icccm4, libxcb-image0, libxcb-keysyms1, libxcb-randr0,
-         libxcb-render0, libxcb-render-util0, libxcb-shape0, libxcb-shm0,
-         libxcb-sync1, libxcb-xfixes0, libxcb-xkb1,
+# The xcb extension bindings and xcb-util helpers are bundled inside the
+# AppImage (#1719) and are deliberately absent here; see
+# appimage_lib_excluded() in debian/lib.sh for which stay external and why.
+# libxcb-cursor0 in particular is in universe and not installed by default on
+# some Ubuntu derivatives, so depending on it here would not have helped the
+# AppImage users who hit that bug in the first place.
+         libx11-6, libx11-xcb1, libxcb1, libxcb-glx0,
          libxkbcommon0, libxkbcommon-x11-0,
          libwayland-client0, libwayland-cursor0,
          libegl1, libgl1, libopengl0,

--- a/debian/lib.sh
+++ b/debian/lib.sh
@@ -563,8 +563,39 @@ appimage_lib_excluded() {
 	# GPU stack: must match the host's drivers
 	libGL.so.*|libGLX.so.*|libEGL.so.*|libOpenGL.so.*|libGLdispatch.so.*) return 0 ;;
 	libglapi.so.*|libgbm.so.*|libdrm.so.*|libvulkan.so.*) return 0 ;;
+	# X protocol bindings that stay external. libxcb.so.1 owns the connection
+	# and libX11/libX11-xcb sit on top of it; the -dri2/-dri3/-present/-glx
+	# bindings are driven by the host's Mesa libGL, which we also keep external
+	# (above), so bundling them would risk two copies in one process. libxcb.so.1
+	# and the DRI/GLX bindings are what the AppImage excludelist names; the
+	# libX*.so.* glob is broader than that and predates this clause, kept as-is
+	# because Xlib-level libraries have never been the ones we needed to bundle.
+	libxcb.so.*|libxcb-glx.so.*|libxcb-dri2.so.*|libxcb-dri3.so.*) return 0 ;;
+	libxcb-present.so.*|libX11-xcb.so.*|libX*.so.*) return 0 ;;
+	# Everything else named libxcb-<extension> is a client-side binding to an X
+	# protocol extension, generated from the protocol XML, or a small xcb-util
+	# helper. None of them own the session: they marshal requests through
+	# whatever libxcb.so.1 the host provides, carry no versioned symbols, and
+	# sit far below our glibc baseline. Bundling them is what the AppImage
+	# excludelist expects -- it names libxcb.so.1, libX11* and the DRI pair, and
+	# pointedly not the helpers.
+	#
+	# Leaving them external broke the AppImage outright (#1719). Qt >= 6.5 makes
+	# libxcb-cursor a hard DT_NEEDED of libQt6XcbQpa, and Qt is close to its only
+	# consumer, so distros have no other reason to pull it in: libxcb-cursor0 is
+	# in Ubuntu universe and absent by default on Linux Mint. The QPA plugin then
+	# failed to load and the app aborted before opening a window. The other
+	# helpers we need -- icccm, image, keysyms, randr, render, render-util,
+	# shape, shm, sync, xfixes, xkb -- were only working by luck, because desktop
+	# distros install them for other packages. This clause fixes the class rather
+	# than the one instance that got reported.
+	#
+	# Deliberately still external: libxkbcommon* (below). Bundling it is
+	# defensible on the same reasoning, but it parses keymaps for every session
+	# including Wayland, so the blast radius is keyboard input rather than
+	# cursors, and every real desktop already ships it.
+	libxcb-*.so.*) return 1 ;;
 	# display server and input: must match the running X/Wayland session
-	libX11-xcb.so.*|libxcb*.so.*|libX*.so.*) return 0 ;;
 	libxkbcommon.so.*|libxkbcommon-x11.so.*|libwayland-*.so.*) return 0 ;;
 	libinput.so.*|libmtdev.so.*|libevdev.so.*|libwacom.so.*) return 0 ;;
 	# session and device integration (#1304, #1577)


### PR DESCRIPTION
appimage_lib_excluded() rejected every libxcb*.so.*, but only libxcb.so.1 and the -dri2/-dri3/-present/-glx bindings must match the running session. The rest are client-side protocol bindings and xcb-util helpers that marshal through the host's libxcb.so.1, and the AppImage excludelist draws the line in the same place.

Excluding them broke the AppImage outright (#1719): Qt >= 6.5 makes libxcb-cursor a hard DT_NEEDED of libQt6XcbQpa, and Mint 22.3 does not install libxcb-cursor0, so the xcb QPA plugin fails to load. Narrowing the exclusion bundles thirteen libraries, 437 KB, found from DT_NEEDED. debian/control drops the eleven now bundled; libxkbcommon stays host-provided.

Verified with the closure walker and by shadowing the host libxcb-cursor; a full build and a Mint GUI launch are untested.