### PR TITLE
fix(linux): restore XDG_DATA_DIRS under sudo/pkexec for xdg-open

### DIFF
--- a/src/linux/platformquirks_linux.cpp
+++ b/src/linux/platformquirks_linux.cpp
@@ -198,6 +198,25 @@ namespace {
 
 namespace PlatformQuirks {
 
+// The XDG_DATA_DIRS a login shell would give this user: the spec default plus
+// the snap and flatpak export directories their profile scripts append.
+static void buildXdgDataDirs(const char* home, char* out, size_t outLen) {
+    std::snprintf(out, outLen,
+                  "/usr/local/share:/usr/share:/var/lib/snapd/desktop:"
+                  "/var/lib/flatpak/exports/share:%s/.local/share/flatpak/exports/share",
+                  home);
+}
+
+#ifdef PLATFORMQUIRKS_ENABLE_TEST_API
+namespace TestAPI {
+    QString xdgDataDirsForHome(const QString& home) {
+        char buf[1024];
+        buildXdgDataDirs(home.toUtf8().constData(), buf, sizeof(buf));
+        return QString::fromUtf8(buf);
+    }
+}
+#endif
+
 void applyQuirks() {
     // Log system information for remote debugging
     // This helps diagnose distro-specific issues from user reports
@@ -284,7 +303,19 @@ void applyQuirks() {
                 ::setenv("XDG_CACHE_HOME", xdgCacheHome, 1);
                 ::setenv("XDG_CONFIG_HOME", xdgConfigHome, 1);
                 ::setenv("XDG_DATA_HOME", xdgDataHome, 1);
-                
+
+                // sudo and pkexec strip XDG_DATA_DIRS, and the snap/flatpak
+                // directories only get added to it by login-shell profile
+                // scripts. Without them xdg-open and GIO cannot resolve the
+                // browser's .desktop file and hand https URLs to whatever
+                // claims text/html, typically a text editor (#1447). Restore
+                // the search path the user's own shell would have.
+                if (!::getenv("XDG_DATA_DIRS")) {
+                    char xdgDataDirs[1024];
+                    buildXdgDataDirs(pwResult->pw_dir, xdgDataDirs, sizeof(xdgDataDirs));
+                    ::setenv("XDG_DATA_DIRS", xdgDataDirs, 1);
+                }
+
                 // Set XDG_RUNTIME_DIR to point to the original user's runtime directory
                 // This is crucial for D-Bus session bus communication
                 ::setenv("XDG_RUNTIME_DIR", xdgRuntimeDir, 1);
@@ -1299,6 +1330,7 @@ static bool openUrlAsOriginalUser(const QString& url) {
     const QString display = env.value(QStringLiteral("DISPLAY"));
     const QString waylandDisplay = env.value(QStringLiteral("WAYLAND_DISPLAY"));
     const QString xauthority = env.value(QStringLiteral("XAUTHORITY"));
+    const QString xdgDataDirs = env.value(QStringLiteral("XDG_DATA_DIRS"));
 
     // runuser -u <user> -- env VAR=value ... xdg-open <url>
     // runuser preserves more than `pkexec --user` and needs no auth when root.
@@ -1314,6 +1346,8 @@ static bool openUrlAsOriginalUser(const QString& url) {
         envArgs << QStringLiteral("WAYLAND_DISPLAY=%1").arg(waylandDisplay);
     if (!xauthority.isEmpty())
         envArgs << QStringLiteral("XAUTHORITY=%1").arg(xauthority);
+    if (!xdgDataDirs.isEmpty())
+        envArgs << QStringLiteral("XDG_DATA_DIRS=%1").arg(xdgDataDirs);
     envArgs << QStringLiteral("xdg-open") << url;
 
     QStringList runuserArgs;

--- a/src/test/platformquirks_test.cpp
+++ b/src/test/platformquirks_test.cpp
@@ -266,6 +266,23 @@ TEST_CASE("launchDetached reports exec success and failure", "[platformquirks][l
                                          QStringList()) == false);
 }
 
+#ifdef PLATFORMQUIRKS_ENABLE_TEST_API
+// Declared in platformquirks_linux.cpp when test API is enabled
+namespace PlatformQuirks {
+namespace TestAPI {
+    QString xdgDataDirsForHome(const QString& home);
+}
+}
+
+TEST_CASE("XDG_DATA_DIRS rebuilt for the invoking user covers snap and flatpak", "[platformquirks][linux]") {
+    // pkexec and sudo strip XDG_DATA_DIRS; applyQuirks() restores the value a
+    // login shell would have so xdg-open can resolve snap/flatpak browsers.
+    CHECK(PlatformQuirks::TestAPI::xdgDataDirsForHome("/home/matt") ==
+          "/usr/local/share:/usr/share:/var/lib/snapd/desktop:"
+          "/var/lib/flatpak/exports/share:/home/matt/.local/share/flatpak/exports/share");
+}
+#endif // PLATFORMQUIRKS_ENABLE_TEST_API
+
 TEST_CASE("registerUriScheme writes the rpi-imager:// desktop entry", "[platformquirks][linux]") {
     // Redirect the XDG data/config dirs to a temp location so the test neither
     // pollutes nor depends on the real user environment (any update-desktop-


### PR DESCRIPTION
Under pkexec or sudo the wrapper strips XDG_DATA_DIRS, and the snap and flatpak directories only get added to it by login-shell profile scripts. xdg-open and GIO then cannot find the browser's .desktop file and fall back to the text/html handler, so the links open in a text editor. The original report's runuser PAM error went away with 2.0.5; the 2.0.7 reports are this.

applyQuirks() already rebuilds the invoking user's HOME, XDG_*_HOME, runtime dir and bus address. This adds XDG_DATA_DIRS to that set when it is absent, spec default plus the snap and flatpak export paths, and forwards it to the runuser xdg-open child like DISPLAY. The string builder is unit-tested; I could not exercise the elevated desktop path end to end, so a try on Ubuntu with snap Firefox would be welcome.

Fixes #1447
