### PR TITLE
Fix local manifest sorting for URL-encoded filenames

### DIFF
--- a/doc/local_json/create_local_json.py
+++ b/doc/local_json/create_local_json.py
@@ -237,7 +237,11 @@ if __name__ == "__main__":
                     device["capabilities"] = sorted(merged_caps)
     # Sort the output OSes into the same order as the input OSes
     os_order = list(online_os_entries.keys())
-    local_data["os_list"] = sorted(local_os_entries.values(), key=lambda x: os_order.index(os.path.basename(x["url"])))
+    local_data["os_list"] = [
+        local_os_entries[name]
+        for name in os_order
+        if name in local_os_entries
+    ]
 
     # Add capabilities to OS entries if specified
     if args.capabilities:


### PR DESCRIPTION
### Summary

Fixes `create_local_json.py` failing when creating a local manifest for image filenames containing characters that are URL-encoded by `Path.as_uri()`, such as `+`.

For example, Ubuntu Server images use filenames such as:

`ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz`

When converted to a local `file://` URI, the `+` becomes `%2B`. The existing sorting code then extracts the basename from this encoded URI and tries to find it in `os_order`, which contains the original unencoded filename, resulting in a `ValueError`.

### Fix

Instead of reconstructing the filename from the rewritten local URL, build the output list by iterating over the existing `os_order` filename keys and selecting matching entries from `local_os_entries`.

This preserves the same ordering as the source manifest while avoiding any dependency on URL encoding.

### Tested

Tested using locally downloaded Ubuntu Server 24.04.4 and 26.04.1 Raspberry Pi images. The original code fails with the `%2B`/`+` mismatch; with this change the local manifest is generated successfully and retains the original manifest ordering.

Addresses issue: https://github.com/raspberrypi/rpi-imager/issues/1727