### PR TITLE
Keep the write failure dialog open until dismissed

### DIFF
--- a/src/qmlcomponents/BaseDialog.qml
+++ b/src/qmlcomponents/BaseDialog.qml
@@ -21,6 +21,11 @@ Dialog {
     
     // Standard dialog properties
     modal: true
+
+    // Dismiss only via Escape or the dialog's own buttons. The Popup default also
+    // closes on a press outside, so the click that re-activates a buried window
+    // would silently discard the message (#1693).
+    closePolicy: Popup.CloseOnEscape
     
     // Reset Dialog's built-in padding - we use our own margins in contentLayout
     padding: 0

--- a/src/wizard/WritingStep.qml
+++ b/src/wizard/WritingStep.qml
@@ -72,6 +72,7 @@ WizardStepBase {
     property string bottleneckStatus: ""
     property int writeThroughputKBps: 0
     property string operationWarning: ""  // Non-fatal warning message (e.g., sync fallback)
+    property string failureMessage: ""  // Last write error; keeps the reason on screen after the dialog closes
     property bool isIndeterminateProgress: false  // True when we can't determine accurate progress (e.g., gz files >4GB)
     readonly property bool anyCustomizationsApplied: (
         wizardContainer.customizationSupported && (
@@ -96,7 +97,7 @@ WizardStepBase {
         spacing: Style.spacingLarge
 
         // Top spacer to vertically center progress section when writing/complete
-        Item { Layout.fillHeight: true; visible: root.isWriting || root.isComplete }
+        Item { Layout.fillHeight: true; visible: root.isWriting || root.isComplete || root.failureMessage !== "" }
 
         // Summary section (de-chromed)
         ColumnLayout {
@@ -280,7 +281,7 @@ WizardStepBase {
             Layout.maximumWidth: Style.sectionMaxWidth
             Layout.alignment: Qt.AlignHCenter
             spacing: Style.spacingMedium
-            visible: root.isWriting || root.isComplete
+            visible: root.isWriting || root.isComplete || root.failureMessage !== ""
 
             FocusableText {
                 id: progressText
@@ -347,7 +348,7 @@ WizardStepBase {
         }
 
         // Bottom spacer to vertically center progress section when writing/complete
-        Item { Layout.fillHeight: true; visible: root.isWriting || root.isComplete }
+        Item { Layout.fillHeight: true; visible: root.isWriting || root.isComplete || root.failureMessage !== "" }
     }
     ]
 
@@ -537,6 +538,7 @@ WizardStepBase {
             root.operationWarning = ""
             // Check if extract size is known upfront (e.g., gz files can't reliably store sizes >4GB)
             root.isIndeterminateProgress = !ImageWriterSingleton.isExtractSizeKnown()
+            root.failureMessage = ""
             progressText.text = qsTr("Starting write process...")
             progressBar.value = 0
             ImageWriterSingleton.startWrite()
@@ -587,6 +589,7 @@ WizardStepBase {
             root.wizardContainer.nextStep()
         }
         function onError(msg) {
+            root.failureMessage = msg
             progressText.text = qsTr("Write failed: %1").arg(msg)
         }
 


### PR DESCRIPTION
BaseDialog never set a closePolicy, so every dialog built on it inherited the Popup default, which also closes on a press outside. If a write fails while the window is buried, the click that brings it forward dismisses the error dialog unread. The writing step also hides its progress section once the state is Failed, so no trace of the failure remains.

BaseDialog now uses CloseOnEscape only. 2d089f7d already did this for every popup in 2024 for the same reason, and the Qt6 dialog rewrite (beb26ff1) dropped it, hence the app-wide change rather than errorDialog-only. The writing step keeps the "Write failed" line visible until the next write starts. Checked against the write state machine and with qmllint; not run in a build.

Fixes #1693
